### PR TITLE
fix: 개인 프로젝트 ID로 업무 생성 시 프로젝트를 찾지 못하는 문제 수정

### DIFF
--- a/src/resolvers/project.ts
+++ b/src/resolvers/project.ts
@@ -57,8 +57,15 @@ export async function resolveProject(
   const match = projects.find((p) => p.code === input || p.id === input);
   if (match) return match.id;
 
+  // private 캐시가 있으면 추가 검색 (캐시 미스 시 API 호출 없음)
+  const privateCached = await getPrivateProjects();
+  if (privateCached && !isExpired(privateCached.updatedAt, PROJECTS_TTL_MS)) {
+    const privateMatch = privateCached.data.find((p) => p.code === input || p.id === input);
+    if (privateMatch) return privateMatch.id;
+  }
+
   throw new DoorayCliError(
-    `프로젝트를 찾을 수 없습니다: ${input}\n  개인 프로젝트라면: dooray project list --type private 로 확인하세요`,
+    `프로젝트를 찾을 수 없습니다: ${input}\n  개인 프로젝트라면: dooray project list --type private 로 캐시를 갱신하세요`,
     EXIT_PARAM_ERROR,
   );
 }


### PR DESCRIPTION
## Summary
- `resolveProject`에서 public 캐시에 없을 때 private 캐시도 검색하도록 수정
- 캐시 미스 시 에러 메시지에 `dooray project list --type private`로 캐시 갱신 안내

## 설계 의도
개인 프로젝트 ID로 업무를 생성(`post create`)할 때, `resolveProject`가 public 캐시만 검색하여 프로젝트를 찾지 못하는 문제가 있었습니다.

`--type private` 옵션을 모든 post 커맨드에 추가하는 방법도 고려했으나, 프로젝트 ID를 직접 지정하는 상황에서 타입까지 매번 명시하는 것은 사용성이 떨어집니다.

대신 private 캐시 파일(`projects-private.json`)이 유효하면 자동으로 검색하되, **캐시가 없거나 만료된 경우 API 호출 없이 에러 메시지로 안내**하는 방식을 선택했습니다. 이는 PR #1 리뷰에서 지적된 "캐시 미스 시 API 2회 호출" 문제를 발생시키지 않으면서 사용성을 개선합니다.

## Test plan
- [ ] `dooray project list --type private`로 캐시 갱신 후 개인 프로젝트 ID로 `post create` 정상 동작 확인
- [ ] private 캐시 없는 상태에서 개인 프로젝트 ID 사용 시 안내 에러 메시지 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)