### PR TITLE
fix(wiki): resolve wiki home pageId when --parent is omitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ dooray post workflow tc-ocr 42 "진행 중"    # 워크플로우 변경
 dooray wiki list                           # 위키 목록
 dooray wiki pages tc-ocr                   # 페이지 목록
 dooray wiki page get tc-ocr <page-id>      # 페이지 상세
-dooray wiki page create tc-ocr             # 페이지 생성 ($EDITOR)
+dooray wiki page create tc-ocr --title "..." [--parent <page-id>] [--body "..." | --body-file <path>]
 dooray wiki page edit tc-ocr <page-id>     # 페이지 수정 ($EDITOR)
 ```
 
@@ -167,7 +167,7 @@ cp -r skills/dooray-cli ~/.claude/skills/
 
 ## 캐시
 
-프로젝트, 멤버, 워크플로우 정보는 `~/.dooray/cache/`에 캐시됩니다.
+프로젝트, 멤버, 워크플로우, 위키 정보는 `~/.dooray/cache/`에 캐시됩니다.
 
 ```bash
 dooray cache clear    # 캐시 삭제

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -34,7 +34,7 @@ src/
     member.ts               # name → organizationMemberId
     workflow.ts             # name·class → workflowId
     post.ts                 # postNumber → postId (API 호출)
-    wiki.ts                 # projectCode → wikiId (캐시)
+    wiki.ts                 # projectCode → wikiId / wikiId → homePageId (캐시)
 
   cache/
     store.ts                # ~/.dooray/cache/ 디렉토리 기반 CRUD + TTL 체크

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -65,7 +65,7 @@ dooray doctor                                 # 설정 검증
 | 위키 목록 | `dooray wiki list` |
 | 위키 페이지 목록 | `dooray wiki pages <project>` |
 | 위키 페이지 상세 | `dooray wiki page get <project> <page-id>` |
-| 위키 페이지 생성 | `dooray wiki page create <project> --subject "..." --body "..."` |
+| 위키 페이지 생성 | `dooray wiki page create <project> --title "..." [--parent <page-id>] [--body "..."]` (--parent 생략 시 위키 home 페이지 아래 생성) |
 | 메일 목록 조회 | `dooray mail list` |
 | 안읽은 메일 | `dooray mail list --unread` |
 | 메일 제목 검색 | `dooray mail list --search "<keyword>"` |
@@ -198,7 +198,7 @@ CLI 에러 발생 시 복구 방법:
 
 ## 캐시
 
-프로젝트, 멤버, 워크플로우 정보는 `~/.dooray/cache/`에 캐시된다.
+프로젝트, 멤버, 워크플로우, 위키 정보는 `~/.dooray/cache/`에 캐시된다.
 캐시가 오래된 것 같으면:
 
 ```bash

--- a/src/cache/store.ts
+++ b/src/cache/store.ts
@@ -7,6 +7,7 @@ import type {
   CachedProject,
   CachedMember,
   CachedWorkflow,
+  CachedWiki,
 } from "./types.js";
 
 const CACHE_DIR = join(homedir(), ".dooray", "cache");
@@ -15,6 +16,7 @@ const PROJECTS_PATH = join(CACHE_DIR, "projects.json");
 const PROJECTS_PRIVATE_PATH = join(CACHE_DIR, "projects-private.json");
 const MEMBERS_DIR = join(CACHE_DIR, "members");
 const WORKFLOWS_DIR = join(CACHE_DIR, "workflows");
+const WIKIS_PATH = join(CACHE_DIR, "wikis.json");
 
 // ─── Helpers ──────────────────────────────────────────────
 
@@ -100,6 +102,16 @@ export async function getWorkflows(projectId: string): Promise<CacheEntry<Cached
 
 export async function setWorkflows(projectId: string, items: CachedWorkflow[]): Promise<void> {
   await writeJson(workflowsPath(projectId), { updatedAt: now(), data: items } satisfies CacheEntry<CachedWorkflow[]>);
+}
+
+// ─── Wikis ────────────────────────────────────────────────
+
+export async function getWikis(): Promise<CacheEntry<CachedWiki[]> | null> {
+  return readJson<CacheEntry<CachedWiki[]>>(WIKIS_PATH);
+}
+
+export async function setWikis(items: CachedWiki[]): Promise<void> {
+  await writeJson(WIKIS_PATH, { updatedAt: now(), data: items } satisfies CacheEntry<CachedWiki[]>);
 }
 
 // ─── Clear ────────────────────────────────────────────────

--- a/src/cache/types.ts
+++ b/src/cache/types.ts
@@ -30,3 +30,12 @@ export interface CachedWorkflow {
   class: "backlog" | "registered" | "working" | "closed";
   order?: number;
 }
+
+export const WIKIS_TTL_MS = 86_400_000; // 24h — wiki home은 거의 불변
+
+export interface CachedWiki {
+  id: string;
+  projectId: string;
+  name: string;
+  homePageId: string;
+}

--- a/src/commands/wiki/page-create.ts
+++ b/src/commands/wiki/page-create.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import fs from "node:fs/promises";
 import { getConfigOrThrow } from "../../config/store.js";
 import { DoorayApiClient } from "../../api/client.js";
-import { resolveWiki } from "../../resolvers/wiki.js";
+import { resolveWiki, resolveWikiHomePageId } from "../../resolvers/wiki.js";
 import { startSpinner, stopSpinner } from "../../utils/spinner.js";
 import { DoorayCliError } from "../../utils/errors.js";
 import { EXIT_PARAM_ERROR } from "../../utils/exit-codes.js";
@@ -52,11 +52,12 @@ export const wikiPageCreateCommand = new Command("create")
 
     startSpinner("위키 페이지 생성 중...");
     const wikiId = await resolveWiki(client, project);
+    const parentPageId = opts.parent ?? (await resolveWikiHomePageId(client, wikiId));
 
     const res = await client.createWikiPage(wikiId, {
       subject: opts.title,
       body: { mimeType: "text/x-markdown", content: bodyContent },
-      parentPageId: opts.parent ?? "",
+      parentPageId,
     });
     stopSpinner(true, "위키 페이지 생성 완료");
 

--- a/src/resolvers/wiki.ts
+++ b/src/resolvers/wiki.ts
@@ -1,8 +1,8 @@
 import { DoorayApiClient } from "../api/client.js";
-import { getProjects, isExpired } from "../cache/store.js";
-import { PROJECTS_TTL_MS } from "../cache/types.js";
+import { getProjects, getWikis, setWikis, isExpired } from "../cache/store.js";
+import { PROJECTS_TTL_MS, WIKIS_TTL_MS, type CachedWiki } from "../cache/types.js";
 import { DoorayCliError } from "../utils/errors.js";
-import { EXIT_PARAM_ERROR } from "../utils/exit-codes.js";
+import { EXIT_PARAM_ERROR, EXIT_API_ERROR } from "../utils/exit-codes.js";
 import { resolveProject } from "./project.js";
 
 export async function resolveWiki(
@@ -25,4 +25,35 @@ export async function resolveWiki(
   }
 
   return project.wikiId;
+}
+
+export async function resolveWikiHomePageId(
+  client: DoorayApiClient,
+  wikiId: string,
+): Promise<string> {
+  const cached = await getWikis();
+  const fresh = cached && !isExpired(cached.updatedAt, WIKIS_TTL_MS);
+
+  let wikis: CachedWiki[];
+  if (fresh) {
+    wikis = cached.data;
+  } else {
+    const res = await client.getWikis({ size: 100 });
+    wikis = res.result.map((w) => ({
+      id: w.id,
+      projectId: w.project.id,
+      name: w.name,
+      homePageId: w.home.pageId,
+    }));
+    await setWikis(wikis);
+  }
+
+  const wiki = wikis.find((w) => w.id === wikiId);
+  if (!wiki?.homePageId) {
+    throw new DoorayCliError(
+      `위키의 home 페이지를 찾을 수 없습니다 (wikiId: ${wikiId})`,
+      EXIT_API_ERROR,
+    );
+  }
+  return wiki.homePageId;
 }

--- a/tasks/fix-wiki-page-create-parent-fallback/phase-01.md
+++ b/tasks/fix-wiki-page-create-parent-fallback/phase-01.md
@@ -115,8 +115,7 @@ grep -n "WIKIS_PATH\|export async function getWikis\|export async function setWi
 # import 업데이트 확인
 grep -n "CachedWiki" src/cache/store.ts
 
-# 빌드 산출물에 반영 확인 (CachedWiki는 type-only라 dist에 안 나올 수 있음 — WIKIS_PATH 존재 여부만 확인)
-grep -c "wikis.json" dist/index.js
+# dist grep은 Phase 2에서 검증 — Phase 1 단독 빌드 시 getWikis/setWikis 호출자 부재로 tree-shake됨
 ```
 
 ## 성공 기준
@@ -127,7 +126,6 @@ grep -c "wikis.json" dist/index.js
 - [ ] `grep "export async function getWikis" src/cache/store.ts` → 1줄
 - [ ] `grep "export async function setWikis" src/cache/store.ts` → 1줄
 - [ ] `grep "WIKIS_PATH" src/cache/store.ts` → 2줄 이상 (선언 + 사용)
-- [ ] `grep -c "wikis.json" dist/index.js` → 1 이상
 - [ ] `git diff --stat src/cache/` → 2 파일 수정
 
 ## 주의사항

--- a/tasks/fix-wiki-page-create-parent-fallback/phase-02.md
+++ b/tasks/fix-wiki-page-create-parent-fallback/phase-02.md
@@ -137,6 +137,9 @@ grep -n 'opts.parent ?? ""' src/commands/wiki/page-create.ts || echo "OK_REMOVED
 # size=100 번들 포함 확인
 grep -c '"size":100\|size: 100' dist/index.js
 
+# wikis.json 번들 포함 확인 (Phase 1의 WIKIS_PATH가 resolver를 통해 번들에 포함됨)
+grep -c "wikis.json" dist/index.js
+
 # EXIT_API_ERROR import 확인 (resolver에서 사용)
 grep -n "EXIT_API_ERROR" src/resolvers/wiki.ts
 ```
@@ -149,6 +152,7 @@ grep -n "EXIT_API_ERROR" src/resolvers/wiki.ts
 - [ ] `grep "resolveWikiHomePageId" src/commands/wiki/page-create.ts` → 2줄 (import + 호출)
 - [ ] `grep 'opts.parent ?? ""' src/commands/wiki/page-create.ts` → 0줄 (매치 없음)
 - [ ] `grep -c "size.*100\|size:100" dist/index.js` → 1 이상 (번들 난독화 대비 유연한 매치)
+- [ ] `grep -c "wikis.json" dist/index.js` → 1 이상 (Phase 1 WIKIS_PATH가 Phase 2 resolver 통해 번들 포함)
 - [ ] `git diff --stat src/resolvers/wiki.ts src/commands/wiki/page-create.ts` → 2 파일 수정
 
 ## 주의사항


### PR DESCRIPTION
## Summary

- `dooray wiki page create --parent` 생략 시 빈 문자열이 API에 전달되어 400 에러가 발생하던 문제(#5) 해결
- 위키 메타(특히 `home.pageId`)를 `~/.dooray/cache/wikis.json` (TTL 24h)에 캐시
- `--parent` 미지정 시 `resolveWikiHomePageId(client, wikiId)`로 자동 폴백

Closes #5

## Changes

**Phase 1 — 캐시 인프라 확장**
- `src/cache/types.ts`: `CachedWiki` 인터페이스 + `WIKIS_TTL_MS = 86_400_000`
- `src/cache/store.ts`: `WIKIS_PATH`, `getWikis`, `setWikis` 추가 (기존 Projects/Workflows 패턴 일관)

**Phase 2 — resolver + 커맨드 연동**
- `src/resolvers/wiki.ts`: `resolveWikiHomePageId(client, wikiId): Promise<string>` 신설 (cache-first, size=100)
- `src/commands/wiki/page-create.ts`: `opts.parent ?? await resolveWikiHomePageId(...)` 패턴
- home.pageId 부재 시 `DoorayCliError(msg, EXIT_API_ERROR)`로 명확히 실패

**문서 최신화**
- `README.md`: `wiki page create` 사용법을 실제 CLI 옵션(`--title` required, `--parent` optional, `--body`/`--body-file`)으로 보정 + 위키 캐시 명시
- `skills/dooray-cli/SKILL.md`: `--subject` 오표기 → `--title` 정정 + `--parent` 생략 시 home 폴백 안내
- `docs/code-architecture.md`: `wikiId → homePageId` 역할 추가

## Pipeline (build-with-teams)

- ✅ critic APPROVE (REVISE 1회 — Phase 1 dist grep tree-shaking 이슈 수정)
- ✅ executor — Phase 1/2 모든 성공 기준 통과
- ✅ code-reviewer PASS — MEDIUM 1건(pagination 없음)은 Dooray 위키 특성상 실패 시나리오 없어 비차단
- ✅ docs-verifier PASS — VIOLATION 4건 수정 반영 후 통과

## Test plan

- [x] `pnpm run build` 성공
- [x] `node dist/index.js wiki page create --help` → `--parent <page-id>` 옵션 표시
- [ ] 실제 프로젝트에서 `dooray wiki page create <project> --title "테스트"` 실행하여 home 페이지 아래 생성되는지 수동 검증
- [ ] `dooray wiki page create <project> --title "테스트" --parent <page-id>` 기존 동작 유지 확인
- [ ] 캐시 파일 `~/.dooray/cache/wikis.json` 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)