### PR TITLE
feat(commands): add non-interactive flags to wiki page edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ dooray wiki list                           # 위키 목록
 dooray wiki pages tc-ocr                   # 페이지 목록
 dooray wiki page get tc-ocr <page-id>      # 페이지 상세
 dooray wiki page create tc-ocr --title "..." [--parent <page-id>] [--body "..." | --body-file <path>]
-dooray wiki page edit tc-ocr <page-id>     # 페이지 수정 ($EDITOR)
+dooray wiki page edit tc-ocr <page-id> --title "새 제목"                   # 제목만 (비대화형)
+dooray wiki page edit tc-ocr <page-id> --body "..." | --body-file <path>  # 본문만 (비대화형)
+dooray wiki page edit tc-ocr <page-id>                                     # $EDITOR (플래그 없을 때)
 ```
 
 ### 메일

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -56,6 +56,7 @@ src/
     errors.ts               # DoorayCliError (message + exitCode)
     spinner.ts              # ora 래퍼
     exit-codes.ts           # 0 성공 / 1 API오류 / 2 인증실패 / 3 파라미터오류 / 4 설정오류
+    body-input.ts           # --body / --body-file → string (stdin "-" + 충돌 가드)
 
   commands/
     setup.ts                # dooray setup — 대화형 초기 설정 마법사 (스킬 설치 포함)
@@ -93,7 +94,7 @@ src/
       pages.ts
       page-get.ts
       page-create.ts
-      page-edit.ts          # $EDITOR 기반
+      page-edit.ts          # $EDITOR + 비대화형 플래그(--title/--body/--body-file)
 
     mail/
       list.ts               # 메일 목록 (--unread, --search)

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -66,6 +66,9 @@ dooray doctor                                 # 설정 검증
 | 위키 페이지 목록 | `dooray wiki pages <project>` |
 | 위키 페이지 상세 | `dooray wiki page get <project> <page-id>` |
 | 위키 페이지 생성 | `dooray wiki page create <project> --title "..." [--parent <page-id>] [--body "..."]` (--parent 생략 시 위키 home 페이지 아래 생성) |
+| 위키 페이지 수정 (제목) | `dooray wiki page edit <project> <page-id> --title "..."` |
+| 위키 페이지 수정 (본문) | `dooray wiki page edit <project> <page-id> --body "..."` 또는 `--body-file ./new.md` |
+| 위키 페이지 수정 (에디터) | `dooray wiki page edit <project> <page-id>` (플래그 없으면 $EDITOR 열림) |
 | 메일 목록 조회 | `dooray mail list` |
 | 안읽은 메일 | `dooray mail list --unread` |
 | 메일 제목 검색 | `dooray mail list --search "<keyword>"` |

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -30,6 +30,8 @@ import type {
   CreateWikiPageRequest,
   CreateWikiPageResponse,
   UpdateWikiPageRequest,
+  UpdateWikiPageTitleRequest,
+  UpdateWikiPageContentRequest,
   DoorayApiUnitResponse,
   DoorayErrorResponse,
   PostFileListResponse,
@@ -395,6 +397,34 @@ export class DoorayApiClient {
     try {
       return await this.api
         .put(`wiki/v1/wikis/${wikiId}/pages/${pageId}`, { json: body })
+        .json<DoorayApiUnitResponse>();
+    } catch (e) {
+      return toDoorayCliError(e);
+    }
+  }
+
+  async updateWikiPageTitle(
+    wikiId: string,
+    pageId: string,
+    body: UpdateWikiPageTitleRequest,
+  ): Promise<DoorayApiUnitResponse> {
+    try {
+      return await this.api
+        .put(`wiki/v1/wikis/${wikiId}/pages/${pageId}/title`, { json: body })
+        .json<DoorayApiUnitResponse>();
+    } catch (e) {
+      return toDoorayCliError(e);
+    }
+  }
+
+  async updateWikiPageContent(
+    wikiId: string,
+    pageId: string,
+    body: UpdateWikiPageContentRequest,
+  ): Promise<DoorayApiUnitResponse> {
+    try {
+      return await this.api
+        .put(`wiki/v1/wikis/${wikiId}/pages/${pageId}/content`, { json: body })
         .json<DoorayApiUnitResponse>();
     } catch (e) {
       return toDoorayCliError(e);

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -427,6 +427,14 @@ export interface UpdateWikiPageRequest {
   referrers?: WikiReferrer[];
 }
 
+export interface UpdateWikiPageTitleRequest {
+  subject: string;
+}
+
+export interface UpdateWikiPageContentRequest {
+  body: WikiPageBody;
+}
+
 export interface CreateWikiPageResult {
   id: string;
   wikiId: string;

--- a/src/commands/wiki/page-create.ts
+++ b/src/commands/wiki/page-create.ts
@@ -1,40 +1,11 @@
 import { Command } from "commander";
-import fs from "node:fs/promises";
 import { getConfigOrThrow } from "../../config/store.js";
 import { DoorayApiClient } from "../../api/client.js";
 import { resolveWiki, resolveWikiHomePageId } from "../../resolvers/wiki.js";
 import { startSpinner, stopSpinner } from "../../utils/spinner.js";
-import { DoorayCliError } from "../../utils/errors.js";
-import { EXIT_PARAM_ERROR } from "../../utils/exit-codes.js";
+import { readBodyInput } from "../../utils/body-input.js";
 import type { OutputOptions } from "../../formatters/table.js";
 import { printJson } from "../../formatters/table.js";
-
-async function readBody(opts: { bodyFile?: string; body?: string }): Promise<string> {
-  if (opts.bodyFile) {
-    if (opts.bodyFile === "-") {
-      return readStdin();
-    }
-    return fs.readFile(opts.bodyFile, "utf-8");
-  }
-  if (opts.body === "-") {
-    return readStdin();
-  }
-  return "";
-}
-
-async function readStdin(): Promise<string> {
-  if (process.stdin.isTTY) {
-    throw new DoorayCliError(
-      "stdin에서 읽으려면 파이프로 데이터를 전달해주세요.",
-      EXIT_PARAM_ERROR,
-    );
-  }
-  const chunks: Buffer[] = [];
-  for await (const chunk of process.stdin) {
-    chunks.push(chunk);
-  }
-  return Buffer.concat(chunks).toString("utf-8");
-}
 
 export const wikiPageCreateCommand = new Command("create")
   .description("위키 페이지 생성")
@@ -48,7 +19,7 @@ export const wikiPageCreateCommand = new Command("create")
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
-    const bodyContent = await readBody(opts);
+    const bodyContent = await readBodyInput(opts);
 
     startSpinner("위키 페이지 생성 중...");
     const wikiId = await resolveWiki(client, project);

--- a/src/commands/wiki/page-edit.ts
+++ b/src/commands/wiki/page-edit.ts
@@ -7,38 +7,76 @@ import {
   serializeWikiFrontmatter,
   parseWikiFrontmatter,
 } from "../../editor/index.js";
+import { readBodyInput } from "../../utils/body-input.js";
 import { startSpinner, stopSpinner } from "../../utils/spinner.js";
 
 export const wikiPageEditCommand = new Command("edit")
-  .description("위키 페이지 수정 ($EDITOR)")
+  .description("위키 페이지 수정 (플래그 없으면 $EDITOR)")
   .argument("<project>", "프로젝트 코드 또는 ID")
   .argument("<page-id>", "페이지 ID")
-  .action(async (project, pageId) => {
+  .option("--title <title>", "페이지 제목 (지정 시 $EDITOR 생략)")
+  .option("--body <text>", "본문 텍스트 (- 입력 시 stdin에서 읽기)")
+  .option("--body-file <path>", "본문 파일 경로 (- 입력 시 stdin에서 읽기)")
+  .action(async (project, pageId, opts) => {
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
-    startSpinner("위키 페이지 조회 중...");
+    const hasTitle = opts.title != null;
+    const hasBody = opts.body != null || opts.bodyFile != null;
+    const nonInteractive = hasTitle || hasBody;
+
+    // resolveWiki 먼저 호출 — $EDITOR flow와 순서 통일 (page-create와 비대칭은 의도적)
+    startSpinner("위키 정보 조회 중...");
     const wikiId = await resolveWiki(client, project);
-    const res = await client.getWikiPage(wikiId, pageId);
-    const page = res.result;
-    stopSpinner(true, "위키 페이지 조회 완료");
 
-    const original = serializeWikiFrontmatter(page);
-    const edited = await openInEditor(original);
+    if (!nonInteractive) {
+      // 기존 $EDITOR flow
+      const res = await client.getWikiPage(wikiId, pageId);
+      const page = res.result;
+      stopSpinner(true, "위키 페이지 조회 완료");
 
-    if (original === edited) {
-      process.stdout.write("변경사항 없음\n");
+      const original = serializeWikiFrontmatter(page);
+      const edited = await openInEditor(original);
+
+      if (original === edited) {
+        process.stdout.write("변경사항 없음\n");
+        return;
+      }
+
+      const parsed = parseWikiFrontmatter(edited);
+
+      startSpinner("위키 페이지 수정 중...");
+      await client.updateWikiPage(wikiId, pageId, {
+        subject: parsed.title,
+        body: { mimeType: "text/x-markdown", content: parsed.body },
+      });
+      stopSpinner(true, "위키 페이지 수정 완료");
+      process.stdout.write(`위키 페이지가 수정되었습니다: ${pageId}\n`);
       return;
     }
 
-    const parsed = parseWikiFrontmatter(edited);
+    // 비대화형 분기
+    stopSpinner(true, "위키 정보 조회 완료");
 
-    startSpinner("위키 페이지 수정 중...");
-    await client.updateWikiPage(wikiId, pageId, {
-      subject: parsed.title,
-      body: { mimeType: "text/x-markdown", content: parsed.body },
-    });
+    if (hasTitle && hasBody) {
+      const bodyContent = await readBodyInput(opts);
+      startSpinner("위키 페이지 수정 중...");
+      await client.updateWikiPage(wikiId, pageId, {
+        subject: opts.title,
+        body: { mimeType: "text/x-markdown", content: bodyContent },
+      });
+    } else if (hasTitle) {
+      startSpinner("위키 페이지 제목 수정 중...");
+      await client.updateWikiPageTitle(wikiId, pageId, { subject: opts.title });
+    } else {
+      // hasBody only
+      const bodyContent = await readBodyInput(opts);
+      startSpinner("위키 페이지 본문 수정 중...");
+      await client.updateWikiPageContent(wikiId, pageId, {
+        body: { mimeType: "text/x-markdown", content: bodyContent },
+      });
+    }
+
     stopSpinner(true, "위키 페이지 수정 완료");
-
     process.stdout.write(`위키 페이지가 수정되었습니다: ${pageId}\n`);
   });

--- a/src/utils/body-input.ts
+++ b/src/utils/body-input.ts
@@ -1,0 +1,44 @@
+import { readFile } from "node:fs/promises";
+import { DoorayCliError } from "./errors.js";
+import { EXIT_PARAM_ERROR } from "./exit-codes.js";
+
+export interface BodyInputOptions {
+  body?: string;
+  bodyFile?: string;
+}
+
+/**
+ * `--body` / `--body-file` 옵션을 받아 본문 문자열을 돌려준다.
+ *
+ * - 둘 중 하나만 지정 가능. 동시 지정 시 에러.
+ * - 값이 `"-"`이면 stdin에서 읽음.
+ * - 둘 다 비어있으면 빈 문자열 반환 (호출자 책임으로 의미 해석).
+ */
+export async function readBodyInput(opts: BodyInputOptions): Promise<string> {
+  if (opts.body != null && opts.bodyFile != null) {
+    throw new DoorayCliError(
+      "--body와 --body-file은 함께 사용할 수 없습니다.",
+      EXIT_PARAM_ERROR,
+    );
+  }
+  if (opts.bodyFile) {
+    if (opts.bodyFile === "-") return readStdin();
+    return readFile(opts.bodyFile, "utf-8");
+  }
+  if (opts.body === "-") return readStdin();
+  return opts.body ?? "";
+}
+
+async function readStdin(): Promise<string> {
+  if (process.stdin.isTTY) {
+    throw new DoorayCliError(
+      "stdin에서 읽으려면 파이프로 데이터를 전달해주세요.",
+      EXIT_PARAM_ERROR,
+    );
+  }
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}

--- a/tasks/006-feat-wiki-page-edit-non-interactive/index.json
+++ b/tasks/006-feat-wiki-page-edit-non-interactive/index.json
@@ -2,8 +2,8 @@
   "name": "006-feat-wiki-page-edit-non-interactive",
   "description": "wiki page edit에 --title/--body/--body-file 비대화형 플래그 추가 — GitHub Issue #4",
   "created_at": "2026-04-23T00:00:00Z",
-  "status": "pending",
-  "current_phase": 1,
+  "status": "completed",
+  "current_phase": 4,
   "total_phases": 4,
   "error_message": null,
   "blocked_reason": null,
@@ -12,30 +12,30 @@
       "number": 1,
       "title": "API client 메서드 + types (updateWikiPageTitle/Content)",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 2,
       "title": "readBody/readStdin 공유 유틸 추출 + page-create 마이그레이션 + 충돌 가드",
       "file": "phase-02.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 3,
       "title": "page-edit 비대화형 플래그 + 분기 로직 + SKILL.md",
       "file": "phase-03.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 4,
       "title": "빌드 + smoke 검증",
       "file": "phase-04.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],
-  "updated_at": "2026-04-23T00:00:00Z"
+  "updated_at": "2026-04-23T09:30:00Z"
 }

--- a/tasks/006-feat-wiki-page-edit-non-interactive/phase-04.md
+++ b/tasks/006-feat-wiki-page-edit-non-interactive/phase-04.md
@@ -8,7 +8,7 @@ Phase 1-3에서 API 레이어 추가, 유틸 추출, 커맨드 분기 로직, SK
 
 ### 먼저 읽을 파일
 
-- `tasks/feat-wiki-page-edit-non-interactive/index.json` — 전체 phase 완료 여부 확인
+- `tasks/006-feat-wiki-page-edit-non-interactive/index.json` — 전체 phase 완료 여부 확인
 - `docs/dooray-api-reference.md` §7 "Wiki 페이지 수정 엔드포인트 3종" — 최종 검증 대조
 
 ## 목표
@@ -75,14 +75,24 @@ grep -c "함께 사용할 수 없습니다" dist/index.js
 grep -c "resolveWikiHomePageId\|normalizeDoorayMessage" dist/index.js
 ```
 
-### 5) task 상태 일관성 확인
+### 5) task 완료 처리 (`index.json` 업데이트)
+
+이 phase는 task의 마지막 phase이므로 **executor가 직접 `tasks/006-feat-wiki-page-edit-non-interactive/index.json`을 업데이트**한다 (team-lead가 PR 브랜치 커밋에 포함하여 main에 별도 커밋 없이 PR 머지로 반영).
+
+업데이트 항목:
+- 최상위 `status`: `"pending"` → `"completed"`
+- 최상위 `current_phase`: `4` (마지막 phase 번호 유지)
+- 최상위 `updated_at`: ISO 8601 현재 시각 (`2026-04-23T...Z`)
+- `phases[0..3].status`: 모두 `"pending"` → `"completed"`
+
+수정 후 검증:
 
 ```bash
 # cwd: /Users/nhn/personal/dooray-cli
-cat tasks/feat-wiki-page-edit-non-interactive/index.json | grep -E "\"status\"|\"current_phase\""
+python3 -c "import json; d=json.load(open('tasks/006-feat-wiki-page-edit-non-interactive/index.json')); assert d['status']=='completed', d['status']; assert all(p['status']=='completed' for p in d['phases']), [p['status'] for p in d['phases']]; print('OK')"
 ```
 
-기대: 마지막 phase 실행 중이므로 status `running` 또는 `completed`, current_phase는 4.
+기대: `OK` 출력.
 
 ## 성공 기준
 
@@ -94,11 +104,12 @@ cat tasks/feat-wiki-page-edit-non-interactive/index.json | grep -E "\"status\"|\
 - [ ] `grep -c "함께 사용할 수 없습니다" dist/index.js` → 1 이상
 - [ ] `grep -c "resolveWikiHomePageId" dist/index.js` → 1 이상 (Issue #5 자산 보존)
 - [ ] `grep -c "normalizeDoorayMessage" dist/index.js` → 1 이상 (Issue #6 자산 보존)
-- [ ] `git status --short` → 코드 수정 없음 (이 phase는 검증만)
+- [ ] `index.json`의 최상위 `status` = `"completed"`, 각 `phases[*].status` = `"completed"` (Python 검증 스크립트 `OK` 출력)
+- [ ] `git status --short` → `tasks/006-feat-wiki-page-edit-non-interactive/index.json` 만 수정 (코드 변경 없음)
 
 ## 주의사항
 
-- **이 phase는 코드 변경 금지** — 검증 실패 시 이전 phase로 되돌아가 수정. phase 4에서 직접 fix하지 말 것
+- **이 phase는 코드 변경 금지** — 검증 실패 시 이전 phase로 되돌아가 수정. phase 4에서 직접 fix하지 말 것 (단, `index.json` 상태 업데이트는 예외)
 - **회귀 확인은 `create --help` 까지만** — 실제 실행은 실 API 키가 필요하므로 smoke 수준에서 멈춤
 - **만약 `pnpm run build`가 성공하는데 smoke 테스트 실패** → `PHASE_BLOCKED: smoke 불일치 — 수동 검토 필요`
 


### PR DESCRIPTION
## Summary
- `wiki page edit`에 `--title` / `--body` / `--body-file` 비대화형 플래그 추가 — AI 에이전트·스크립트에서 위키 페이지 수정 호출 가능 (closes #4)
- 3-엔드포인트 분기: 제목만→`/title`, 본문만→`/content`, 둘 다 또는 `$EDITOR`→기존 `updateWikiPage`
- `src/utils/body-input.ts` 공용 유틸 추출 + `--body`·`--body-file` 동시 지정 `DoorayCliError(EXIT_PARAM_ERROR)` 충돌 가드

## 주요 변경
- `src/api/client.ts`, `src/api/types.ts`: `updateWikiPageTitle`, `updateWikiPageContent` 메서드·타입 추가
- `src/commands/wiki/page-edit.ts`: 플래그 분기 로직 + 기존 `$EDITOR` flow 보존 (`resolveWiki` 순서는 $EDITOR flow와 통일, `page-create`와 비대칭은 의도적)
- `src/commands/wiki/page-create.ts`: 로컬 `readBody`/`readStdin` 제거 후 공용 유틸 마이그레이션
- `src/utils/body-input.ts` (신규): `readBodyInput` export + stdin `"-"` 지원
- `README.md` / `docs/code-architecture.md` / `skills/dooray-cli/SKILL.md`: 신규 플래그·파일 반영
- `tasks/006-feat-wiki-page-edit-non-interactive/index.json`: status=completed

## Test plan
- [x] `pnpm run build` — 성공 (dist/index.js 99.64 KB)
- [x] `node dist/index.js wiki page edit --help` — `--title`, `--body`, `--body-file` 3개 노출
- [x] `node dist/index.js wiki page create --help` — 회귀 없음 (기존 4개 옵션 유지)
- [x] 번들 grep — `pages/{id}/title`, `pages/{id}/content` 경로 포함 / 충돌 가드 메시지 포함 / `resolveWikiHomePageId`·`normalizeDoorayMessage` 기존 자산 보존
- [x] code-reviewer PASS — 공통 6 + dooray-cli 특화 7 = 13항목 모두 이상 없음
- [x] docs-verifier PASS — CLAUDE.md ADR 준수 / SKILL.md·README·code-architecture 정합

## build-with-teams 파이프라인
critic APPROVE → executor 4 phase 완료 → code-reviewer PASS → docs-verifier PASS (2차 재검증) → 이 커밋.

🤖 Generated with [Claude Code](https://claude.com/claude-code)