### PR TITLE
feat(commands): add post create meta options (--tag/--parent/--workflow/--milestone)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,17 @@ dooray post create tc-ocr \
 
 # 본문을 파일에서 읽기 (--body와 --body-file은 동시 사용 불가)
 dooray post create tc-ocr --title "업무 제목" --body-file ./content.md
+
+# 메타 옵션: --tag(반복) / --parent / --workflow / --milestone
+dooray post create tc-ocr \
+  --title "업무 제목" --body "본문" --to "담당자이름" \
+  --tag "버그" --tag "긴급" \
+  --parent "tc-ocr/337" \
+  --workflow "진행 중" \
+  --milestone "Sprint 12"
 ```
+
+> mandatory-tag 정책 프로젝트(예: `tc-ocr`)에서는 mandatory 그룹마다 1개 이상 `--tag`로 지정해야 한다. 누락 시 클라이언트가 사전 검증으로 후보 목록과 함께 에러 출력.
 
 ### 업무 수정
 

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -35,6 +35,10 @@ src/
     workflow.ts             # name·class → workflowId
     post.ts                 # postNumber → postId (API 호출)
     wiki.ts                 # projectCode → wikiId / wikiId → homePageId (캐시)
+    postRef.ts              # "code/number" 또는 raw postId → postId
+    tag.ts                  # name[] → tagIds + mandatory/selectOne 검증
+    milestone.ts            # name → milestoneId
+    match.ts                # 공용: 정확일치 → 부분일치 → 모호 시 에러
 
   cache/
     store.ts                # ~/.dooray/cache/ 디렉토리 기반 CRUD + TTL 체크

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -54,7 +54,7 @@ dooray doctor                                 # 설정 검증
 | 업무 목록 조회 | `dooray post list <project>` |
 | 업무 검색 | `dooray post search <project> "<keyword>"` |
 | 업무 상세 보기 | `dooray post get <project> <number>` |
-| 업무 생성 | `dooray post create <project> --title "..." --body "..."` 또는 `--body-file <path>` (`--body`와 `--body-file`은 동시 사용 불가) |
+| 업무 생성 | `dooray post create <project> --title "..." --body "..."` 또는 `--body-file <path>` (`--body`와 `--body-file`은 동시 사용 불가, `--tag`/`--parent`/`--workflow`/`--milestone` 지원) |
 | 업무 제목/본문 수정 | `dooray post edit <project> <number> --title "..." --body "..."` 또는 `--body-file <path>` |
 | 업무 완료 처리 | `dooray post done <project> <number>` |
 | 업무 워크플로우 변경 | `dooray post workflow <project> <number> <workflow>` |
@@ -170,13 +170,19 @@ dooray post create <project> \
   --to "담당자이름" \           # 여러 명: --to "김철수" --to "이영희"
   --cc "참조자이름" \
   --priority normal \           # highest, high, normal, low, lowest
-  --due-date "2026-04-30T18:00:00+09:00"
+  --due-date "2026-04-30T18:00:00+09:00" \
+  --tag "버그" --tag "긴급" \   # 반복 지정. mandatory 그룹은 클라이언트 사전 검증
+  --parent "tc-ocr/337" \       # "code/number" 또는 raw postId 두 형태만 허용
+  --workflow "진행 중" \         # 이름 또는 class (registered/working/closed). 부분일치 모호 시 후보 + 에러
+  --milestone "Sprint 12"
 ```
 
 본문이 길면 파일로 (`--body`와 `--body-file`은 함께 사용 불가):
 ```bash
 dooray post create <project> --title "제목" --body-file ./content.md
 ```
+
+> **`--workflow` 동작 주의**: 워크플로우 설정은 post 생성 *후속* 호출이므로, 워크플로우 resolve/설정에 실패해도 stderr 경고만 출력되고 **exit code는 0** (post는 이미 생성됨). 자동화 스크립트에서 워크플로우 적용 여부를 보장해야 하면 stderr를 별도 점검할 것.
 
 ### 업무 수정 (non-interactive)
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -24,6 +24,8 @@ import type {
   ProjectMemberListResponse,
   ProjectWorkflowListResponse,
   MemberDetailResponse,
+  TagListResponse,
+  MilestoneListResponse,
   WikiListResponse,
   WikiPagesResponse,
   WikiPageResponse,
@@ -337,6 +339,46 @@ export class DoorayApiClient {
       return await this.api
         .get(`project/v1/projects/${projectId}/workflows`)
         .json<ProjectWorkflowListResponse>();
+    } catch (e) {
+      return toDoorayCliError(e);
+    }
+  }
+
+  // ─── Tags ───────────────────────────────────────────
+
+  async getProjectTags(
+    projectId: string,
+    params?: { page?: number; size?: number },
+  ): Promise<TagListResponse> {
+    try {
+      return await this.api
+        .get(`project/v1/projects/${projectId}/tags`, {
+          searchParams: {
+            ...(params?.page != null && { page: params.page }),
+            ...(params?.size != null && { size: params.size }),
+          },
+        })
+        .json<TagListResponse>();
+    } catch (e) {
+      return toDoorayCliError(e);
+    }
+  }
+
+  // ─── Milestones ─────────────────────────────────────
+
+  async getProjectMilestones(
+    projectId: string,
+    params?: { page?: number; size?: number },
+  ): Promise<MilestoneListResponse> {
+    try {
+      return await this.api
+        .get(`project/v1/projects/${projectId}/milestones`, {
+          searchParams: {
+            ...(params?.page != null && { page: params.page }),
+            ...(params?.size != null && { size: params.size }),
+          },
+        })
+        .json<MilestoneListResponse>();
     } catch (e) {
       return toDoorayCliError(e);
     }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -71,13 +71,37 @@ export interface ParentPost {
   subject: string;
 }
 
+export interface TagGroup {
+  id: string;
+  name: string;
+  mandatory: boolean;
+  selectOne: boolean;
+}
+
+// 기존 Tag 확장 — 신규 필드는 모두 optional.
+// PostDetailItem.tags 응답에는 id 외 필드가 없을 수 있어 런타임 undefined 위험 방지.
+export interface Tag {
+  id: string;
+  name?: string;
+  color?: string;
+  tagGroup?: TagGroup | null;
+}
+
 export interface Milestone {
   id: string;
   name: string;
 }
 
-export interface Tag {
-  id: string;
+export interface TagListResponse {
+  header: DoorayApiHeader;
+  result: Tag[];
+  totalCount: number;
+}
+
+export interface MilestoneListResponse {
+  header: DoorayApiHeader;
+  result: Milestone[];
+  totalCount: number;
 }
 
 export interface Workflow {

--- a/src/cache/store.ts
+++ b/src/cache/store.ts
@@ -7,6 +7,8 @@ import type {
   CachedProject,
   CachedMember,
   CachedWorkflow,
+  CachedTag,
+  CachedMilestone,
   CachedWiki,
 } from "./types.js";
 
@@ -16,6 +18,8 @@ const PROJECTS_PATH = join(CACHE_DIR, "projects.json");
 const PROJECTS_PRIVATE_PATH = join(CACHE_DIR, "projects-private.json");
 const MEMBERS_DIR = join(CACHE_DIR, "members");
 const WORKFLOWS_DIR = join(CACHE_DIR, "workflows");
+const TAGS_DIR = join(CACHE_DIR, "tags");
+const MILESTONES_DIR = join(CACHE_DIR, "milestones");
 const WIKIS_PATH = join(CACHE_DIR, "wikis.json");
 
 // ─── Helpers ──────────────────────────────────────────────
@@ -104,6 +108,34 @@ export async function setWorkflows(projectId: string, items: CachedWorkflow[]): 
   await writeJson(workflowsPath(projectId), { updatedAt: now(), data: items } satisfies CacheEntry<CachedWorkflow[]>);
 }
 
+// ─── Tags (per project) ──────────────────────────────
+
+function tagsPath(projectId: string): string {
+  return join(TAGS_DIR, `${projectId}.json`);
+}
+
+export async function getTags(projectId: string): Promise<CacheEntry<CachedTag[]> | null> {
+  return readJson<CacheEntry<CachedTag[]>>(tagsPath(projectId));
+}
+
+export async function setTags(projectId: string, items: CachedTag[]): Promise<void> {
+  await writeJson(tagsPath(projectId), { updatedAt: now(), data: items } satisfies CacheEntry<CachedTag[]>);
+}
+
+// ─── Milestones (per project) ─────────────────────────
+
+function milestonesPath(projectId: string): string {
+  return join(MILESTONES_DIR, `${projectId}.json`);
+}
+
+export async function getMilestones(projectId: string): Promise<CacheEntry<CachedMilestone[]> | null> {
+  return readJson<CacheEntry<CachedMilestone[]>>(milestonesPath(projectId));
+}
+
+export async function setMilestones(projectId: string, items: CachedMilestone[]): Promise<void> {
+  await writeJson(milestonesPath(projectId), { updatedAt: now(), data: items } satisfies CacheEntry<CachedMilestone[]>);
+}
+
 // ─── Wikis ────────────────────────────────────────────────
 
 export async function getWikis(): Promise<CacheEntry<CachedWiki[]> | null> {
@@ -130,6 +162,8 @@ export async function getCacheStats(): Promise<{
   projectCount: number;
   memberProjectCount: number;
   workflowProjectCount: number;
+  tagProjectCount: number;
+  milestoneProjectCount: number;
   me: CachedMe | null;
 }> {
   const projects = await getProjects();
@@ -147,7 +181,19 @@ export async function getCacheStats(): Promise<{
     workflowProjectCount = files.filter((f) => f.endsWith(".json")).length;
   } catch { /* dir doesn't exist */ }
 
+  let tagProjectCount = 0;
+  try {
+    const files = await readdir(TAGS_DIR);
+    tagProjectCount = files.filter((f) => f.endsWith(".json")).length;
+  } catch { /* dir doesn't exist */ }
+
+  let milestoneProjectCount = 0;
+  try {
+    const files = await readdir(MILESTONES_DIR);
+    milestoneProjectCount = files.filter((f) => f.endsWith(".json")).length;
+  } catch { /* dir doesn't exist */ }
+
   const me = await getMe();
 
-  return { projectCount, memberProjectCount, workflowProjectCount, me: me?.data ?? null };
+  return { projectCount, memberProjectCount, workflowProjectCount, tagProjectCount, milestoneProjectCount, me: me?.data ?? null };
 }

--- a/src/cache/types.ts
+++ b/src/cache/types.ts
@@ -31,6 +31,24 @@ export interface CachedWorkflow {
   order?: number;
 }
 
+export const TAGS_TTL_MS = 86_400_000;       // 24h
+export const MILESTONES_TTL_MS = 86_400_000; // 24h
+export const RESOLVER_FETCH_PAGE_SIZE = 100;
+
+export interface CachedTag {
+  id: string;
+  name: string;
+  groupId: string | null;        // tagGroup.id (null이면 미소속)
+  groupName: string | null;
+  groupMandatory: boolean;       // mandatory 검증에 필요
+  groupSelectOne: boolean;       // selectOne 검증에 필요
+}
+
+export interface CachedMilestone {
+  id: string;
+  name: string;
+}
+
 export const WIKIS_TTL_MS = 86_400_000; // 24h — wiki home은 거의 불변
 
 export interface CachedWiki {

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -43,6 +43,8 @@ export const doctorCommand = new Command("doctor")
     console.log(`  프로젝트:   ${stats.projectCount}개`);
     console.log(`  멤버:       ${stats.memberProjectCount}개 프로젝트`);
     console.log(`  워크플로우: ${stats.workflowProjectCount}개 프로젝트`);
+    console.log(`  Tag 캐시 (프로젝트 수): ${stats.tagProjectCount}`);
+    console.log(`  Milestone 캐시 (프로젝트 수): ${stats.milestoneProjectCount}`);
 
     // Claude Code 스킬 검증
     const claudeDir = path.join(

--- a/src/commands/post/create.ts
+++ b/src/commands/post/create.ts
@@ -3,6 +3,10 @@ import { getConfigOrThrow } from "../../config/store.js";
 import { DoorayApiClient } from "../../api/client.js";
 import { resolveProject } from "../../resolvers/project.js";
 import { resolveMember } from "../../resolvers/member.js";
+import { resolveTags } from "../../resolvers/tag.js";
+import { resolveMilestone } from "../../resolvers/milestone.js";
+import { resolvePostRef } from "../../resolvers/postRef.js";
+import { resolveWorkflow } from "../../resolvers/workflow.js";
 import { startSpinner, stopSpinner } from "../../utils/spinner.js";
 import { DoorayCliError } from "../../utils/errors.js";
 import { EXIT_PARAM_ERROR } from "../../utils/exit-codes.js";
@@ -35,6 +39,10 @@ export const postCreateCommand = new Command("create")
   .option("--body-file <path>", "본문 파일 경로 (- 입력 시 stdin에서 읽기)")
   .option("--priority <level>", "우선순위 (highest, high, normal, low, lowest)", "normal")
   .option("--due-date <date>", "마감일 (ISO 8601 형식)")
+  .option("--tag <name>", "태그 이름 (반복 가능)", (value, prev: string[]) => [...prev, value], [] as string[])
+  .option("--parent <ref>", "부모 업무 (project/number 또는 postId)")
+  .option("--workflow <name>", "초기 워크플로우 이름 또는 class")
+  .option("--milestone <name>", "마일스톤 이름")
   .action(async (project, opts) => {
     const globalOpts = postCreateCommand.optsWithGlobals() as OutputOptions;
     const config = await getConfigOrThrow();
@@ -61,14 +69,42 @@ export const postCreateCommand = new Command("create")
     const toUsers = opts.to ? await resolveUsers(client, projectId, opts.to) : [];
     const ccUsers = opts.cc ? await resolveUsers(client, projectId, opts.cc) : [];
 
+    const tagInputs = (opts.tag ?? []).filter((s: string) => s.length > 0);
+
+    const [tagIds, parentPostId, milestoneId] = await Promise.all([
+      tagInputs.length > 0
+        ? resolveTags(client, projectId, tagInputs)
+        : Promise.resolve<string[] | undefined>(undefined),
+      opts.parent
+        ? resolvePostRef(client, opts.parent)
+        : Promise.resolve<string | undefined>(undefined),
+      opts.milestone
+        ? resolveMilestone(client, projectId, opts.milestone)
+        : Promise.resolve<string | undefined>(undefined),
+    ]);
+
     const res = await client.createPost(projectId, {
       subject: subject,
       body: { mimeType: "text/x-markdown", content: bodyContent },
       users: { to: toUsers, cc: ccUsers },
       priority: opts.priority,
       ...(opts.dueDate && { dueDate: opts.dueDate, dueDateFlag: true }),
+      ...(parentPostId && { parentPostId }),
+      ...(milestoneId && { milestoneId }),
+      ...(tagIds && tagIds.length > 0 && { tagIds }),
     });
     stopSpinner(true, "업무 생성 완료");
+
+    if (opts.workflow) {
+      try {
+        const workflowId = await resolveWorkflow(client, projectId, opts.workflow);
+        await client.setPostWorkflow(projectId, res.result.id, workflowId);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`⚠  워크플로우 설정 실패 (post는 생성됨): ${msg}\n`);
+        // exit 0 유지 — 업무는 이미 생성됨
+      }
+    }
 
     if (globalOpts.json) {
       printJson(res.result);

--- a/src/resolvers/match.ts
+++ b/src/resolvers/match.ts
@@ -1,0 +1,47 @@
+import { DoorayCliError } from "../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../utils/exit-codes.js";
+
+export interface NameRecord {
+  name: string;
+}
+
+/**
+ * 정확일치 → 부분일치(includes) → 모호시 에러 + 후보 목록.
+ * 0개 매칭이면 not-found 에러.
+ *
+ * @param items 후보 목록
+ * @param input 사용자 입력
+ * @param label 에러 메시지에 들어갈 도메인 명 (예: "태그", "멤버")
+ * @param renderCandidate 후보 한 줄 표현 (예: m => `${m.name} (${m.id})`)
+ */
+export function matchByName<T extends NameRecord>(
+  items: T[],
+  input: string,
+  label: string,
+  renderCandidate: (item: T) => string,
+): T {
+  const exact = items.filter((i) => i.name === input);
+  if (exact.length === 1) return exact[0];
+  if (exact.length > 1) {
+    throw new DoorayCliError(
+      `복수의 ${label}가 매칭됩니다(정확일치): "${input}"\n` +
+        exact.map((i) => `  - ${renderCandidate(i)}`).join("\n"),
+      EXIT_PARAM_ERROR,
+    );
+  }
+
+  const partial = items.filter((i) => i.name.includes(input));
+  if (partial.length === 1) return partial[0];
+  if (partial.length > 1) {
+    throw new DoorayCliError(
+      `복수의 ${label}가 매칭됩니다: "${input}"\n` +
+        partial.map((i) => `  - ${renderCandidate(i)}`).join("\n"),
+      EXIT_PARAM_ERROR,
+    );
+  }
+
+  throw new DoorayCliError(
+    `${label}을(를) 찾을 수 없습니다: ${input}`,
+    EXIT_PARAM_ERROR,
+  );
+}

--- a/src/resolvers/member.ts
+++ b/src/resolvers/member.ts
@@ -2,8 +2,7 @@ import { DoorayApiClient } from "../api/client.js";
 import type { CachedMember } from "../cache/types.js";
 import { getMembers, setMembers, isExpired } from "../cache/store.js";
 import { MEMBERS_TTL_MS } from "../cache/types.js";
-import { DoorayCliError } from "../utils/errors.js";
-import { EXIT_PARAM_ERROR } from "../utils/exit-codes.js";
+import { matchByName } from "./match.js";
 
 async function fetchAllMembers(
   client: DoorayApiClient,
@@ -64,23 +63,11 @@ export async function resolveMember(
   input: string,
 ): Promise<string> {
   const members = await ensureMembers(client, projectId);
-
-  // name 부분일치
-  const byName = members.filter((m) => m.name.includes(input));
-  if (byName.length === 1) return byName[0].organizationMemberId;
-
-  if (byName.length > 1) {
-    const candidates = byName
-      .map((m) => `  - ${m.name} (${m.organizationMemberId})`)
-      .join("\n");
-    throw new DoorayCliError(
-      `복수의 멤버가 매칭됩니다: "${input}"\n${candidates}`,
-      EXIT_PARAM_ERROR,
-    );
-  }
-
-  throw new DoorayCliError(
-    `멤버를 찾을 수 없습니다: ${input}`,
-    EXIT_PARAM_ERROR,
+  const match = matchByName(
+    members,
+    input,
+    "멤버",
+    (m) => `${m.name} (${m.organizationMemberId})`,
   );
+  return match.organizationMemberId;
 }

--- a/src/resolvers/milestone.ts
+++ b/src/resolvers/milestone.ts
@@ -1,0 +1,40 @@
+import { DoorayApiClient } from "../api/client.js";
+import type { CachedMilestone } from "../cache/types.js";
+import { getMilestones, setMilestones, isExpired } from "../cache/store.js";
+import { MILESTONES_TTL_MS, RESOLVER_FETCH_PAGE_SIZE } from "../cache/types.js";
+import { matchByName } from "./match.js";
+
+async function fetchAllMilestones(client: DoorayApiClient, projectId: string): Promise<CachedMilestone[]> {
+  const all: CachedMilestone[] = [];
+  let page = 0;
+  const size = RESOLVER_FETCH_PAGE_SIZE;
+  while (true) {
+    const res = await client.getProjectMilestones(projectId, { page, size });
+    for (const m of res.result) all.push({ id: m.id, name: m.name });
+    const total = res.totalCount ?? all.length;
+    if (all.length >= total) break;
+    page++;
+  }
+  return all;
+}
+
+export async function ensureMilestones(
+  client: DoorayApiClient,
+  projectId: string,
+): Promise<CachedMilestone[]> {
+  const entry = await getMilestones(projectId);
+  if (entry && !isExpired(entry.updatedAt, MILESTONES_TTL_MS)) return entry.data;
+  const items = await fetchAllMilestones(client, projectId);
+  await setMilestones(projectId, items);
+  return items;
+}
+
+export async function resolveMilestone(
+  client: DoorayApiClient,
+  projectId: string,
+  input: string,
+): Promise<string> {
+  const all = await ensureMilestones(client, projectId);
+  const match = matchByName(all, input, "마일스톤", (m) => `${m.name} (${m.id})`);
+  return match.id;
+}

--- a/src/resolvers/postRef.ts
+++ b/src/resolvers/postRef.ts
@@ -1,0 +1,26 @@
+import { DoorayApiClient } from "../api/client.js";
+import { resolveProject } from "./project.js";
+import { resolvePost } from "./post.js";
+import { DoorayCliError } from "../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../utils/exit-codes.js";
+
+/**
+ * 입력 형식:
+ *  - "<projectCode>/<postNumber>"  → resolveProject + resolvePost
+ *  - 그 외(슬래시 없음)            → raw postId로 간주, 그대로 반환
+ */
+export async function resolvePostRef(client: DoorayApiClient, ref: string): Promise<string> {
+  if (ref.includes("/")) {
+    const [code, numStr] = ref.split("/", 2);
+    const num = Number(numStr);
+    if (!code || !Number.isFinite(num) || num <= 0) {
+      throw new DoorayCliError(
+        `--parent 형식이 올바르지 않습니다: "${ref}" (예: "tc-ocr/337" 또는 raw postId)`,
+        EXIT_PARAM_ERROR,
+      );
+    }
+    const projectId = await resolveProject(client, code);
+    return resolvePost(client, projectId, num);
+  }
+  return ref;
+}

--- a/src/resolvers/tag.ts
+++ b/src/resolvers/tag.ts
@@ -1,0 +1,102 @@
+import { DoorayApiClient } from "../api/client.js";
+import type { CachedTag } from "../cache/types.js";
+import { getTags, setTags, isExpired } from "../cache/store.js";
+import { TAGS_TTL_MS, RESOLVER_FETCH_PAGE_SIZE } from "../cache/types.js";
+import { DoorayCliError } from "../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../utils/exit-codes.js";
+import { matchByName } from "./match.js";
+
+async function fetchAllTags(client: DoorayApiClient, projectId: string): Promise<CachedTag[]> {
+  const all: CachedTag[] = [];
+  let page = 0;
+  const size = RESOLVER_FETCH_PAGE_SIZE;
+  while (true) {
+    const res = await client.getProjectTags(projectId, { page, size });
+    for (const t of res.result) {
+      all.push({
+        id: t.id,
+        name: t.name ?? "",
+        groupId: t.tagGroup?.id ?? null,
+        groupName: t.tagGroup?.name ?? null,
+        groupMandatory: t.tagGroup?.mandatory ?? false,
+        groupSelectOne: t.tagGroup?.selectOne ?? false,
+      });
+    }
+    const total = res.totalCount ?? all.length;
+    if (all.length >= total) break;
+    page++;
+  }
+  return all;
+}
+
+export async function ensureTags(client: DoorayApiClient, projectId: string): Promise<CachedTag[]> {
+  const entry = await getTags(projectId);
+  if (entry && !isExpired(entry.updatedAt, TAGS_TTL_MS)) return entry.data;
+  const items = await fetchAllTags(client, projectId);
+  await setTags(projectId, items);
+  return items;
+}
+
+/**
+ * 입력된 태그 이름들을 CachedTag로 lookup하고 mandatory/selectOne 정책을 검증.
+ * 반환값은 tagIds (post create body용).
+ */
+export async function resolveTags(
+  client: DoorayApiClient,
+  projectId: string,
+  inputs: string[],
+): Promise<string[]> {
+  const allTags = await ensureTags(client, projectId);
+
+  // 1. 각 input → CachedTag (matchByName 사용, 모호시 에러)
+  const selected: CachedTag[] = inputs.map((input) =>
+    matchByName(
+      allTags,
+      input,
+      "태그",
+      (t) => (t.groupName ? `${t.groupName} / ${t.name} (${t.id})` : `${t.name} (${t.id})`),
+    ),
+  );
+
+  // 2. mandatory 그룹 충족 검증
+  const mandatoryGroups = new Map<string, string>(); // groupId -> groupName
+  for (const t of allTags) {
+    if (t.groupMandatory && t.groupId) mandatoryGroups.set(t.groupId, t.groupName ?? t.groupId);
+  }
+  const coveredGroups = new Set(selected.map((t) => t.groupId).filter((g): g is string => !!g));
+  const missing: string[] = [];
+  for (const [gid, gname] of mandatoryGroups) {
+    if (!coveredGroups.has(gid)) missing.push(gname);
+  }
+  if (missing.length > 0) {
+    throw new DoorayCliError(
+      `필수 태그 그룹이 누락되었습니다 (그룹당 1개 이상 필요):\n` +
+        missing.map((g) => `  - ${g}`).join("\n"),
+      EXIT_PARAM_ERROR,
+    );
+  }
+
+  // 3. selectOne 그룹에 2개 이상 선택 시 에러
+  const selectOneGroups = new Map<string, { name: string; tags: string[] }>();
+  for (const t of selected) {
+    if (!t.groupSelectOne || !t.groupId) continue;
+    const entry = selectOneGroups.get(t.groupId) ?? { name: t.groupName ?? t.groupId, tags: [] };
+    entry.tags.push(t.name);
+    selectOneGroups.set(t.groupId, entry);
+  }
+  const violators: string[] = [];
+  for (const [, info] of selectOneGroups) {
+    if (info.tags.length > 1) {
+      violators.push(`${info.name} (선택: ${info.tags.join(", ")})`);
+    }
+  }
+  if (violators.length > 0) {
+    throw new DoorayCliError(
+      `다음 태그 그룹은 1개만 선택 가능합니다:\n` +
+        violators.map((v) => `  - ${v}`).join("\n"),
+      EXIT_PARAM_ERROR,
+    );
+  }
+
+  return selected.map((t) => t.id);
+}

--- a/src/resolvers/workflow.ts
+++ b/src/resolvers/workflow.ts
@@ -2,6 +2,7 @@ import { DoorayApiClient } from "../api/client.js";
 import type { CachedWorkflow } from "../cache/types.js";
 import { getWorkflows, setWorkflows, isExpired } from "../cache/store.js";
 import { WORKFLOWS_TTL_MS } from "../cache/types.js";
+import { matchByName } from "./match.js";
 import { DoorayCliError } from "../utils/errors.js";
 import { EXIT_PARAM_ERROR } from "../utils/exit-codes.js";
 
@@ -31,11 +32,16 @@ export async function resolveWorkflow(
 ): Promise<string> {
   const workflows = await ensureWorkflows(client, projectId);
 
-  const match = workflows.find((w) => w.name === input || w.class === input);
-  if (match) return match.id;
+  // class 정확일치 우선 (registered/working/closed/backlog)
+  const byClass = workflows.filter((w) => w.class === input);
+  if (byClass.length === 1) return byClass[0].id;
+  if (byClass.length > 1) {
+    throw new DoorayCliError(
+      `동일 class의 워크플로우가 여러 개입니다: "${input}"`,
+      EXIT_PARAM_ERROR,
+    );
+  }
 
-  throw new DoorayCliError(
-    `워크플로우를 찾을 수 없습니다: ${input}`,
-    EXIT_PARAM_ERROR,
-  );
+  const match = matchByName(workflows, input, "워크플로우", (w) => `${w.name} [${w.class}] (${w.id})`);
+  return match.id;
 }

--- a/tasks/010-feat-post-create-meta-options/index.json
+++ b/tasks/010-feat-post-create-meta-options/index.json
@@ -2,8 +2,8 @@
   "name": "010-feat-post-create-meta-options",
   "description": "Issue #18 — post create에 --tag/--parent/--workflow/--milestone 옵션 추가. mandatory-tag 정책 프로젝트(예: tc-ocr)에서 CLI 사용 가능하게 함. 매칭 정책(정확→부분→모호 에러) 전체 resolver에 통일. ADR-019.",
   "created_at": "2026-04-27T00:00:00Z",
-  "status": "pending",
-  "current_phase": 1,
+  "status": "completed",
+  "current_phase": 5,
   "total_phases": 5,
   "error_message": null,
   "blocked_reason": null,
@@ -12,37 +12,37 @@
       "number": 1,
       "title": "API 클라이언트 + types + 캐시 기반",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 2,
       "title": "resolver 신설 + 기존 매칭 정책 통일",
       "file": "phase-02.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 3,
       "title": "post create 명령에 4개 옵션 통합",
       "file": "phase-03.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 4,
       "title": "doctor/cache 명령 갱신 + 정합성 점검",
       "file": "phase-04.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 5,
       "title": "빌드 검증 + 실호출 시나리오",
       "file": "phase-05.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],
-  "updated_at": "2026-04-27T00:00:00Z"
+  "updated_at": "2026-04-27T10:00:00Z"
 }

--- a/tasks/010-feat-post-create-meta-options/phase-01.md
+++ b/tasks/010-feat-post-create-meta-options/phase-01.md
@@ -7,7 +7,7 @@ Issue #18 — `post create`가 mandatory-tag 정책 프로젝트에서 동작하
 ### 먼저 읽을 파일
 
 - `docs/adr.md` ADR-019 — 본 task의 결정 근거 (필드명·캐시·mandatory 검증 정책)
-- `src/api/client.ts` (페이지네이션 패턴: `getProjectMembers`, `getProjectWorkflows`)
+- `src/api/client.ts` (페이지네이션 패턴: `getProjectMembers` 단독 — `getProjectWorkflows`는 page/size 미수신이라 참고 대상 아님)
 - `src/api/types.ts` (기존 `Tag`, `Milestone` 정의 여부 확인 — 응답 형태 일부 이미 있음)
 - `src/cache/types.ts` + `src/cache/store.ts` (멤버·워크플로우 패턴)
 
@@ -25,7 +25,11 @@ Issue #18 — `post create`가 mandatory-tag 정책 프로젝트에서 동작하
 ```
 - 페이지네이션: `page` (기본 0), `size` (기본 20, 최대 100)
 
-`GET /project/v1/projects/{project-id}/milestones` — 동일한 페이지네이션. 응답 스키마는 구현 시 실호출 또는 기존 `Milestone` 타입(types.ts) 재확인.
+`GET /project/v1/projects/{project-id}/milestones` — 동일한 페이지네이션. 응답 wrapper는 tag와 동일한 형태로 가정:
+```json
+{ "header": {...}, "result": [{ "id": "...", "name": "..." }], "totalCount": N }
+```
+구현 시 실호출(`hurl`/`curl`)로 wrapper 형태(`result` + `totalCount`)를 반드시 1회 검증한 뒤 `MilestoneListResponse` 타입을 확정. 다르면 phase-02 진행 전에 phase-01 작업 1)/4) 수정.
 
 POST `/project/v1/projects/{project-id}/posts` body 필드명: `tagIds`, `parentPostId`, `milestoneId` (단수). **이슈 본문 curl의 `tagIdList`는 사용자 오타** — 코드의 `tagIds` 그대로 사용.
 
@@ -43,12 +47,14 @@ export interface TagGroup {
   selectOne: boolean;
 }
 
-// 기존 Tag 인터페이스에 tagGroup 필드 추가 (이미 있으면 검증만)
+// 기존 Tag 인터페이스 확장 — 신규 필드는 모두 optional.
+// 사유: 기존 `PostDetailItem.tags: Tag[]` 응답에는 id 외 필드가 없을 수 있어
+// 필수로 두면 런타임 undefined 위험. resolver(tag.ts)에서 CachedTag 정규화 시 좁힘.
 export interface Tag {
   id: string;
-  name: string;
-  color: string;
-  tagGroup: TagGroup | null;
+  name?: string;
+  color?: string;
+  tagGroup?: TagGroup | null;
 }
 
 // Milestone은 최소 필드만 (id, name) — 추가 필드는 추후 확장
@@ -74,39 +80,49 @@ export interface MilestoneListResponse {
 
 ### 2) `src/api/client.ts` — 신규 메서드 2개
 
-`getProjectWorkflows`/`getProjectMembers` 패턴 그대로:
+**필수 패턴**: `client.ts`의 실제 컨벤션은 try/catch + `this.api` + `toDoorayCliError`. `handle()` 헬퍼는 존재하지 않음. `getProjectMembers` (대략 client.ts:307~321)를 그대로 복제:
 
 ```ts
 async getProjectTags(
   projectId: string,
   params?: { page?: number; size?: number },
 ): Promise<TagListResponse> {
-  const searchParams: Record<string, string> = {};
-  if (params?.page !== undefined) searchParams.page = String(params.page);
-  if (params?.size !== undefined) searchParams.size = String(params.size);
-  return this.handle(() =>
-    this.client
-      .get(`project/v1/projects/${projectId}/tags`, { searchParams })
-      .json<TagListResponse>(),
-  );
+  try {
+    return await this.api
+      .get(`project/v1/projects/${projectId}/tags`, {
+        searchParams: {
+          ...(params?.page != null && { page: params.page }),
+          ...(params?.size != null && { size: params.size }),
+        },
+      })
+      .json<TagListResponse>();
+  } catch (e) {
+    return toDoorayCliError(e);
+  }
 }
 
 async getProjectMilestones(
   projectId: string,
   params?: { page?: number; size?: number },
 ): Promise<MilestoneListResponse> {
-  const searchParams: Record<string, string> = {};
-  if (params?.page !== undefined) searchParams.page = String(params.page);
-  if (params?.size !== undefined) searchParams.size = String(params.size);
-  return this.handle(() =>
-    this.client
-      .get(`project/v1/projects/${projectId}/milestones`, { searchParams })
-      .json<MilestoneListResponse>(),
-  );
+  try {
+    return await this.api
+      .get(`project/v1/projects/${projectId}/milestones`, {
+        searchParams: {
+          ...(params?.page != null && { page: params.page }),
+          ...(params?.size != null && { size: params.size }),
+        },
+      })
+      .json<MilestoneListResponse>();
+  } catch (e) {
+    return toDoorayCliError(e);
+  }
 }
 ```
 
-기존 메서드의 `handle` / `searchParams` 헬퍼 사용 패턴을 정확히 따를 것.
+- `this.api` (필드명) 사용 — `this.client` 아님
+- `toDoorayCliError(e)`는 같은 파일 상단에 이미 존재. import 추가 불필요
+- `searchParams`는 spread + `!= null` 가드로 0 값도 보존
 
 ### 3) `src/cache/types.ts` — 캐시 타입 추가
 
@@ -174,9 +190,9 @@ export async function setMilestones(projectId: string, items: CachedMilestone[])
 - **`post create` 수정은 phase 3에서** — 이 phase에서 명령 수정 금지
 - **`getCacheStats` 갱신은 phase 4에서** — 본 phase에서 건드리지 않음
 - 기존 `Tag`/`Milestone` 타입이 이미 있으면 **확장만**. 중복 정의시 빌드 에러 가능
-- `handle()` 헬퍼 시그니처는 `client.ts` 다른 메서드와 정확히 동일하게
+- `client.ts`의 실제 패턴은 try/catch + `this.api` + `toDoorayCliError` (handle 헬퍼 없음). `getProjectMembers`를 그대로 복제할 것
 
 ## Blocked 조건
 
 - `src/api/types.ts`에 이미 `Tag`/`Milestone`/`TagGroup` 정의가 본 phase 요구와 호환 불가하게 충돌 → `PHASE_BLOCKED: 기존 타입 정의 충돌`
-- `client.ts`의 `handle`/`searchParams` 헬퍼 패턴이 변경됨 → `PHASE_BLOCKED: 클라이언트 패턴 변경`
+- `client.ts`의 try/catch + `toDoorayCliError` 패턴이 변경됨 → `PHASE_BLOCKED: 클라이언트 패턴 변경`

--- a/tasks/010-feat-post-create-meta-options/phase-02.md
+++ b/tasks/010-feat-post-create-meta-options/phase-02.md
@@ -279,7 +279,7 @@ export async function resolveWorkflow(
 }
 ```
 
-**member.ts**: 정확일치 우선 분기 추가. 단 멤버는 `name + id`를 후보 표시에 사용 — `matchByName` 호출. 단 멤버는 이메일 매칭도 있을 수 있으니 기존 `byName` 변수 흐름 보존하며 `matchByName`으로 교체.
+**member.ts**: 현재 `resolveMember` 본문(member.ts:69~)은 단순 `name.includes(input)` 한 줄 + 모호 시 후보 목록 출력. 이메일 분기는 **존재하지 않음** — 그대로 `matchByName` 호출로 1:1 교체. `getMemberDetail` 실패로 `name: ""`인 항목은 빈 문자열이 어떤 입력에도 매칭 안 되므로 자동 제외 (별도 처리 불필요).
 
 ```ts
 // resolveMember 본문에서:
@@ -294,7 +294,13 @@ const match = matchByName(
 return match.organizationMemberId;
 ```
 
-기존 멤버 매칭이 이메일/email-like 입력을 어떻게 처리하는지 확인 후, 그 분기는 보존해야 함. 만약 `member.ts`에 이메일 분기가 있다면 `matchByName` 호출 전에 처리.
+**회귀 영향 호출 경로** (변경 후 동작 동일성 확인 대상):
+- `--to`, `--cc` (post create / mail send)
+- `post done`, `post workflow` (assignee resolve)
+
+정확일치 → 부분일치 → 모호 시 에러 우선순위 유지가 회귀 검증 핵심.
+
+**resolveWorkflow 의도 명시**: 기존 동작은 `w.name === input || w.class === input` (정확일치 OR class 일치)였음. 통일 후 우선순위는 (1) name 정확일치 → (2) class 정확일치 → (3) name 부분일치 → (4) 모호 시 에러. class는 `matchByName` 외부에서 별도 분기로 처리하여 의미 동등성 유지.
 
 ## 성공 기준
 
@@ -308,7 +314,7 @@ return match.organizationMemberId;
 
 - **`post create` 명령 수정은 phase 3에서** — resolver만 작성
 - **`matchByName` 헬퍼는 부분일치 = `includes()`**, 정규식 X
-- 멤버 resolver의 기존 이메일/특수 분기가 있다면 보존
+- 멤버 resolver는 단순 `name.includes` 단일 분기 — `matchByName` 1:1 교체
 - workflow의 `class` 매칭 우선순위는 변경 금지 (기존 동작 호환)
 - Tag mandatory 검증 메시지는 사용자 친화적으로 — 어느 그룹이 누락인지 그룹명 노출
 - `DoorayCliError(message, EXIT_PARAM_ERROR)` 일관 사용

--- a/tasks/010-feat-post-create-meta-options/phase-03.md
+++ b/tasks/010-feat-post-create-meta-options/phase-03.md
@@ -25,6 +25,8 @@ Phase 1 (api/cache) + Phase 2 (resolver) 위에 사용자 인터페이스를 통
 
 `--tag`는 **반복 입력**(`--tag X --tag Y`) 형태로 받음 — commander의 `(value, prev) => [...prev, value]` 패턴. 이슈 본문이 그렇게 명시.
 
+**참고 — 이슈 #18 본문의 `tagIdList` 오타**: API 실제 필드명은 `tagIds`. 본 task는 신규 옵션 추가이므로 `tagIdList`와의 호환성은 비대상이며, 코드는 `tagIds`를 사용한다.
+
 ### action 핸들러 변경
 
 기존 흐름 (`subject` 검증 → `bodyContent` → spinner 시작 → projectId resolve → toUsers/ccUsers → createPost) 사이에 다음 추가:
@@ -32,9 +34,12 @@ Phase 1 (api/cache) + Phase 2 (resolver) 위에 사용자 인터페이스를 통
 1. **resolve 단계 (createPost 호출 전)** — 병렬 처리:
 
 ```ts
+// commander variadic이 누적한 빈 문자열 제거 (입력 사고 방지)
+const tagInputs = (opts.tag ?? []).filter((s: string) => s.length > 0);
+
 const [tagIds, parentPostId, milestoneId] = await Promise.all([
-  opts.tag && opts.tag.length > 0
-    ? resolveTags(client, projectId, opts.tag)
+  tagInputs.length > 0
+    ? resolveTags(client, projectId, tagInputs)
     : Promise.resolve<string[] | undefined>(undefined),
   opts.parent
     ? resolvePostRef(client, opts.parent)

--- a/tasks/010-feat-post-create-meta-options/phase-04.md
+++ b/tasks/010-feat-post-create-meta-options/phase-04.md
@@ -2,16 +2,17 @@
 
 ## 컨텍스트
 
-신규 캐시(`tags/`, `milestones/`)를 doctor·cache 통계에 반영. 본 phase는 사용자가 `dooray doctor`/`dooray cache stats`로 새 캐시 상태를 볼 수 있게 함.
+신규 캐시(`tags/`, `milestones/`)를 doctor 통계에 반영. 본 phase는 사용자가 `dooray doctor`로 새 캐시 상태를 볼 수 있게 함.
+
+`src/commands/cache.ts`는 현재 `clear`/`refresh` 서브커맨드만 존재 (`stats` 서브커맨드 없음). `cache clear`는 디렉토리 통째 삭제이므로 신규 캐시도 자동 적용 — cache.ts는 본 phase에서 변경하지 않는다.
 
 ### 먼저 읽을 파일
 
 - `src/cache/store.ts` `getCacheStats` — 통계 함수
-- `src/commands/doctor.ts` — stats 출력 위치
-- `src/commands/cache.ts` — `cache stats`/`cache clear` 출력
-- 위 3개 파일에서 `memberProjectCount`, `workflowProjectCount` 패턴 파악
+- `src/commands/doctor.ts` — `getCacheStats` 호출자 (단 1곳)
+- 위 2개 파일에서 `memberProjectCount`, `workflowProjectCount` 패턴 파악
 
-## 작업 목록 (3개)
+## 작업 목록 (2개)
 
 ### 1) `src/cache/store.ts` — `getCacheStats` 확장
 
@@ -47,23 +48,20 @@ export async function getCacheStats(): Promise<{
 
 기존 라벨 한글/영문 톤 그대로 따를 것.
 
-### 3) `src/commands/cache.ts` — `cache stats` 출력 추가
-
-`stats` 서브커맨드에서 동일하게 2줄 추가. `cache clear`는 `~/.dooray/cache/` 통째 삭제이므로 자동 적용 — 변경 불필요.
-
 ## 성공 기준
 
 - [ ] `pnpm build` 성공
 - [ ] `grep -c "tagProjectCount\|milestoneProjectCount" src/cache/store.ts` → 2 이상
-- [ ] `grep -c "tagProjectCount\|milestoneProjectCount\|Tag 캐시\|Milestone 캐시" src/commands/doctor.ts src/commands/cache.ts` → 4 이상
-- [ ] `node dist/index.js cache stats` 실행 시 새 항목 2줄 노출 (수동 확인 가능 — phase 5 시나리오에 포함)
-- [ ] `getCacheStats` 호출자가 doctor/cache 외에 또 있으면 빌드 에러 — 없는 게 정상
+- [ ] `grep -c "tagProjectCount\|milestoneProjectCount\|Tag 캐시\|Milestone 캐시" src/commands/doctor.ts` → 2 이상
+- [ ] `node dist/index.js doctor` 실행 시 Tag/Milestone 캐시 라인 2줄 노출 (phase 5 시나리오 포함)
+- [ ] `getCacheStats` 호출자가 doctor.ts 외에 또 있으면 빌드 에러 — 없는 게 정상
+- [ ] `git diff --stat` — `src/cache/store.ts`, `src/commands/doctor.ts` 만 변경 (`src/commands/cache.ts` 미변경)
 
 ## 주의사항
 
 - **TAGS_DIR/MILESTONES_DIR 상수는 phase 1에서 추가**되어 있어야 함. 없으면 phase 1 누락
 - **기존 라벨 톤(한글)** 그대로 — "프로젝트 수" 같은 표현 일관
-- **`cache clear` 변경 금지** — 디렉토리 통째 삭제로 자동 작동
+- **`src/commands/cache.ts` 변경 금지** — `cache stats` 서브커맨드는 존재하지 않으며 `cache clear`는 디렉토리 통째 삭제로 자동 작동
 
 ## Blocked 조건
 

--- a/tasks/010-feat-post-create-meta-options/phase-05.md
+++ b/tasks/010-feat-post-create-meta-options/phase-05.md
@@ -9,16 +9,15 @@
 - `tasks/010-feat-post-create-meta-options/index.json` — phase 1-4 완료 상태 확인
 - 이슈 본문 차단 케이스: `tc-ocr` 프로젝트, 0/1/2 그룹 mandatory-tag 정책
 
-## 작업 목록 (4개)
+## 작업 목록 (5개 — 마지막 task 완료 처리 포함)
 
 ### 1) 빌드 + lint
 
 ```bash
-# cwd: /Users/nhn/personal/dooray-cli
 pnpm build
 ```
 
-성공 확인. 실패 시 phase 1-4 산출물 점검.
+성공 확인. 실패 시 phase 1-4 산출물 점검. (cwd는 worktree 루트)
 
 ### 2) `--help` 출력 검증
 
@@ -32,13 +31,13 @@ node dist/index.js post create --help
 - `--workflow <name>`
 - `--milestone <name>`
 
-### 3) 캐시 통계 검증
+### 3) doctor 출력 검증
 
 ```bash
-node dist/index.js cache stats
+node dist/index.js doctor
 ```
 
-새 항목 2줄(`Tag 캐시`, `Milestone 캐시`) 출력 확인.
+`Tag 캐시`, `Milestone 캐시` 라인 2줄이 신규로 노출되는지 확인 (phase 4 산출물).
 
 ### 4) 실호출 시나리오 (사용자 환경 의존, 가능 범위에서)
 
@@ -87,13 +86,24 @@ node dist/index.js post create tc-ocr \
 ```
 다중 매칭이면 후보 목록 + exit non-zero.
 
-> 사용자 환경(API 키, 프로젝트 접근권한)에 따라 시나리오 A-D 일부 또는 전부 실행 불가능할 수 있음. **빌드/help/stats(작업 1-3) 통과를 필수**, 실호출(작업 4)은 best-effort.
+> 사용자 환경(API 키, 프로젝트 접근권한)에 따라 시나리오 A-D 일부 또는 전부 실행 불가능할 수 있음. **빌드/help/doctor(작업 1-3) 통과를 필수**, 실호출(작업 4)은 best-effort.
+
+### 5) Task 완료 처리 (index.json 업데이트)
+
+`tasks/010-feat-post-create-meta-options/index.json`을 다음과 같이 업데이트:
+- 최상위 `status` → `"completed"`
+- `current_phase` → `5`
+- 모든 `phases[*].status` → `"completed"`
+- `updated_at` → 현재 ISO 8601 타임스탬프
+
+이 업데이트는 PR 브랜치 마지막 커밋에 포함되어야 한다 (team-lead가 합본 커밋). 별도 phase로 분리하지 않고 본 phase 마지막 작업으로 수행.
 
 ## 성공 기준
 
 - [ ] `pnpm build` 성공 (warning 없음)
 - [ ] `node dist/index.js post create --help` 4개 옵션 노출
-- [ ] `node dist/index.js cache stats` 새 2줄 출력
+- [ ] `node dist/index.js doctor` 출력에 Tag/Milestone 캐시 라인 2줄
+- [ ] `index.json` `status: "completed"`, 모든 phase `status: "completed"`
 - [ ] (선택) 시나리오 A 정상 케이스 실행 → post 생성 성공
 - [ ] (선택) 시나리오 A 누락 케이스 → mandatory 에러 메시지 출력
 - [ ] (선택) 시나리오 B → `code/number` 분기 정상
@@ -109,4 +119,4 @@ node dist/index.js post create tc-ocr \
 
 - `pnpm build` 실패 → `PHASE_BLOCKED: 빌드 실패 (앞 phase 산출물 결함)`
 - `--help`에 옵션 미노출 → `PHASE_BLOCKED: phase 3 미완료`
-- `cache stats`에 신규 항목 미노출 → `PHASE_BLOCKED: phase 4 미완료`
+- `doctor`에 신규 캐시 항목 미노출 → `PHASE_BLOCKED: phase 4 미완료`


### PR DESCRIPTION
## Summary

- Issue #18 해결: mandatory-tag 정책 프로젝트(예: `tc-ocr`)에서 `dooray post create`가 차단되던 문제 해소.
- `--tag`(반복) / `--parent` (`code/number` 또는 raw postId) / `--workflow` (이름 또는 class) / `--milestone` (이름) 4개 메타 옵션 추가.
- resolver 매칭 정책을 공용 `matchByName`(정확→부분→모호 시 후보+에러)으로 통일 (member, workflow, tag, milestone 모두 동일).
- `~/.dooray/cache/tags/` + `milestones/` 슬롯 신설 (TTL 24h), `dooray doctor`에 캐시 통계 노출.

## ADR

- `docs/adr.md` ADR-019 — 이름 lookup 정책 / mandatory·selectOne 사전 검증 / workflow 후속 호출 + exit 0 / `--parent` slash 분기

## Test plan

- [x] `pnpm run build` 성공
- [x] `node dist/index.js post create --help` — 4개 옵션 노출
- [x] `node dist/index.js doctor` — Tag/Milestone 캐시 라인 노출
- [ ] 시나리오 A: mandatory-tag 프로젝트(`tc-ocr`)에서 `--tag` 누락 시 친절한 에러
- [ ] 시나리오 A: `--tag "0:..." --tag "1:..." --tag "2:..."`로 정상 생성
- [ ] 시나리오 B: `--parent tc-ocr/337` 정상 분기
- [ ] 시나리오 C: `--workflow "등록"` 부분일치 + 후속 설정 (실패 시 stderr warn + exit 0)
- [ ] 시나리오 D: 모호 매칭 → 후보 목록 + exit non-zero

## Notes

- 코드 검토: `code-reviewer`가 3 MEDIUM 지적(satisfies 누락 / 매직넘버 / class 다중일치 silent fallthrough) → 모두 fix 적용
- docs 정합성: `docs-verifier`(architect)가 `docs/code-architecture.md`, `README.md`, `skills/dooray-cli/SKILL.md` 갱신 후 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)