### PR TITLE
refactor(commands): unify post body input via body-input.ts util

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ dooray post create tc-ocr \
   --body "본문 마크다운" \
   --to "담당자이름" \
   --priority normal
+
+# 본문을 파일에서 읽기 (--body와 --body-file은 동시 사용 불가)
+dooray post create tc-ocr --title "업무 제목" --body-file ./content.md
 ```
 
 ### 업무 수정
@@ -68,6 +71,9 @@ dooray post edit tc-ocr 42
 
 # 비대화형 (AI 에이전트 친화)
 dooray post edit tc-ocr 42 --title "새 제목" --body "새 본문"
+
+# 본문을 파일에서 읽기
+dooray post edit tc-ocr 42 --body-file ./updated.md
 ```
 
 ### 댓글
@@ -75,6 +81,7 @@ dooray post edit tc-ocr 42 --title "새 제목" --body "새 본문"
 ```bash
 dooray post comment list tc-ocr 42
 dooray post comment add tc-ocr 42 --body "댓글 내용"
+dooray post comment add tc-ocr 42 --body-file ./comment.md
 ```
 
 ### 상태 변경

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -54,13 +54,13 @@ dooray doctor                                 # 설정 검증
 | 업무 목록 조회 | `dooray post list <project>` |
 | 업무 검색 | `dooray post search <project> "<keyword>"` |
 | 업무 상세 보기 | `dooray post get <project> <number>` |
-| 업무 생성 | `dooray post create <project> --title "..." --body "..."` |
-| 업무 제목/본문 수정 | `dooray post edit <project> <number> --title "..." --body "..."` |
+| 업무 생성 | `dooray post create <project> --title "..." --body "..."` 또는 `--body-file <path>` (`--body`와 `--body-file`은 동시 사용 불가) |
+| 업무 제목/본문 수정 | `dooray post edit <project> <number> --title "..." --body "..."` 또는 `--body-file <path>` |
 | 업무 완료 처리 | `dooray post done <project> <number>` |
 | 업무 워크플로우 변경 | `dooray post workflow <project> <number> <workflow>` |
 | 댓글 조회 | `dooray post comment list <project> <number>` |
-| 댓글 추가 | `dooray post comment add <project> <number> --body "..."` |
-| 댓글 수정 | `dooray post comment edit <project> <number> <comment-id> --body "..."` |
+| 댓글 추가 | `dooray post comment add <project> <number> --body "..."` 또는 `--body-file <path>` |
+| 댓글 수정 | `dooray post comment edit <project> <number> <comment-id> --body "..."` 또는 `--body-file <path>` |
 | 댓글 삭제 | `dooray post comment delete <project> <number> <comment-id>` |
 | 위키 목록 | `dooray wiki list` |
 | 위키 페이지 목록 | `dooray wiki pages <project>` |
@@ -173,7 +173,7 @@ dooray post create <project> \
   --due-date "2026-04-30T18:00:00+09:00"
 ```
 
-본문이 길면 파일로:
+본문이 길면 파일로 (`--body`와 `--body-file`은 함께 사용 불가):
 ```bash
 dooray post create <project> --title "제목" --body-file ./content.md
 ```

--- a/src/commands/post/comment/add.ts
+++ b/src/commands/post/comment/add.ts
@@ -1,44 +1,13 @@
 import { Command } from "commander";
-import fs from "node:fs/promises";
 import { getConfigOrThrow } from "../../../config/store.js";
 import { DoorayApiClient } from "../../../api/client.js";
 import { resolveProject } from "../../../resolvers/project.js";
 import { resolvePost } from "../../../resolvers/post.js";
 import { openInEditor } from "../../../editor/index.js";
 import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
-import { DoorayCliError } from "../../../utils/errors.js";
-import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
+import { readBodyInputOrNull } from "../../../utils/body-input.js";
 import type { OutputOptions } from "../../../formatters/table.js";
 import { printJson } from "../../../formatters/table.js";
-
-async function readStdin(): Promise<string> {
-  if (process.stdin.isTTY) {
-    throw new DoorayCliError(
-      "stdin에서 읽으려면 파이프로 데이터를 전달해주세요.",
-      EXIT_PARAM_ERROR,
-    );
-  }
-  const chunks: Buffer[] = [];
-  for await (const chunk of process.stdin) {
-    chunks.push(chunk);
-  }
-  return Buffer.concat(chunks).toString("utf-8");
-}
-
-async function resolveBody(opts: {
-  body?: string;
-  bodyFile?: string;
-}): Promise<string | null> {
-  if (opts.body) {
-    if (opts.body === "-") return readStdin();
-    return opts.body;
-  }
-  if (opts.bodyFile) {
-    if (opts.bodyFile === "-") return readStdin();
-    return fs.readFile(opts.bodyFile, "utf-8");
-  }
-  return null;
-}
 
 export const commentAddCommand = new Command("add")
   .description("댓글 추가")
@@ -51,7 +20,7 @@ export const commentAddCommand = new Command("add")
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
-    let bodyContent = await resolveBody(opts);
+    let bodyContent = await readBodyInputOrNull(opts);
 
     if (bodyContent == null) {
       bodyContent = await openInEditor("");

--- a/src/commands/post/comment/edit.ts
+++ b/src/commands/post/comment/edit.ts
@@ -1,42 +1,11 @@
 import { Command } from "commander";
-import fs from "node:fs/promises";
 import { getConfigOrThrow } from "../../../config/store.js";
 import { DoorayApiClient } from "../../../api/client.js";
 import { resolveProject } from "../../../resolvers/project.js";
 import { resolvePost } from "../../../resolvers/post.js";
 import { openInEditor } from "../../../editor/index.js";
 import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
-import { DoorayCliError } from "../../../utils/errors.js";
-import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
-
-async function readStdin(): Promise<string> {
-  if (process.stdin.isTTY) {
-    throw new DoorayCliError(
-      "stdin에서 읽으려면 파이프로 데이터를 전달해주세요.",
-      EXIT_PARAM_ERROR,
-    );
-  }
-  const chunks: Buffer[] = [];
-  for await (const chunk of process.stdin) {
-    chunks.push(chunk);
-  }
-  return Buffer.concat(chunks).toString("utf-8");
-}
-
-async function resolveBody(opts: {
-  body?: string;
-  bodyFile?: string;
-}): Promise<string | null> {
-  if (opts.body) {
-    if (opts.body === "-") return readStdin();
-    return opts.body;
-  }
-  if (opts.bodyFile) {
-    if (opts.bodyFile === "-") return readStdin();
-    return fs.readFile(opts.bodyFile, "utf-8");
-  }
-  return null;
-}
+import { readBodyInputOrNull } from "../../../utils/body-input.js";
 
 export const commentEditCommand = new Command("edit")
   .description("댓글 수정 ($EDITOR 또는 --body 옵션)")
@@ -61,7 +30,7 @@ export const commentEditCommand = new Command("edit")
       process.exit(1);
     }
 
-    let edited = await resolveBody(opts);
+    let edited = await readBodyInputOrNull(opts);
 
     if (edited == null) {
       // Interactive mode: $EDITOR

--- a/src/commands/post/create.ts
+++ b/src/commands/post/create.ts
@@ -1,5 +1,4 @@
 import { Command } from "commander";
-import fs from "node:fs/promises";
 import { getConfigOrThrow } from "../../config/store.js";
 import { DoorayApiClient } from "../../api/client.js";
 import { resolveProject } from "../../resolvers/project.js";
@@ -7,36 +6,10 @@ import { resolveMember } from "../../resolvers/member.js";
 import { startSpinner, stopSpinner } from "../../utils/spinner.js";
 import { DoorayCliError } from "../../utils/errors.js";
 import { EXIT_PARAM_ERROR } from "../../utils/exit-codes.js";
+import { readBodyInput } from "../../utils/body-input.js";
 import type { CreatePostUser } from "../../api/types.js";
 import type { OutputOptions } from "../../formatters/table.js";
 import { printJson } from "../../formatters/table.js";
-
-async function readBody(opts: { bodyFile?: string; body?: string }): Promise<string> {
-  if (opts.bodyFile) {
-    if (opts.bodyFile === "-") {
-      return readStdin();
-    }
-    return fs.readFile(opts.bodyFile, "utf-8");
-  }
-  if (opts.body === "-") {
-    return readStdin();
-  }
-  return "";
-}
-
-async function readStdin(): Promise<string> {
-  if (process.stdin.isTTY) {
-    throw new DoorayCliError(
-      "stdin에서 읽으려면 파이프로 데이터를 전달해주세요.",
-      EXIT_PARAM_ERROR,
-    );
-  }
-  const chunks: Buffer[] = [];
-  for await (const chunk of process.stdin) {
-    chunks.push(chunk);
-  }
-  return Buffer.concat(chunks).toString("utf-8");
-}
 
 async function resolveUsers(
   client: DoorayApiClient,
@@ -80,7 +53,7 @@ export const postCreateCommand = new Command("create")
       );
     }
 
-    const bodyContent = await readBody(opts);
+    const bodyContent = await readBodyInput(opts);
 
     startSpinner("업무 생성 중...");
     const projectId = await resolveProject(client, project);

--- a/src/commands/post/edit.ts
+++ b/src/commands/post/edit.ts
@@ -1,5 +1,4 @@
 import { Command } from "commander";
-import fs from "node:fs/promises";
 import { getConfigOrThrow } from "../../config/store.js";
 import { DoorayApiClient } from "../../api/client.js";
 import { resolveProject } from "../../resolvers/project.js";
@@ -11,8 +10,7 @@ import {
   parsePostFrontmatter,
 } from "../../editor/index.js";
 import { startSpinner, stopSpinner } from "../../utils/spinner.js";
-import { DoorayCliError } from "../../utils/errors.js";
-import { EXIT_PARAM_ERROR } from "../../utils/exit-codes.js";
+import { readBodyInputOrNull } from "../../utils/body-input.js";
 import type { CreatePostUser } from "../../api/types.js";
 
 async function resolveUsers(
@@ -26,35 +24,6 @@ async function resolveUsers(
     users.push({ type: "member", member: { organizationMemberId: memberId } });
   }
   return users;
-}
-
-async function readStdin(): Promise<string> {
-  if (process.stdin.isTTY) {
-    throw new DoorayCliError(
-      "stdin에서 읽으려면 파이프로 데이터를 전달해주세요.",
-      EXIT_PARAM_ERROR,
-    );
-  }
-  const chunks: Buffer[] = [];
-  for await (const chunk of process.stdin) {
-    chunks.push(chunk);
-  }
-  return Buffer.concat(chunks).toString("utf-8");
-}
-
-async function resolveBody(opts: {
-  body?: string;
-  bodyFile?: string;
-}): Promise<string | null> {
-  if (opts.body) {
-    if (opts.body === "-") return readStdin();
-    return opts.body;
-  }
-  if (opts.bodyFile) {
-    if (opts.bodyFile === "-") return readStdin();
-    return fs.readFile(opts.bodyFile, "utf-8");
-  }
-  return null;
 }
 
 export const postEditCommand = new Command("edit")
@@ -88,7 +57,7 @@ export const postEditCommand = new Command("edit")
 
     if (nonInteractive) {
       // Non-interactive mode: apply only specified changes
-      const newBody = await resolveBody(opts);
+      const newBody = await readBodyInputOrNull(opts);
 
       startSpinner("업무 수정 중...");
       const toUsers: CreatePostUser[] = post.users.to.map((u) => ({

--- a/src/utils/body-input.ts
+++ b/src/utils/body-input.ts
@@ -29,6 +29,20 @@ export async function readBodyInput(opts: BodyInputOptions): Promise<string> {
   return opts.body ?? "";
 }
 
+/**
+ * `readBodyInput`의 null-friendly variant.
+ *
+ * - body/bodyFile 둘 다 미지정 시 `null` 반환 (호출자가 "본문 유지" / "$EDITOR 폴백" 등으로 해석)
+ * - 동시 지정 시 에러 (`readBodyInput`과 동일)
+ * - 하나만 지정 시 해당 값 반환 (`readBodyInput`과 동일)
+ */
+export async function readBodyInputOrNull(
+  opts: BodyInputOptions,
+): Promise<string | null> {
+  if (opts.body == null && opts.bodyFile == null) return null;
+  return readBodyInput(opts);
+}
+
 async function readStdin(): Promise<string> {
   if (process.stdin.isTTY) {
     throw new DoorayCliError(

--- a/tasks/008-refactor-post-body-input/index.json
+++ b/tasks/008-refactor-post-body-input/index.json
@@ -2,8 +2,8 @@
   "name": "008-refactor-post-body-input",
   "description": "post 4 파일(create/edit/comment-add/comment-edit)의 readBody/resolveBody/readStdin 중복을 body-input.ts 유틸로 일원화 — GitHub Issue #12",
   "created_at": "2026-04-24T00:00:00Z",
-  "status": "pending",
-  "current_phase": 1,
+  "status": "completed",
+  "current_phase": 2,
   "total_phases": 2,
   "error_message": null,
   "blocked_reason": null,
@@ -12,16 +12,16 @@
       "number": 1,
       "title": "readBodyInputOrNull 유틸 추가 + post 4 파일 migration",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 2,
       "title": "빌드 + smoke 검증",
       "file": "phase-02.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],
-  "updated_at": "2026-04-24T00:00:00Z"
+  "updated_at": "2026-04-24T01:05:00Z"
 }

--- a/tasks/008-refactor-post-body-input/phase-01.md
+++ b/tasks/008-refactor-post-body-input/phase-01.md
@@ -44,6 +44,7 @@ Task 006(PR #13)에서 `body-input.ts` 가 추가됐고, task 007(PR #14) 에서
 2. **동작 변화 수용**: post 4 파일 모두 `--body` + `--body-file` **동시 지정 시 에러** (기존 silent ignore 제거). Issue #12 Acceptance에 명시됨
 3. **post/create**: `readBodyInput` 그대로 사용 (미지정 시 `""`)
 4. **post/edit, comment/add, comment/edit**: `readBodyInputOrNull` 사용 (미지정 시 `null` = 기존 "본문 유지" / "에디터 폴백" 시맨틱 유지)
+5. **잠재 버그 동시 수정 (의도된 부수효과)**: post/create의 기존 로컬 `readBody`는 `--body <text>`(non-"-") 전달 시 문자열을 silent drop하고 `""`를 반환하는 버그가 있었음. `readBodyInput`(`return opts.body ?? ""`)으로 migration 하면서 이 버그가 자동 수정됨
 
 ## 목표
 
@@ -53,7 +54,7 @@ Task 006(PR #13)에서 `body-input.ts` 가 추가됐고, task 007(PR #14) 에서
 4. `DoorayCliError`/`EXIT_PARAM_ERROR` import는 **다른 용도로 쓰이면 보존**, 아니면 제거
 5. 빌드 통과 + 동일 동작(+ 새 에러 가드)
 
-## 작업 목록
+## 작업 목록 (4개)
 
 ### 1) `src/utils/body-input.ts` 확장
 
@@ -77,7 +78,11 @@ export async function readBodyInputOrNull(
 
 **주의**: `readBodyInput` 내부의 `--body와 --body-file은 함께 사용할 수 없습니다.` 에러 가드가 자동 전파됨. 별도 구현 불필요.
 
-### 2) `src/commands/post/create.ts` migration
+### 2) post 4 파일 migration (create / edit / comment-add / comment-edit)
+
+4개 파일을 동일한 패턴으로 일괄 migration. 각 파일 작업은 독립적이지만 의존성이 없어 하나의 묶음으로 취급.
+
+#### 2a) `src/commands/post/create.ts` migration
 
 **Before (L1-39 구조)**:
 ```ts
@@ -101,7 +106,7 @@ async function readStdin(): Promise<string> { ... }
 
 **주의**: `DoorayCliError`, `EXIT_PARAM_ERROR` 는 post/create.ts에서 **`--title` 필수 체크에 계속 사용** → 유지.
 
-### 3) `src/commands/post/edit.ts` migration
+#### 2b) `src/commands/post/edit.ts` migration
 
 **Before (L31-58 구조)**:
 ```ts
@@ -129,7 +134,7 @@ grep -n "DoorayCliError\|EXIT_PARAM_ERROR" src/commands/post/edit.ts
 ```
 → 결과가 readStdin 내부 외에 없으면 두 import 모두 **제거**. 있으면 유지.
 
-### 4) `src/commands/post/comment/add.ts` migration
+#### 2c) `src/commands/post/comment/add.ts` migration
 
 **Before (L14-41 구조)**:
 ```ts
@@ -154,7 +159,7 @@ async function resolveBody(opts: {...}): Promise<string | null> { ... }
 
 **주의**: `DoorayCliError` / `EXIT_PARAM_ERROR` 사용 여부 grep 확인 후 선별 제거.
 
-### 5) `src/commands/post/comment/edit.ts` migration
+#### 2d) `src/commands/post/comment/edit.ts` migration
 
 **Before (L12-39 구조)**:
 ```ts
@@ -178,14 +183,14 @@ async function resolveBody(opts: {...}): Promise<string | null> { ... }
 
 **주의**: 마찬가지로 `DoorayCliError` / `EXIT_PARAM_ERROR` 사용 여부 grep 후 선별 제거.
 
-### 6) 빌드 검증
+### 3) 빌드 검증
 
 ```bash
 # cwd: /Users/nhn/personal/dooray-cli
 pnpm run build
 ```
 
-### 7) 정적 검증
+### 4) 정적 검증
 
 ```bash
 # cwd: /Users/nhn/personal/dooray-cli

--- a/tasks/008-refactor-post-body-input/phase-02.md
+++ b/tasks/008-refactor-post-body-input/phase-02.md
@@ -95,6 +95,7 @@ Edit 도구로 `tasks/008-refactor-post-body-input/index.json` 수정:
 - smoke 결과는 `grep -c` 정수 비교 or `exit code`로만
 - `testproj` 등 존재하지 않는 프로젝트 사용은 안전 (Dooray 권한 범위 내 missing이라 resolve 단계에서 실패)
 - **4) 스텝은 반드시 1~3 모두 통과 후** — 검증 실패 상태에서 completed로 전환 금지
+- **`post edit` / `post comment edit`의 body 가드 검증은 `exit code != 0` 체크만** — 이 두 명령은 action 내부에서 `readBodyInputOrNull`을 `resolveProject`/`resolvePost` **뒤에** 호출하므로, `testproj` 인자로는 resolve 단계 에러가 먼저 발생하여 body 가드 stdout 메시지 검증 불가. body 가드가 실제 발동하는지는 `post create`/`post comment add` 2파일의 엄격 smoke로 대리 증명 (4파일 모두 `body-input.ts`의 동일 경로를 사용하므로 충분). 완전 단위 검증이 필요하면 `node -e "require('./dist/index.js')"` 후 `readBodyInputOrNull`을 직접 호출하는 단위 스모크 추가 가능
 
 ## Blocked 조건
 

--- a/tasks/008-refactor-post-body-input/phase-02.md
+++ b/tasks/008-refactor-post-body-input/phase-02.md
@@ -1,115 +1,100 @@
-# Phase 2: 빌드 + smoke 검증
+# Phase 2: 빌드 + smoke 검증 + task 완료 처리
 
 ## 컨텍스트
 
-Phase 1 완료 후 기계 검증. 코드 변경 없음.
+Phase 1 완료 후 기계 검증 및 task 메타데이터(`index.json`) `completed` 확정. 코드 변경은 이 phase에서 수행하지 않음 (마지막 스텝의 `index.json` 수정만 예외).
 
 ### 먼저 읽을 파일
 
-- `tasks/008-refactor-post-body-input/index.json` — phase 1 상태 확인용
+- `tasks/008-refactor-post-body-input/index.json` — 완료 처리 대상
 
 ## 목표
 
-1. `pnpm run build` 통과
-2. `post create / edit / comment add / comment edit --help` 4개 smoke — 기존 옵션 표면 보존 확인
-3. `--body` + `--body-file` 동시 지정 시 에러 동작 확인 (4 파일 모두)
-4. wiki 커맨드 회귀 없음 (page-create, page-edit 는 body-input.ts 시그니처 무변경이라 자동 보존)
+1. `pnpm run build` 통과 + 번들 크기 감소 확인
+2. `post create / edit / comment add / comment edit --help` 4개 + wiki 회귀 2개 smoke — 옵션 표면 보존
+3. `--body` + `--body-file` 동시 지정 시 에러 동작 확인 (body 가드가 먼저 발동하는 2파일은 엄격, 나중에 발동하는 2파일은 exit 코드 검증)
+4. `index.json` 완료 처리 (`status: "completed"` 확정)
 
-## 작업 목록
+## 작업 목록 (4개)
 
-### 1) 빌드
+### 1) 빌드 + 번들 크기
 
 ```bash
 # cwd: /Users/nhn/personal/dooray-cli
 pnpm run build
+ls -la dist/index.js
 ```
 
-### 2) `--help` smoke 4개
+기대: build 성공 (exit 0). 번들 크기는 이전 대비 감소 (4파일 중복 함수 제거로 수 KB).
+
+### 2) help smoke (post 4개 + wiki 회귀 2개 묶음)
 
 ```bash
 # cwd: /Users/nhn/personal/dooray-cli
 
-node dist/index.js post create --help 2>&1 | grep -E "\-\-body|\-\-body-file|\-\-title"
-node dist/index.js post edit --help 2>&1 | grep -E "\-\-body|\-\-body-file|\-\-title"
-node dist/index.js post comment add --help 2>&1 | grep -E "\-\-body|\-\-body-file"
+# post 4개 — 옵션 표면 보존
+node dist/index.js post create       --help 2>&1 | grep -E "\-\-body|\-\-body-file|\-\-title"
+node dist/index.js post edit         --help 2>&1 | grep -E "\-\-body|\-\-body-file|\-\-title"
+node dist/index.js post comment add  --help 2>&1 | grep -E "\-\-body|\-\-body-file"
 node dist/index.js post comment edit --help 2>&1 | grep -E "\-\-body|\-\-body-file"
-```
 
-기대: 각 명령의 help 출력에 관련 옵션 모두 그대로 존재.
-
-### 3) wiki 회귀 확인
-
-```bash
+# wiki 회귀 2개 — readBodyInput signature 무변경이라 자동 보존
 node dist/index.js wiki page create --help 2>&1 | grep -E "\-\-body|\-\-body-file|\-\-title|\-\-parent"
-node dist/index.js wiki page edit --help 2>&1 | grep -E "\-\-body|\-\-body-file|\-\-title"
+node dist/index.js wiki page edit   --help 2>&1 | grep -E "\-\-body|\-\-body-file|\-\-title"
 ```
 
-기대: 기존 옵션 그대로.
+기대: 각 명령의 관련 옵션 모두 그대로 존재.
 
-### 4) 동시 지정 에러 smoke (post 4파일)
+### 3) 동시 지정 에러 smoke
 
-실제 API 호출 전에 에러가 뜨도록 **존재하지 않는 프로젝트**를 인자로 주되 body 충돌을 만든다. 가드가 early throw 하므로 프로젝트 해석 전에 에러가 나와야 함.
-
-```bash
-# post create
-node dist/index.js post create testproj --title "t" --body "a" --body-file /dev/null 2>&1 | grep "함께 사용할 수 없습니다"
-
-# post edit
-node dist/index.js post edit testproj 1 --body "a" --body-file /dev/null 2>&1 | grep "함께 사용할 수 없습니다"
-
-# post comment add
-node dist/index.js post comment add testproj 1 --body "a" --body-file /dev/null 2>&1 | grep "함께 사용할 수 없습니다"
-
-# post comment edit
-node dist/index.js post comment edit testproj 1 dummy-comment-id --body "a" --body-file /dev/null 2>&1 | grep "함께 사용할 수 없습니다"
-```
-
-**주의**: 일부 명령은 API 호출보다 config 로드/프로젝트 resolve가 먼저 일어날 수 있음 — 그 경우 `config not found` 같은 에러가 먼저 나오면 smoke 실패. 실제 동작 순서 확인 필요. action 함수 진입 직후에 `readBodyInput*` 을 호출하는 파일은 body 가드가 먼저. resolve 후에 호출하는 파일은 resolve 에러가 먼저.
-
-Phase 1 설계에 따르면:
-- `post/create`: `resolveProject` **전**에 `readBodyInput` 호출 → body 가드 먼저
-- `post/edit`: `resolveProject`/`resolvePost` **후**에 `readBodyInputOrNull` 호출 → resolve 에러 먼저 (실제 프로젝트 없으면 config/API 에러)
-- `post/comment/add`: `readBodyInputOrNull`을 `resolveProject` **전**에 호출 → body 가드 먼저
-- `post/comment/edit`: `resolveProject`/`resolvePost`/`getPostComments` **후**에 `readBodyInputOrNull` 호출 → resolve 에러 먼저
-
-**수정된 smoke 전략**: body 가드가 먼저 발동하는 2파일만 strict grep. 나머지 2파일은 grep 없이 exit 코드 비영(!=0)만 확인.
+body 가드가 먼저 발동하는 2파일은 엄격 grep. 나중 발동하는 2파일은 exit 코드만 확인 (resolve 에러가 먼저 나올 수 있음).
 
 ```bash
-# body 가드가 먼저 발동 (엄격)
+# 엄격: body 가드가 resolve 전
 node dist/index.js post create testproj --title "t" --body "a" --body-file /dev/null 2>&1 | grep -c "함께 사용할 수 없습니다"
-node dist/index.js post comment add testproj 1 --body "a" --body-file /dev/null 2>&1 | grep -c "함께 사용할 수 없습니다"
+node dist/index.js post comment add testproj 1     --body "a" --body-file /dev/null 2>&1 | grep -c "함께 사용할 수 없습니다"
 
-# body 가드가 나중에 발동 (완화: exit 코드만)
-node dist/index.js post edit testproj 1 --body "a" --body-file /dev/null; echo "exit=$?"
+# 완화: exit 코드만
+node dist/index.js post edit testproj 1            --body "a" --body-file /dev/null; echo "exit=$?"
 node dist/index.js post comment edit testproj 1 cid --body "a" --body-file /dev/null; echo "exit=$?"
 ```
 
-### 5) 번들 크기 점검
+기대: 처음 2개는 grep 결과 `>= 1`. 나머지 2개는 `exit=0`이 아닌 값 출력.
 
-```bash
-ls -la dist/index.js
-# 이전 빌드 대비 크기가 크게 감소 (4파일의 중복 함수 제거로 수 KB)
-```
+### 4) `index.json` 완료 처리
+
+Edit 도구로 `tasks/008-refactor-post-body-input/index.json` 수정:
+
+- 최상위 `status`: `"pending"` → `"completed"`
+- 최상위 `current_phase`: `2`
+- 최상위 `updated_at`: 현재 ISO 8601 타임스탬프 (예: `"2026-04-24T00:00:00Z"`)
+- `phases[0].status`, `phases[1].status`: 모두 `"completed"`
+
+**반드시 위 1~3 스텝이 모두 통과한 뒤에만 수행.** 검증 실패 상태에서 `completed`로 표시 금지.
 
 ## 성공 기준
 
 - [ ] `pnpm run build` 성공 (exit 0)
-- [ ] `post create --help` 출력에 `--body`, `--body-file`, `--title` 존재
-- [ ] `post edit --help` 출력에 `--body`, `--body-file`, `--title` 존재
-- [ ] `post comment add --help` 출력에 `--body`, `--body-file` 존재
-- [ ] `post comment edit --help` 출력에 `--body`, `--body-file` 존재
-- [ ] `wiki page create --help` 출력에 `--title`, `--parent`, `--body`, `--body-file` 존재 (무회귀)
-- [ ] `wiki page edit --help` 출력에 `--title`, `--body`, `--body-file` 존재 (무회귀)
-- [ ] `post create testproj --title t --body a --body-file /dev/null` → 에러 메시지 `"함께 사용할 수 없습니다"` 매치
-- [ ] `post comment add testproj 1 --body a --body-file /dev/null` → 동일 에러 매치
-- [ ] `post edit` / `post comment edit` 동시 지정 호출 → exit code != 0 (resolve 에러가 먼저 나올 수 있어 message grep은 완화)
-- [ ] `git status --short` → 이 phase에서는 코드 수정 없음
+- [ ] `dist/index.js` 번들 크기 이전 대비 감소 (주관적, 그래프만)
+- [ ] `post create --help` → `--body`, `--body-file`, `--title` 존재
+- [ ] `post edit --help` → `--body`, `--body-file`, `--title` 존재
+- [ ] `post comment add --help` → `--body`, `--body-file` 존재
+- [ ] `post comment edit --help` → `--body`, `--body-file` 존재
+- [ ] `wiki page create --help` → `--title`, `--parent`, `--body`, `--body-file` 존재 (무회귀)
+- [ ] `wiki page edit --help` → `--title`, `--body`, `--body-file` 존재 (무회귀)
+- [ ] `post create testproj --title t --body a --body-file /dev/null` → `"함께 사용할 수 없습니다"` grep 매치
+- [ ] `post comment add testproj 1 --body a --body-file /dev/null` → 동일 매치
+- [ ] `post edit` / `post comment edit` 동시 지정 호출 → exit code != 0
+- [ ] `jq -r '.status' tasks/008-refactor-post-body-input/index.json` → `completed`
+- [ ] `jq -r '[.phases[].status] | unique | .[]' tasks/008-refactor-post-body-input/index.json` → `completed` (단일 값)
+- [ ] `git status --short src/` → 코드 수정 없음 (`index.json`만 변경)
 
 ## 주의사항
 
-- **이 phase는 코드 변경 금지** — 실패 시 phase-01 재개 (`--from-phase 1`)
-- smoke 결과는 `grep -c` 로 정수 비교 or `exit code` 확인
-- `testproj` 같이 존재하지 않는 프로젝트 코드 사용 — 실제 API 호출이 가능한 환경에서도 안전 (Dooray 권한 범위 내에서 missing 이라 resolve 단계에서 실패)
+- **코드 수정 금지** — 검증 실패 시 phase-01 재개 (`--from-phase 1`)
+- smoke 결과는 `grep -c` 정수 비교 or `exit code`로만
+- `testproj` 등 존재하지 않는 프로젝트 사용은 안전 (Dooray 권한 범위 내 missing이라 resolve 단계에서 실패)
+- **4) 스텝은 반드시 1~3 모두 통과 후** — 검증 실패 상태에서 completed로 전환 금지
 
 ## Blocked 조건
 


### PR DESCRIPTION
## Summary

- `post create` / `post edit` / `post comment add` / `post comment edit` 4개 파일의 로컬 `readBody` / `resolveBody` / `readStdin` 중복을 `src/utils/body-input.ts`로 일원화 (Issue #12)
- `readBodyInputOrNull` (string | null) 유틸 추가 — 기존 `readBodyInput`(string)을 재사용하는 null-friendly variant
- **동작 변화**: `--body` + `--body-file` 동시 지정 시 에러 (기존 silent ignore 제거)
- **부수 fix**: `post/create`의 `--body <text>` silent drop 버그 자동 수정 (기존 `readBody`는 `body === "-"`가 아니면 `""` 반환)
- 공개 문서 갱신: `skills/dooray-cli/SKILL.md` + `README.md`에 `--body-file` 예시 및 `--body`/`--body-file` 상호배타 안내

## Changes

| File | Change |
|---|---|
| `src/utils/body-input.ts` | `readBodyInputOrNull` export 추가 (+14 lines) |
| `src/commands/post/create.ts` | fs import·로컬 readBody/readStdin 제거, `readBodyInput` 교체 |
| `src/commands/post/edit.ts` | fs import·로컬 함수 제거, `readBodyInputOrNull` 교체, 불필요 import 정리 |
| `src/commands/post/comment/add.ts` | 동일 패턴 |
| `src/commands/post/comment/edit.ts` | 동일 패턴 |
| `skills/dooray-cli/SKILL.md` | post 커맨드 예시에 `--body-file` + 상호배타 명시 |
| `README.md` | post create/edit/comment-add 섹션에 `--body-file` 예시 |
| `tasks/008-refactor-post-body-input/index.json` | status completed |

## Metrics

- 번들 크기: 100.34 KB → **97.52 KB** (2.82 KB 감소)
- 코드 변경: -138 / +39 (net -99 lines)
- wiki 콜러 (`wiki page create/edit`): 무변경 (`readBodyInput` signature 보존)

## Non-breaking 대상 (건드리지 않음)

- `mail send --subject/--body` — 이메일 표준
- `post list --subject <keyword>` — 키워드 필터
- `wiki page create/edit` — 이미 `readBodyInput` 사용 중

## Pipeline

build-with-teams 파이프라인 (critic REVISE 1회 → APPROVE → executor → code-reviewer PASS → docs-verifier UPDATE_NEEDED 2회 → PASS).

## Test plan

- [x] `pnpm run build` 성공 (97.52 KB)
- [x] `post create --help` / `post edit --help` / `post comment add --help` / `post comment edit --help` — 기존 옵션 표면 보존
- [x] `wiki page create --help` / `wiki page edit --help` — 무회귀
- [x] `post create testproj --title t --body a --body-file /dev/null` → `"함께 사용할 수 없습니다"` 에러
- [x] `post comment add testproj 1 --body a --body-file /dev/null` → 동일 에러
- [x] `post edit` / `post comment edit` 동시 지정 → exit code != 0 (resolve 에러 먼저 발생 가능, 대리 증명은 위 2파일로)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)