### PR TITLE
feat(commands): unify post title option to --title with --subject alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ dooray post get tc-ocr 42 --json           # JSON 출력
 
 ```bash
 dooray post create tc-ocr \
-  --subject "업무 제목" \
+  --title "업무 제목" \
   --body "본문 마크다운" \
   --to "담당자이름" \
   --priority normal
@@ -67,7 +67,7 @@ dooray post create tc-ocr \
 dooray post edit tc-ocr 42
 
 # 비대화형 (AI 에이전트 친화)
-dooray post edit tc-ocr 42 --subject "새 제목" --body "새 본문"
+dooray post edit tc-ocr 42 --title "새 제목" --body "새 본문"
 ```
 
 ### 댓글

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -54,8 +54,8 @@ dooray doctor                                 # 설정 검증
 | 업무 목록 조회 | `dooray post list <project>` |
 | 업무 검색 | `dooray post search <project> "<keyword>"` |
 | 업무 상세 보기 | `dooray post get <project> <number>` |
-| 업무 생성 | `dooray post create <project> --subject "..." --body "..."` |
-| 업무 제목/본문 수정 | `dooray post edit <project> <number> --subject "..." --body "..."` |
+| 업무 생성 | `dooray post create <project> --title "..." --body "..."` |
+| 업무 제목/본문 수정 | `dooray post edit <project> <number> --title "..." --body "..."` |
 | 업무 완료 처리 | `dooray post done <project> <number>` |
 | 업무 워크플로우 변경 | `dooray post workflow <project> <number> <workflow>` |
 | 댓글 조회 | `dooray post comment list <project> <number>` |
@@ -80,6 +80,8 @@ dooray doctor                                 # 설정 검증
 | 전체 첨부파일 다운로드 | `dooray post file download-all <project> <number>` |
 | 첨부파일 업로드 | `dooray post file upload <project> <number> <file-path>` |
 | 첨부파일 삭제 | `dooray post file delete <project> <number> <file-id>` |
+
+> **제목 옵션 네이밍**: `post` 와 `wiki page` 모두 `--title` 표준. `post`의 `--subject`는 deprecated alias로 당분간 동작하되, 새 코드에서는 `--title` 사용을 권장.
 
 ---
 
@@ -129,7 +131,7 @@ dooray project list --search "AI서비스" --json
 
 # 2. 업무 생성
 dooray post create ai-service-dev \
-  --subject "주간보고 2026-W14" \
+  --title "주간보고 2026-W14" \
   --body "## 이번 주 성과\n- 항목1\n- 항목2" \
   --to "김철수"
 ```
@@ -163,7 +165,7 @@ dooray wiki page get tc-ocr 3052841366755571094 --json
 
 ```bash
 dooray post create <project> \
-  --subject "제목" \
+  --title "제목" \
   --body "본문 마크다운" \
   --to "담당자이름" \           # 여러 명: --to "김철수" --to "이영희"
   --cc "참조자이름" \
@@ -173,20 +175,20 @@ dooray post create <project> \
 
 본문이 길면 파일로:
 ```bash
-dooray post create <project> --subject "제목" --body-file ./content.md
+dooray post create <project> --title "제목" --body-file ./content.md
 ```
 
 ### 업무 수정 (non-interactive)
 
 ```bash
 # 제목만 변경
-dooray post edit <project> <number> --subject "새 제목"
+dooray post edit <project> <number> --title "새 제목"
 
 # 본문만 변경
 dooray post edit <project> <number> --body "새 본문"
 
 # 제목 + 본문 동시 변경
-dooray post edit <project> <number> --subject "새 제목" --body-file ./updated.md
+dooray post edit <project> <number> --title "새 제목" --body-file ./updated.md
 ```
 
 ### 댓글 추가 (non-interactive)

--- a/src/commands/post/create.ts
+++ b/src/commands/post/create.ts
@@ -54,7 +54,8 @@ async function resolveUsers(
 export const postCreateCommand = new Command("create")
   .description("업무 생성")
   .argument("<project>", "프로젝트 코드 또는 ID")
-  .requiredOption("--subject <title>", "업무 제목")
+  .option("--title <title>", "업무 제목")
+  .option("--subject <subject>", "--title의 deprecated alias")
   .option("--to <members...>", "담당자 (이름 또는 이메일, 여러 명 가능)")
   .option("--cc <members...>", "참조자 (이름 또는 이메일, 여러 명 가능)")
   .option("--body <text>", "본문 텍스트 (- 입력 시 stdin에서 읽기)")
@@ -66,6 +67,19 @@ export const postCreateCommand = new Command("create")
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
+    const subject = opts.title ?? opts.subject;
+    if (!subject) {
+      throw new DoorayCliError(
+        "--title이 필요합니다.",
+        EXIT_PARAM_ERROR,
+      );
+    }
+    if (opts.subject && !opts.title) {
+      process.stderr.write(
+        "⚠  --subject는 deprecated입니다. 대신 --title을 사용해주세요.\n",
+      );
+    }
+
     const bodyContent = await readBody(opts);
 
     startSpinner("업무 생성 중...");
@@ -75,7 +89,7 @@ export const postCreateCommand = new Command("create")
     const ccUsers = opts.cc ? await resolveUsers(client, projectId, opts.cc) : [];
 
     const res = await client.createPost(projectId, {
-      subject: opts.subject,
+      subject: subject,
       body: { mimeType: "text/x-markdown", content: bodyContent },
       users: { to: toUsers, cc: ccUsers },
       priority: opts.priority,

--- a/src/commands/post/edit.ts
+++ b/src/commands/post/edit.ts
@@ -58,10 +58,11 @@ async function resolveBody(opts: {
 }
 
 export const postEditCommand = new Command("edit")
-  .description("업무 수정 ($EDITOR 또는 --subject/--body 옵션)")
+  .description("업무 수정 ($EDITOR 또는 --title/--body 옵션)")
   .argument("<project>", "프로젝트 코드 또는 ID")
   .argument("<post-number>", "업무 번호")
-  .option("--subject <title>", "제목 변경 (non-interactive)")
+  .option("--title <title>", "제목 변경 (non-interactive)")
+  .option("--subject <subject>", "--title의 deprecated alias")
   .option("--body <text>", "본문 변경 (- 입력 시 stdin, non-interactive)")
   .option("--body-file <path>", "본문 파일 경로 (- 입력 시 stdin, non-interactive)")
   .action(async (project, postNumberStr, opts) => {
@@ -76,7 +77,14 @@ export const postEditCommand = new Command("edit")
     const members = await ensureMembers(client, projectId);
     stopSpinner(true, "업무 조회 완료");
 
-    const nonInteractive = opts.subject || opts.body || opts.bodyFile;
+    const title = opts.title ?? opts.subject;
+    if (opts.subject && !opts.title) {
+      process.stderr.write(
+        "⚠  --subject는 deprecated입니다. 대신 --title을 사용해주세요.\n",
+      );
+    }
+
+    const nonInteractive = title || opts.body || opts.bodyFile;
 
     if (nonInteractive) {
       // Non-interactive mode: apply only specified changes
@@ -97,7 +105,7 @@ export const postEditCommand = new Command("edit")
       }));
 
       await client.updatePost(projectId, postId, {
-        subject: opts.subject ?? post.subject,
+        subject: title ?? post.subject,
         body: {
           mimeType: "text/x-markdown",
           content: newBody ?? post.body.content,

--- a/tasks/007-refactor-unify-title-option/index.json
+++ b/tasks/007-refactor-unify-title-option/index.json
@@ -2,8 +2,8 @@
   "name": "007-refactor-unify-title-option",
   "description": "post create/edit에 --title 추가, --subject는 deprecated alias로 유지 — GitHub Issue #8",
   "created_at": "2026-04-23T00:00:00Z",
-  "status": "pending",
-  "current_phase": 1,
+  "status": "completed",
+  "current_phase": 3,
   "total_phases": 3,
   "error_message": null,
   "blocked_reason": null,
@@ -12,23 +12,23 @@
       "number": 1,
       "title": "post/create + post/edit 옵션 통일 (--title 추가, --subject alias 유지)",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 2,
       "title": "skills/dooray-cli/SKILL.md 예시 갱신",
       "file": "phase-02.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 3,
       "title": "빌드 + smoke 검증",
       "file": "phase-03.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],
-  "updated_at": "2026-04-23T00:00:00Z"
+  "updated_at": "2026-04-23T10:38:00Z"
 }

--- a/tasks/007-refactor-unify-title-option/phase-02.md
+++ b/tasks/007-refactor-unify-title-option/phase-02.md
@@ -13,22 +13,24 @@ Phase 1에서 `post create/edit`의 `--title` 표준화가 완료됐다. `skills
 
 Phase 1 완료가 전제. post/create, post/edit 코드가 `--title`을 이미 받고 있어야 SKILL.md 예시와 일치.
 
-### 갱신 대상 4곳 (작성 시점 기준 grep)
+### 갱신 대상 7곳 (작성 시점 기준 grep)
 
 ```
 skills/dooray-cli/SKILL.md:57:| 업무 생성 | `dooray post create <project> --subject "..." --body "..."` |
 skills/dooray-cli/SKILL.md:58:| 업무 제목/본문 수정 | `dooray post edit <project> <number> --subject "..." --body "..."` |
-skills/dooray-cli/SKILL.md:129:  --subject "주간보고 2026-W14" \
-skills/dooray-cli/SKILL.md:163:  --subject "제목" \
-skills/dooray-cli/SKILL.md:173:dooray post create <project> --subject "제목" --body-file ./content.md
-skills/dooray-cli/SKILL.md:180:dooray post edit <project> <number> --subject "새 제목"
-skills/dooray-cli/SKILL.md:186:dooray post edit <project> <number> --subject "새 제목" --body-file ./updated.md
+skills/dooray-cli/SKILL.md:132:  --subject "주간보고 2026-W14" \
+skills/dooray-cli/SKILL.md:166:  --subject "제목" \
+skills/dooray-cli/SKILL.md:176:dooray post create <project> --subject "제목" --body-file ./content.md
+skills/dooray-cli/SKILL.md:183:dooray post edit <project> <number> --subject "새 제목"
+skills/dooray-cli/SKILL.md:189:dooray post edit <project> <number> --subject "새 제목" --body-file ./updated.md
 ```
 
 7개 라인에서 `--subject` 사용. 모두 `--title`로 교체.
 
+> 줄 번호는 작성 시점 스냅샷. 작업 직전 `grep -n '\-\-subject' skills/dooray-cli/SKILL.md`로 재확인 후 진행.
+
 **제외 대상**:
-- `skills/dooray-cli/SKILL.md:73` — `dooray mail send --to "..." --subject "..."` → mail/send는 `--subject` 유지 (이메일 표준). **건드리지 말 것**
+- `skills/dooray-cli/SKILL.md:76` — `dooray mail send --to "..." --subject "..."` → mail/send는 `--subject` 유지 (이메일 표준). **건드리지 말 것**
 
 ## 목표
 

--- a/tasks/007-refactor-unify-title-option/phase-03.md
+++ b/tasks/007-refactor-unify-title-option/phase-03.md
@@ -1,86 +1,72 @@
-# Phase 3: 빌드 + smoke 검증
+# Phase 3: 빌드 + smoke 검증 + task 완료 처리
 
 ## 컨텍스트
 
-Phase 1-2 결과를 기계적으로 검증. 코드 변경 없음.
+Phase 1-2 결과를 기계적으로 검증하고, task 메타데이터(`index.json`)를 `completed`로 확정. 코드 변경은 이 phase에서 수행하지 않음.
 
 ### 먼저 읽을 파일
 
-- `tasks/007-refactor-unify-title-option/index.json` — 이전 phase status 확인용
+- `tasks/007-refactor-unify-title-option/index.json` — 완료 처리 대상
 
 ## 목표
 
 1. `pnpm run build` 통과
-2. `post create --help` / `post edit --help` smoke: `--title`, `--subject` 둘 다 노출
-3. `post list --help` / `mail send --help` 회귀 확인: `--subject` 그대로
-4. `wiki page create --help` 회귀: `--title` 그대로
+2. 변경 커맨드(`post create`/`post edit`) help 출력에 `--title` + `--subject` 둘 다 노출
+3. 회귀 검증 — `post list`/`mail send`의 `--subject`, `wiki page create`의 `--title` 유지
+4. 필수 옵션 누락 에러 smoke (`post create` 인자 누락 시 에러)
+5. `index.json` 완료 처리 (`status: "completed"` 확정)
 
-## 작업 목록
+## 작업 목록 (5개)
 
-### 1) 빌드
+### 1) 빌드 + 번들 크기 확인
 
 ```bash
 # cwd: /Users/nhn/personal/dooray-cli
 pnpm run build
+ls -la dist/index.js
 ```
 
-### 2) `post create --help`
+번들 크기 증가는 수 KB 이하 (정책 문자열·옵션 추가 정도)여야 정상.
 
-```bash
-# cwd: /Users/nhn/personal/dooray-cli
-node dist/index.js post create --help
-```
-
-기대: `--title`과 `--subject` 두 옵션 모두 help 출력에 존재, `--subject`는 "deprecated alias" 설명이 보여야 함.
+### 2) 변경 커맨드 help smoke (post create + post edit 묶음)
 
 ```bash
 node dist/index.js post create --help 2>&1 | grep -E "\-\-title|\-\-subject"
+node dist/index.js post edit   --help 2>&1 | grep -E "\-\-title|\-\-subject"
 ```
 
-### 3) `post edit --help`
+기대: 각 커맨드에 `--title`·`--subject` 두 옵션 모두 존재. `--subject`에는 "deprecated alias" 설명 노출.
+
+### 3) 회귀 help smoke (post list + mail send + wiki page create 묶음)
 
 ```bash
-node dist/index.js post edit --help 2>&1 | grep -E "\-\-title|\-\-subject"
-```
-
-### 4) 회귀: `post list --help`
-
-```bash
-node dist/index.js post list --help 2>&1 | grep -E "\-\-subject"
-```
-
-기대: `--subject <keyword>` 한 줄 (필터 키워드 설명 유지).
-
-### 5) 회귀: `mail send --help`
-
-```bash
-node dist/index.js mail send --help 2>&1 | grep -E "\-\-subject"
-```
-
-기대: 이메일 제목 설명 유지.
-
-### 6) 회귀: `wiki page create --help`
-
-```bash
+node dist/index.js post list        --help 2>&1 | grep -E "\-\-subject"
+node dist/index.js mail send        --help 2>&1 | grep -E "\-\-subject"
 node dist/index.js wiki page create --help 2>&1 | grep -E "\-\-title"
 ```
 
-기대: `--title` 옵션 유지.
+기대:
+- `post list`의 `--subject <keyword>` 유지 (필터 키워드)
+- `mail send`의 `--subject` 유지 (이메일 표준 용어)
+- `wiki page create`의 `--title` 유지
 
-### 7) 필수 옵션 누락 에러 smoke
+### 4) 에러 경로 smoke (post create 인자 누락)
 
 ```bash
-# post create: --title도 --subject도 없으면 "--title이 필요합니다." 에러
+# --title/--subject 둘 다 없으면 "--title이 필요합니다." 에러 + exit != 0
 node dist/index.js post create testproj 2>&1 | grep -E "title|필요"
-# 기대: 에러 메시지 출력 + exit != 0
 ```
 
-### 8) 번들 크기 회귀 (허용 범위)
+기대: 에러 메시지에 "title" 또는 "필요" 포함, shell non-zero exit.
 
-```bash
-ls -la dist/index.js
-# 이전 빌드 대비 크기 증가가 수 KB 이하여야 정상 (정책 문자열·옵션 추가 정도)
-```
+### 5) `index.json` 완료 처리
+
+Edit 도구로 `tasks/007-refactor-unify-title-option/index.json` 수정:
+
+- 최상위 `status`: `"pending"` → `"completed"`
+- 최상위 `current_phase`: `3`
+- 최상위 `updated_at`: 현재 ISO 8601 타임스탬프 (예: `"2026-04-23T00:00:00Z"`)
+- `phases[0].status`, `phases[1].status`, `phases[2].status`: 모두 `"completed"`
 
 ## 성공 기준
 
@@ -90,14 +76,17 @@ ls -la dist/index.js
 - [ ] `post list --help` 출력에 `--subject` 존재 (필터 키워드 유지)
 - [ ] `mail send --help` 출력에 `--subject` 존재 (이메일 제목 유지)
 - [ ] `wiki page create --help` 출력에 `--title` 존재
-- [ ] `node dist/index.js post create testproj` exit != 0 + 에러 메시지 "title" 또는 "필요" 포함
-- [ ] `git status --short` → 이 phase에서는 코드 수정 없음
+- [ ] `node dist/index.js post create testproj` exit != 0 + 에러 메시지에 "title" 또는 "필요" 포함
+- [ ] `jq -r '.status' tasks/007-refactor-unify-title-option/index.json` → `completed`
+- [ ] `jq -r '[.phases[].status] | unique | .[]' tasks/007-refactor-unify-title-option/index.json` → `completed` (단일 값)
+- [ ] `git status --short src/` → 이 phase에서는 코드 수정 없음 (`index.json`만 변경)
 
 ## 주의사항
 
-- **이 phase는 코드 변경 금지** — 검증 실패 시 이전 phase 재개 (`--from-phase N`)
+- **코드 수정 금지** — 검증 실패 시 이전 phase 재개 (`--from-phase N`)
 - smoke 검증은 `--help` 위주 — 실제 API 호출은 API 키 필요하므로 생략
-- 에러 smoke(post create 인자 누락)에서 `process.exit(N)` 때문에 쉘 non-zero 반환됨 — `grep -E` 가 매치되면 테스트 통과
+- 에러 smoke에서 `process.exit(N)` 때문에 쉘 non-zero 반환됨 — `grep -E` 가 매치되면 테스트 통과
+- **5) 스텝은 반드시 모든 검증 통과 후 실행** — 검증 실패 상태에서 `completed`로 표시하지 말 것
 
 ## Blocked 조건
 


### PR DESCRIPTION
## Summary

- `post create` / `post edit` 커맨드의 제목 옵션을 `--title`로 통일 (Issue #8)
- `--subject`는 deprecated alias로 유지하되 stderr에 한 줄 경고 출력 → AI agent/스크립트 호환성 유지
- 공개 스킬(`skills/dooray-cli/SKILL.md`) 및 `README.md`의 post 예시 갱신, deprecation 정책 문구 추가

## Changes

| File | Change |
|---|---|
| `src/commands/post/create.ts` | `requiredOption --subject` → `--title` (+ deprecated `--subject` alias, 인라인 검증, stderr 경고) |
| `src/commands/post/edit.ts` | `--subject` → `--title` (+ deprecated `--subject` alias, title fallback, stderr 경고) |
| `skills/dooray-cli/SKILL.md` | post 관련 7곳 `--subject` → `--title` (mail send 1줄은 이메일 표준으로 유지), deprecation 정책 문구 추가 |
| `README.md` | post create/edit 예시 `--subject` → `--title` |
| `tasks/007-refactor-unify-title-option/index.json` | status completed |

## Non-breaking 대상 (변경 금지 준수)

- `post list --subject <keyword>` — 제목 키워드 필터 (의미 다름, 유지)
- `mail send --subject` — 이메일 표준 용어 (유지)
- `wiki page create/edit` — 이미 `--title` 사용 중 (유지)

## Pipeline

build-with-teams 파이프라인으로 실행 (critic APPROVE → executor → code-reviewer PASS → docs-verifier PASS).

## Test plan

- [x] `pnpm run build` → 성공 (100.34 KB)
- [x] `post create --help` → `--title` + `--subject` 둘 다 노출
- [x] `post edit --help` → `--title` + `--subject` 둘 다 노출
- [x] `post list --help` → `--subject` 유지
- [x] `mail send --help` → `--subject` 유지
- [x] `wiki page create --help` → `--title` 유지
- [x] `node dist/index.js post create testproj` → exit 3 + "--title이 필요합니다."

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)