### PR TITLE
feat(commands): unify post 12-command input (--id/--url/positional URL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ dooray post get tc-ocr 42                  # 업무 상세
 dooray post get tc-ocr 42 --json           # JSON 출력
 ```
 
+#### 업무 식별 방식 (post 하위 12개 명령 공통)
+
+| 방식 | 예시 |
+|---|---|
+| `<project> <number>` | `dooray post get tc-ocr 42` |
+| Dooray URL positional | `dooray post get https://x.dooray.com/task/to/4319587406666362045` |
+| `--id <postId>` | `dooray post get --id 4319587406666362045` |
+| `--url <url>` | `dooray post get --url https://x.dooray.com/task/to/...` |
+
+대상: `post get`/`edit`/`done`/`workflow`, `post comment list`/`add`/`edit`/`delete`, `post file list`/`upload`/`download`/`download-all`/`delete`. AI 에이전트는 사용자 메시지의 Dooray URL을 그대로 첫 인자로 전달하면 가장 빠르다 (ADR-020).
+
 ### 업무 생성
 
 ```bash
@@ -159,6 +170,15 @@ dooray post file upload <project> <number> ./report.pdf
 
 # 파일 삭제
 dooray post file delete <project> <number> <file-id>
+```
+
+URL/`--id`/`--url` 모드에서는 sub-id를 옵션으로 전달:
+```bash
+dooray post file download --url <url> --file-id <fileId> -o ./downloads
+dooray post file delete   --url <url> --file-id <fileId>
+dooray post file upload   --url <url> --file ./report.pdf
+dooray post comment edit  --url <url> --comment-id <commentId> --body "..."
+dooray post comment delete --url <url> --comment-id <commentId>
 ```
 
 ## 출력 모드

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -35,10 +35,11 @@ src/
     workflow.ts             # name·class → workflowId
     post.ts                 # postNumber → postId (API 호출)
     wiki.ts                 # projectCode → wikiId / wikiId → homePageId (캐시)
-    postRef.ts              # "code/number" 또는 raw postId → postId
+    postRef.ts              # "code/number" 또는 raw postId → postId (post create --parent 전용)
     tag.ts                  # name[] → tagIds + mandatory/selectOne 검증
     milestone.ts            # name → milestoneId
     match.ts                # 공용: 정확일치 → 부분일치 → 모호 시 에러
+    post-input.ts           # --id / --url / positional / Dooray URL → {projectId, postId, ...} 단일 헬퍼 (ADR-020)
 
   cache/
     store.ts                # ~/.dooray/cache/ 디렉토리 기반 CRUD + TTL 체크
@@ -61,6 +62,7 @@ src/
     spinner.ts              # ora 래퍼
     exit-codes.ts           # 0 성공 / 1 API오류 / 2 인증실패 / 3 파라미터오류 / 4 설정오류
     body-input.ts           # --body / --body-file → string (stdin "-" + 충돌 가드)
+    dooray-url.ts           # https://*.dooray.com/task/to/<postId> URL parser (ADR-020)
 
   commands/
     setup.ts                # dooray setup — 대화형 초기 설정 마법사 (스킬 설치 포함)
@@ -133,6 +135,7 @@ class DoorayApiClient {
   getProjects(params?): Promise<ProjectListResponse>;
   getPosts(projectId, params?): Promise<PostListResponse>;
   getPost(projectId, postId): Promise<PostDetailResponse>;
+  getPostStandalone(postId): Promise<PostDetailResponse>;  // GET /project/v1/posts/{postId} — projectId 불명일 때 (ADR-020)
   createPost(projectId, body): Promise<CreatePostResponse>;
   updatePost(projectId, postId, body): Promise<void>;
   // ... (dooray-mcp-server DoorayClient 인터페이스와 1:1 대응)
@@ -145,8 +148,10 @@ class DoorayApiClient {
 1. index.ts — Commander가 커맨드 파싱
 2. commands/post/done.ts — 실행 진입
 3. config/store.ts — apiKey, baseUrl 로드 (없으면 exitCode 4)
-4. resolvers/project.ts — "my-project" → projectId
-5. resolvers/post.ts — 42 → postId (API 호출)
+4. resolvers/post-input.ts — 입력 분기:
+     • <project> <number>  → resolveProject + resolvePost (4·5단계 정상 실행)
+     • --id / --url / URL positional → getPostStandalone(postId) 단일 호출로 4·5단계 단축
+5. (positional 모드에서만) resolvers/post.ts — 42 → postId
 6. api/client.ts — POST /project/v1/projects/{id}/posts/{id}/set-done
 7. formatters/post.ts — 성공 메시지 출력
 ```
@@ -164,6 +169,13 @@ class DoorayApiClient {
 - `--quiet`: ID만 출력 (스크립팅용)
 - `--no-color`: 컬러 제거 (CI 환경, `NO_COLOR` env 자동 감지)
 - 스피너·에러: stderr / 데이터: stdout (파이프 시 stderr 오염 방지)
+
+## 테스트
+
+- vitest (코로케이션 `*.test.ts` 패턴 — 소스 옆에 테스트 배치)
+- `pnpm test` (단발) / `pnpm test:watch` (개발 중)
+- 현재 커버: `src/utils/dooray-url.ts` (URL parser), `src/resolvers/post-input.ts` (7-branch 분기, ADR-020)
+- 신규 도메인 헬퍼·복잡 분기는 vitest 단위 테스트 동반 권장 (ADR-020 도입 근거)
 
 ## 빌드·배포
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
   },
   "scripts": {
     "build": "tsup",
-    "dev": "tsup --watch"
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "license": "MIT",
   "dependencies": {
@@ -53,6 +55,7 @@
     "@types/nodemailer": "^7.0.11",
     "@types/tmp": "^0.2.6",
     "tsup": "^8.5.1",
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,16 +59,28 @@ importers:
         version: 0.2.6
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(typescript@6.0.2)
+        version: 8.5.1(postcss@8.5.12)(typescript@6.0.2)
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.5.0)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.7))
 
 packages:
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -373,8 +385,115 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
@@ -517,6 +636,18 @@ packages:
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -534,6 +665,35 @@ packages:
 
   '@types/tmp@0.2.6':
     resolution: {integrity: sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==}
+
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
   '@zone-eu/mailsplit@5.4.8':
     resolution: {integrity: sha512-eEyACj4JZ7sjzRvy26QhLgKEMWwQbsw1+QZnlLX+/gihcNH07lVPOcnwf5U6UAL7gkc//J3jVd76o/WS+taUiA==}
@@ -557,6 +717,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
@@ -570,6 +734,10 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
@@ -613,6 +781,9 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -625,6 +796,10 @@ packages:
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -650,10 +825,20 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
@@ -747,6 +932,80 @@ packages:
   libqp@2.1.1:
     resolution: {integrity: sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
@@ -788,6 +1047,11 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   nodemailer@8.0.4:
     resolution: {integrity: sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ==}
     engines: {node: '>=6.0.0'}
@@ -795,6 +1059,9 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
@@ -859,6 +1126,10 @@ packages:
       yaml:
         optional: true
 
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
+    engines: {node: ^10 || ^12 || >=14}
+
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
@@ -885,6 +1156,11 @@ packages:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup@4.60.1:
     resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -899,6 +1175,9 @@ packages:
 
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -915,6 +1194,10 @@ packages:
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
@@ -922,6 +1205,12 @@ packages:
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stdin-discarder@0.3.1:
     resolution: {integrity: sha512-reExS1kSGoElkextOcPkel4NE99S0BWxjUHQeDFnR8S993JxpPX7KU4MNmO19NXhlJp+8dmdCbKQVNgLJh2teA==}
@@ -959,12 +1248,27 @@ packages:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
     engines: {node: '>=20'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tlds@1.261.0:
     resolution: {integrity: sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==}
@@ -980,6 +1284,9 @@ packages:
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsup@8.5.1:
     resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
@@ -1014,6 +1321,95 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
@@ -1021,6 +1417,22 @@ packages:
 snapshots:
 
   '@colors/colors@1.5.0':
+    optional: true
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
     optional: true
 
   '@esbuild/aix-ppc64@0.27.7':
@@ -1234,7 +1646,67 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@oxc-project/types@0.127.0': {}
+
   '@pinojs/redact@0.4.0': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     optional: true
@@ -1316,6 +1788,20 @@ snapshots:
       domhandler: 5.0.3
       selderee: 0.11.0
 
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/js-yaml@4.0.9': {}
@@ -1335,6 +1821,47 @@ snapshots:
 
   '@types/tmp@0.2.6': {}
 
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.7))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.10(@types/node@25.5.0)(esbuild@0.27.7)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@zone-eu/mailsplit@5.4.8':
     dependencies:
       libbase64: 1.3.0
@@ -1351,6 +1878,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  assertion-error@2.0.1: {}
+
   atomic-sleep@1.0.0: {}
 
   bundle-require@5.1.0(esbuild@0.27.7):
@@ -1359,6 +1888,8 @@ snapshots:
       load-tsconfig: 0.2.5
 
   cac@6.7.14: {}
+
+  chai@6.2.2: {}
 
   chalk@5.6.2: {}
 
@@ -1390,11 +1921,15 @@ snapshots:
 
   consola@3.4.2: {}
 
+  convert-source-map@2.0.0: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
   deepmerge@4.3.1: {}
+
+  detect-libc@2.1.2: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -1419,6 +1954,8 @@ snapshots:
   encoding-japanese@2.2.0: {}
 
   entities@4.5.0: {}
+
+  es-module-lexer@2.1.0: {}
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -1448,6 +1985,12 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.7
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
 
   fast-string-truncated-width@3.0.3: {}
 
@@ -1540,6 +2083,55 @@ snapshots:
 
   libqp@2.1.1: {}
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
@@ -1591,9 +2183,13 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
+  nanoid@3.3.11: {}
+
   nodemailer@8.0.4: {}
 
   object-assign@4.1.1: {}
+
+  obug@2.1.1: {}
 
   on-exit-leak-free@2.1.2: {}
 
@@ -1653,9 +2249,17 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1:
+  postcss-load-config@6.0.1(postcss@8.5.12):
     dependencies:
       lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.12
+
+  postcss@8.5.12:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   process-warning@5.0.0: {}
 
@@ -1673,6 +2277,27 @@ snapshots:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
+
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
   rollup@4.60.1:
     dependencies:
@@ -1713,6 +2338,8 @@ snapshots:
     dependencies:
       parseley: 0.12.1
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   smart-buffer@4.2.0: {}
@@ -1726,9 +2353,15 @@ snapshots:
     dependencies:
       atomic-sleep: 1.0.0
 
+  source-map-js@1.2.1: {}
+
   source-map@0.7.6: {}
 
   split2@4.2.0: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   stdin-discarder@0.3.1: {}
 
@@ -1773,12 +2406,23 @@ snapshots:
     dependencies:
       real-require: 0.2.0
 
+  tinybench@2.9.0: {}
+
   tinyexec@0.3.2: {}
+
+  tinyexec@1.1.1: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   tlds@1.261.0: {}
 
@@ -1788,7 +2432,10 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.1(typescript@6.0.2):
+  tslib@2.8.1:
+    optional: true
+
+  tsup@8.5.1(postcss@8.5.12)(typescript@6.0.2):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -1799,7 +2446,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1
+      postcss-load-config: 6.0.1(postcss@8.5.12)
       resolve-from: 5.0.0
       rollup: 4.60.1
       source-map: 0.7.6
@@ -1808,6 +2455,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
+      postcss: 8.5.12
       typescript: 6.0.2
     transitivePeerDependencies:
       - jiti
@@ -1822,5 +2470,49 @@ snapshots:
   ufo@1.6.3: {}
 
   undici-types@7.18.2: {}
+
+  vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.7):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.12
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.5.0
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+
+  vitest@4.1.5(@types/node@25.5.0)(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.7)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.7))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@25.5.0)(esbuild@0.27.7)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.5.0
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   yoctocolors@2.1.2: {}

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -45,6 +45,8 @@ dooray doctor                                 # 설정 검증
 
 자연어 요청을 커맨드로 변환할 때 아래 표를 참고한다.
 
+> **공통 (post 하위 12개 명령)**: `post get`/`edit`/`done`/`workflow`, `post comment list`/`add`/`edit`/`delete`, `post file list`/`upload`/`download`/`download-all`/`delete`는 `<project> <number>` 외에도 `--id <postId>`, `--url <url>`, 또는 첫 인자에 Dooray URL(`https://*.dooray.com/task/to/<postId>`)을 직접 받는다. **사용자가 URL을 줬으면 그대로 첫 인자로 전달**하는 것이 가장 빠른 경로 (resolve 단계 단축, ADR-020).
+
 | 의도 | 커맨드 |
 |------|--------|
 | 초기 설정 (대화형) | `dooray setup` |
@@ -160,6 +162,42 @@ dooray wiki page get tc-ocr 3052841366755571094 --json
 ---
 
 ## 커맨드 상세
+
+### 업무 식별 방식 (post 하위 12개 명령 공통, ADR-020)
+
+`post get`/`edit`/`done`/`workflow`, `post comment list`/`add`/`edit`/`delete`, `post file list`/`upload`/`download`/`download-all`/`delete`는 4가지 입력을 모두 받는다:
+
+```bash
+# (1) 기존 positional — 가장 익숙한 형태
+dooray post get tc-ocr 42
+
+# (2) Dooray URL을 첫 인자로 — 사용자 메시지에서 URL을 그대로 복사할 때 최적
+dooray post get https://x.dooray.com/task/to/4319587406666362045
+
+# (3) --id <postId>
+dooray post get --id 4319587406666362045
+
+# (4) --url <url>
+dooray post get --url https://x.dooray.com/task/to/4319587406666362045
+```
+
+**우선순위 / 충돌 규칙**: `--id`+`--url` 동시 지정 → 에러. `--id`/`--url`+positional 동시 지정 → 에러. URL/`--id`/`--url` 모드는 standalone API(`getPost(postId)`)로 resolve 단계를 단축.
+
+**sub-id 옵션화** (URL/`--id`/`--url` 모드에서 필수):
+```bash
+# comment edit/delete: --comment-id
+dooray post comment edit  --url <url> --comment-id <commentId> --body "..."
+dooray post comment delete --url <url> --comment-id <commentId>
+
+# file download/delete: --file-id
+dooray post file download --url <url> --file-id <fileId> -o ./downloads
+dooray post file delete   --url <url> --file-id <fileId>
+
+# file upload: --file (로컬 경로)
+dooray post file upload   --url <url> --file ./report.pdf
+```
+
+기존 positional 3-arg(`comment edit <project> <number> <comment-id>`, `file upload <project> <number> <path>`)는 그대로 유지.
 
 ### 업무 생성 (non-interactive)
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -202,6 +202,16 @@ export class DoorayApiClient {
     }
   }
 
+  async getPostStandalone(postId: string): Promise<PostDetailResponse> {
+    try {
+      return await this.api
+        .get(`project/v1/posts/${postId}`)
+        .json<PostDetailResponse>();
+    } catch (e) {
+      return toDoorayCliError(e);
+    }
+  }
+
   async createPost(projectId: string, body: CreatePostRequest): Promise<CreatePostApiResponse> {
     try {
       return await this.api

--- a/src/commands/post/comment/add.ts
+++ b/src/commands/post/comment/add.ts
@@ -1,8 +1,7 @@
 import { Command } from "commander";
 import { getConfigOrThrow } from "../../../config/store.js";
 import { DoorayApiClient } from "../../../api/client.js";
-import { resolveProject } from "../../../resolvers/project.js";
-import { resolvePost } from "../../../resolvers/post.js";
+import { resolvePostInput } from "../../../resolvers/post-input.js";
 import { openInEditor } from "../../../editor/index.js";
 import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
 import { readBodyInputOrNull } from "../../../utils/body-input.js";
@@ -11,8 +10,10 @@ import { printJson } from "../../../formatters/table.js";
 
 export const commentAddCommand = new Command("add")
   .description("댓글 추가")
-  .argument("<project>", "프로젝트 코드 또는 ID")
-  .argument("<post-number>", "업무 번호")
+  .argument("[project]", "프로젝트 코드 (또는 첫 인자에 Dooray URL)")
+  .argument("[post-number]", "업무 번호 (project와 함께 사용)")
+  .option("--id <postId>", "Dooray post ID (project/post-number 대신)")
+  .option("--url <url>", "Dooray 업무 URL (project/post-number 대신)")
   .option("--body <text>", "댓글 본문 (- 입력 시 stdin에서 읽기)")
   .option("--body-file <path>", "본문 파일 경로 (- 입력 시 stdin에서 읽기)")
   .action(async (project, postNumberStr, opts) => {
@@ -31,8 +32,12 @@ export const commentAddCommand = new Command("add")
     }
 
     startSpinner("댓글 추가 중...");
-    const projectId = await resolveProject(client, project);
-    const postId = await resolvePost(client, projectId, Number(postNumberStr));
+    const { projectId, postId } = await resolvePostInput(client, {
+      projectArg: project,
+      postNumberArg: postNumberStr,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+    });
     const res = await client.createPostComment(projectId, postId, {
       body: { mimeType: "text/x-markdown", content: bodyContent },
     });

--- a/src/commands/post/comment/delete.ts
+++ b/src/commands/post/comment/delete.ts
@@ -1,22 +1,76 @@
 import { Command } from "commander";
 import { getConfigOrThrow } from "../../../config/store.js";
 import { DoorayApiClient } from "../../../api/client.js";
-import { resolveProject } from "../../../resolvers/project.js";
-import { resolvePost } from "../../../resolvers/post.js";
+import { resolvePostInput } from "../../../resolvers/post-input.js";
 import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
+import { DoorayCliError } from "../../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
 
 export const commentDeleteCommand = new Command("delete")
   .description("댓글 삭제")
-  .argument("<project>", "프로젝트 코드 또는 ID")
-  .argument("<post-number>", "업무 번호")
-  .argument("<comment-id>", "댓글 ID")
-  .action(async (project, postNumberStr, commentId) => {
+  .argument("[arg1]", "프로젝트 코드 / Dooray URL / 댓글 ID (모드별)")
+  .argument("[arg2]", "업무 번호 또는 댓글 ID (모드별)")
+  .argument("[arg3]", "댓글 ID (positional 3개 모드)")
+  .option("--id <postId>", "Dooray post ID (project/post-number 대신)")
+  .option("--url <url>", "Dooray 업무 URL (project/post-number 대신)")
+  .option("--comment-id <commentId>", "댓글 ID (positional 대체)")
+  .action(async (arg1, arg2, arg3, opts) => {
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
+    let projectArg: string | undefined;
+    let postNumberArg: string | undefined;
+    let commentId: string | undefined = opts.commentId;
+
+    if (opts.id || opts.url) {
+      // 옵션 모드: arg1 = comment-id (있다면), arg2/arg3은 비어야 함
+      if (arg2 || arg3) {
+        throw new DoorayCliError(
+          "--id/--url 모드에서는 댓글 ID 외 추가 positional 인자를 받지 않습니다. --comment-id 옵션 사용을 권장합니다.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+      commentId = commentId ?? arg1;
+    } else if (arg3) {
+      // positional 3개 모드 (legacy): project + post-number + comment-id
+      projectArg = arg1;
+      postNumberArg = arg2;
+      commentId = commentId ?? arg3;
+    } else if (arg1 && !arg2) {
+      // positional 1개 — URL positional 모드
+      projectArg = arg1;
+      if (!commentId) {
+        throw new DoorayCliError(
+          "URL/--id 모드에서는 --comment-id 옵션이 필요합니다.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+    } else {
+      // positional 2개 — project + post-number, comment-id는 옵션 필수
+      projectArg = arg1;
+      postNumberArg = arg2;
+      if (!commentId) {
+        throw new DoorayCliError(
+          "<comment-id>가 필요합니다. positional 3번째 또는 --comment-id 옵션을 사용하세요.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+    }
+
+    if (!commentId) {
+      throw new DoorayCliError(
+        "<comment-id>가 필요합니다.",
+        EXIT_PARAM_ERROR,
+      );
+    }
+
     startSpinner("댓글 삭제 중...");
-    const projectId = await resolveProject(client, project);
-    const postId = await resolvePost(client, projectId, Number(postNumberStr));
+    const { projectId, postId } = await resolvePostInput(client, {
+      projectArg,
+      postNumberArg,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+    });
     await client.deletePostComment(projectId, postId, commentId);
     stopSpinner(true, "댓글 삭제 완료");
 

--- a/src/commands/post/comment/edit.ts
+++ b/src/commands/post/comment/edit.ts
@@ -1,26 +1,80 @@
 import { Command } from "commander";
 import { getConfigOrThrow } from "../../../config/store.js";
 import { DoorayApiClient } from "../../../api/client.js";
-import { resolveProject } from "../../../resolvers/project.js";
-import { resolvePost } from "../../../resolvers/post.js";
+import { resolvePostInput } from "../../../resolvers/post-input.js";
 import { openInEditor } from "../../../editor/index.js";
 import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
 import { readBodyInputOrNull } from "../../../utils/body-input.js";
+import { DoorayCliError } from "../../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
 
 export const commentEditCommand = new Command("edit")
   .description("댓글 수정 ($EDITOR 또는 --body 옵션)")
-  .argument("<project>", "프로젝트 코드 또는 ID")
-  .argument("<post-number>", "업무 번호")
-  .argument("<comment-id>", "댓글 ID")
+  .argument("[arg1]", "프로젝트 코드 / Dooray URL / 댓글 ID (모드별)")
+  .argument("[arg2]", "업무 번호 또는 댓글 ID (모드별)")
+  .argument("[arg3]", "댓글 ID (positional 3개 모드)")
+  .option("--id <postId>", "Dooray post ID (project/post-number 대신)")
+  .option("--url <url>", "Dooray 업무 URL (project/post-number 대신)")
+  .option("--comment-id <commentId>", "댓글 ID (positional 대체)")
   .option("--body <text>", "댓글 본문 변경 (- 입력 시 stdin, non-interactive)")
   .option("--body-file <path>", "본문 파일 경로 (- 입력 시 stdin, non-interactive)")
-  .action(async (project, postNumberStr, commentId, opts) => {
+  .action(async (arg1, arg2, arg3, opts) => {
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
+    let projectArg: string | undefined;
+    let postNumberArg: string | undefined;
+    let commentId: string | undefined = opts.commentId;
+
+    if (opts.id || opts.url) {
+      // 옵션 모드: arg1 = comment-id (있다면), arg2/arg3은 비어야 함
+      if (arg2 || arg3) {
+        throw new DoorayCliError(
+          "--id/--url 모드에서는 댓글 ID 외 추가 positional 인자를 받지 않습니다. --comment-id 옵션 사용을 권장합니다.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+      commentId = commentId ?? arg1;
+    } else if (arg3) {
+      // positional 3개 모드 (legacy): project + post-number + comment-id
+      projectArg = arg1;
+      postNumberArg = arg2;
+      commentId = commentId ?? arg3;
+    } else if (arg1 && !arg2) {
+      // positional 1개 — URL positional 모드
+      projectArg = arg1;
+      if (!commentId) {
+        throw new DoorayCliError(
+          "URL/--id 모드에서는 --comment-id 옵션이 필요합니다.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+    } else {
+      // positional 2개 — project + post-number, comment-id는 옵션 필수
+      projectArg = arg1;
+      postNumberArg = arg2;
+      if (!commentId) {
+        throw new DoorayCliError(
+          "<comment-id>가 필요합니다. positional 3번째 또는 --comment-id 옵션을 사용하세요.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+    }
+
+    if (!commentId) {
+      throw new DoorayCliError(
+        "<comment-id>가 필요합니다.",
+        EXIT_PARAM_ERROR,
+      );
+    }
+
     startSpinner("댓글 조회 중...");
-    const projectId = await resolveProject(client, project);
-    const postId = await resolvePost(client, projectId, Number(postNumberStr));
+    const { projectId, postId } = await resolvePostInput(client, {
+      projectArg,
+      postNumberArg,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+    });
     const comments = await client.getPostComments(projectId, postId);
     const comment = comments.result.find((c) => c.id === commentId);
     stopSpinner(true, "댓글 조회 완료");

--- a/src/commands/post/comment/list.ts
+++ b/src/commands/post/comment/list.ts
@@ -1,16 +1,17 @@
 import { Command } from "commander";
 import { getConfigOrThrow } from "../../../config/store.js";
 import { DoorayApiClient } from "../../../api/client.js";
-import { resolveProject } from "../../../resolvers/project.js";
-import { resolvePost } from "../../../resolvers/post.js";
+import { resolvePostInput } from "../../../resolvers/post-input.js";
 import { formatCommentList } from "../../../formatters/post.js";
 import type { OutputOptions } from "../../../formatters/table.js";
 import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
 
 export const commentListCommand = new Command("list")
   .description("댓글 목록 조회")
-  .argument("<project>", "프로젝트 코드 또는 ID")
-  .argument("<post-number>", "업무 번호")
+  .argument("[project]", "프로젝트 코드 (또는 첫 인자에 Dooray URL)")
+  .argument("[post-number]", "업무 번호 (project와 함께 사용)")
+  .option("--id <postId>", "Dooray post ID (project/post-number 대신)")
+  .option("--url <url>", "Dooray 업무 URL (project/post-number 대신)")
   .option("--page <number>", "페이지 번호", "0")
   .option("--size <number>", "페이지 크기", "20")
   .action(async (project, postNumberStr, opts) => {
@@ -19,8 +20,12 @@ export const commentListCommand = new Command("list")
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
     startSpinner("댓글 목록 조회 중...");
-    const projectId = await resolveProject(client, project);
-    const postId = await resolvePost(client, projectId, Number(postNumberStr));
+    const { projectId, postId } = await resolvePostInput(client, {
+      projectArg: project,
+      postNumberArg: postNumberStr,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+    });
     const res = await client.getPostComments(projectId, postId, {
       page: Number(opts.page),
       size: Number(opts.size),

--- a/src/commands/post/done.ts
+++ b/src/commands/post/done.ts
@@ -1,23 +1,28 @@
 import { Command } from "commander";
 import { getConfigOrThrow } from "../../config/store.js";
 import { DoorayApiClient } from "../../api/client.js";
-import { resolveProject } from "../../resolvers/project.js";
-import { resolvePost } from "../../resolvers/post.js";
+import { resolvePostInput } from "../../resolvers/post-input.js";
 import { startSpinner, stopSpinner } from "../../utils/spinner.js";
 
 export const postDoneCommand = new Command("done")
   .description("업무 완료 처리")
-  .argument("<project>", "프로젝트 코드 또는 ID")
-  .argument("<post-number>", "업무 번호")
-  .action(async (project, postNumberStr) => {
+  .argument("[project]", "프로젝트 코드 (또는 첫 인자에 Dooray URL)")
+  .argument("[post-number]", "업무 번호 (project와 함께 사용)")
+  .option("--id <postId>", "Dooray post ID (project/post-number 대신)")
+  .option("--url <url>", "Dooray 업무 URL (project/post-number 대신)")
+  .action(async (project, postNumberStr, opts) => {
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
     startSpinner("업무 완료 처리 중...");
-    const projectId = await resolveProject(client, project);
-    const postId = await resolvePost(client, projectId, Number(postNumberStr));
+    const { projectId, postId, postNumber } = await resolvePostInput(client, {
+      projectArg: project,
+      postNumberArg: postNumberStr,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+    });
     await client.setPostDone(projectId, postId);
     stopSpinner(true, "업무 완료 처리 완료");
 
-    process.stdout.write(`#${postNumberStr} 업무가 완료 처리되었습니다.\n`);
+    process.stdout.write(`#${postNumber} 업무가 완료 처리되었습니다.\n`);
   });

--- a/src/commands/post/edit.ts
+++ b/src/commands/post/edit.ts
@@ -1,8 +1,7 @@
 import { Command } from "commander";
 import { getConfigOrThrow } from "../../config/store.js";
 import { DoorayApiClient } from "../../api/client.js";
-import { resolveProject } from "../../resolvers/project.js";
-import { resolvePost } from "../../resolvers/post.js";
+import { resolvePostInput } from "../../resolvers/post-input.js";
 import { resolveMember, ensureMembers } from "../../resolvers/member.js";
 import {
   openInEditor,
@@ -28,8 +27,10 @@ async function resolveUsers(
 
 export const postEditCommand = new Command("edit")
   .description("업무 수정 ($EDITOR 또는 --title/--body 옵션)")
-  .argument("<project>", "프로젝트 코드 또는 ID")
-  .argument("<post-number>", "업무 번호")
+  .argument("[project]", "프로젝트 코드 (또는 첫 인자에 Dooray URL)")
+  .argument("[post-number]", "업무 번호 (project와 함께 사용)")
+  .option("--id <postId>", "Dooray post ID (project/post-number 대신)")
+  .option("--url <url>", "Dooray 업무 URL (project/post-number 대신)")
   .option("--title <title>", "제목 변경 (non-interactive)")
   .option("--subject <subject>", "--title의 deprecated alias")
   .option("--body <text>", "본문 변경 (- 입력 시 stdin, non-interactive)")
@@ -39,8 +40,12 @@ export const postEditCommand = new Command("edit")
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
     startSpinner("업무 조회 중...");
-    const projectId = await resolveProject(client, project);
-    const postId = await resolvePost(client, projectId, Number(postNumberStr));
+    const { projectId, postId, postNumber } = await resolvePostInput(client, {
+      projectArg: project,
+      postNumberArg: postNumberStr,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+    });
     const res = await client.getPost(projectId, postId);
     const post = res.result;
     const members = await ensureMembers(client, projectId);
@@ -112,5 +117,5 @@ export const postEditCommand = new Command("edit")
       stopSpinner(true, "업무 수정 완료");
     }
 
-    process.stdout.write(`#${postNumberStr} 업무가 수정되었습니다.\n`);
+    process.stdout.write(`#${postNumber} 업무가 수정되었습니다.\n`);
   });

--- a/src/commands/post/file/delete.ts
+++ b/src/commands/post/file/delete.ts
@@ -1,22 +1,69 @@
 import { Command } from "commander";
 import { getConfigOrThrow } from "../../../config/store.js";
 import { DoorayApiClient } from "../../../api/client.js";
-import { resolveProject } from "../../../resolvers/project.js";
-import { resolvePost } from "../../../resolvers/post.js";
+import { resolvePostInput } from "../../../resolvers/post-input.js";
 import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
+import { DoorayCliError } from "../../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
 
 export const fileDeleteCommand = new Command("delete")
   .description("첨부파일 삭제")
-  .argument("<project>", "프로젝트 코드 또는 ID")
-  .argument("<post-number>", "업무 번호")
-  .argument("<file-id>", "파일 ID")
-  .action(async (project, postNumberStr, fileId) => {
+  .argument("[arg1]", "프로젝트 코드, Dooray URL, 또는 (`--id`/`--url` 모드일 때) 파일 ID")
+  .argument("[arg2]", "업무 번호 또는 (`--id`/`--url` 모드일 때) 파일 ID")
+  .argument("[arg3]", "파일 ID (positional 3개 모드)")
+  .option("--id <postId>", "Dooray post ID (project/post-number 대신)")
+  .option("--url <url>", "Dooray 업무 URL (project/post-number 대신)")
+  .option("--file-id <fileId>", "파일 ID (positional 대체)")
+  .action(async (arg1, arg2, arg3, opts) => {
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
+    let projectArg: string | undefined;
+    let postNumberArg: string | undefined;
+    let fileId: string | undefined = opts.fileId;
+
+    if (opts.id || opts.url) {
+      if (arg2 || arg3) {
+        throw new DoorayCliError(
+          "--id/--url 모드에서는 파일 ID 외 추가 positional 인자를 받지 않습니다. --file-id 옵션 사용을 권장합니다.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+      fileId = fileId ?? arg1;
+    } else if (arg3) {
+      projectArg = arg1;
+      postNumberArg = arg2;
+      fileId = fileId ?? arg3;
+    } else if (arg1 && !arg2) {
+      projectArg = arg1;
+      if (!fileId) {
+        throw new DoorayCliError(
+          "URL/--id 모드에서는 --file-id 옵션이 필요합니다.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+    } else {
+      projectArg = arg1;
+      postNumberArg = arg2;
+      if (!fileId) {
+        throw new DoorayCliError(
+          "<file-id>가 필요합니다. positional 3번째 또는 --file-id 옵션을 사용하세요.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+    }
+
+    if (!fileId) {
+      throw new DoorayCliError("파일 ID가 필요합니다.", EXIT_PARAM_ERROR);
+    }
+
     startSpinner("파일 삭제 중...");
-    const projectId = await resolveProject(client, project);
-    const postId = await resolvePost(client, projectId, Number(postNumberStr));
+    const { projectId, postId } = await resolvePostInput(client, {
+      projectArg,
+      postNumberArg,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+    });
     await client.deletePostFile(projectId, postId, fileId);
     stopSpinner(true, "삭제 완료");
 

--- a/src/commands/post/file/download-all.ts
+++ b/src/commands/post/file/download-all.ts
@@ -3,22 +3,27 @@ import { writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { getConfigOrThrow } from "../../../config/store.js";
 import { DoorayApiClient } from "../../../api/client.js";
-import { resolveProject } from "../../../resolvers/project.js";
-import { resolvePost } from "../../../resolvers/post.js";
+import { resolvePostInput } from "../../../resolvers/post-input.js";
 import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
 
 export const fileDownloadAllCommand = new Command("download-all")
   .description("업무의 모든 첨부파일 다운로드")
-  .argument("<project>", "프로젝트 코드 또는 ID")
-  .argument("<post-number>", "업무 번호")
+  .argument("[project]", "프로젝트 코드 (또는 첫 인자에 Dooray URL)")
+  .argument("[post-number]", "업무 번호 (project와 함께 사용)")
+  .option("--id <postId>", "Dooray post ID (project/post-number 대신)")
+  .option("--url <url>", "Dooray 업무 URL (project/post-number 대신)")
   .option("-o, --output <dir>", "저장 디렉토리", ".")
   .action(async (project, postNumberStr, opts) => {
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
     const spinner = startSpinner("첨부파일 목록 조회 중...");
-    const projectId = await resolveProject(client, project);
-    const postId = await resolvePost(client, projectId, Number(postNumberStr));
+    const { projectId, postId } = await resolvePostInput(client, {
+      projectArg: project,
+      postNumberArg: postNumberStr,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+    });
     const res = await client.getPostFiles(projectId, postId);
 
     if (res.result.length === 0) {

--- a/src/commands/post/file/download.ts
+++ b/src/commands/post/file/download.ts
@@ -3,23 +3,70 @@ import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { getConfigOrThrow } from "../../../config/store.js";
 import { DoorayApiClient } from "../../../api/client.js";
-import { resolveProject } from "../../../resolvers/project.js";
-import { resolvePost } from "../../../resolvers/post.js";
+import { resolvePostInput } from "../../../resolvers/post-input.js";
 import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
+import { DoorayCliError } from "../../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
 
 export const fileDownloadCommand = new Command("download")
   .description("첨부파일 다운로드")
-  .argument("<project>", "프로젝트 코드 또는 ID")
-  .argument("<post-number>", "업무 번호")
-  .argument("<file-id>", "파일 ID")
+  .argument("[arg1]", "프로젝트 코드, Dooray URL, 또는 (`--id`/`--url` 모드일 때) 파일 ID")
+  .argument("[arg2]", "업무 번호 또는 (`--id`/`--url` 모드일 때) 파일 ID")
+  .argument("[arg3]", "파일 ID (positional 모드)")
+  .option("--id <postId>", "Dooray post ID (project/post-number 대신)")
+  .option("--url <url>", "Dooray 업무 URL (project/post-number 대신)")
+  .option("--file-id <fileId>", "파일 ID (positional 대체)")
   .option("-o, --output <dir>", "저장 디렉토리", ".")
-  .action(async (project, postNumberStr, fileId, opts) => {
+  .action(async (arg1, arg2, arg3, opts) => {
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
+    let projectArg: string | undefined;
+    let postNumberArg: string | undefined;
+    let fileId: string | undefined = opts.fileId;
+
+    if (opts.id || opts.url) {
+      if (arg2 || arg3) {
+        throw new DoorayCliError(
+          "--id/--url 모드에서는 파일 ID 외 추가 positional 인자를 받지 않습니다. --file-id 옵션 사용을 권장합니다.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+      fileId = fileId ?? arg1;
+    } else if (arg3) {
+      projectArg = arg1;
+      postNumberArg = arg2;
+      fileId = fileId ?? arg3;
+    } else if (arg1 && !arg2) {
+      projectArg = arg1;
+      if (!fileId) {
+        throw new DoorayCliError(
+          "URL/--id 모드에서는 --file-id 옵션이 필요합니다.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+    } else {
+      projectArg = arg1;
+      postNumberArg = arg2;
+      if (!fileId) {
+        throw new DoorayCliError(
+          "<file-id>가 필요합니다. positional 3번째 또는 --file-id 옵션을 사용하세요.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+    }
+
+    if (!fileId) {
+      throw new DoorayCliError("파일 ID가 필요합니다.", EXIT_PARAM_ERROR);
+    }
+
     startSpinner("파일 다운로드 중...");
-    const projectId = await resolveProject(client, project);
-    const postId = await resolvePost(client, projectId, Number(postNumberStr));
+    const { projectId, postId } = await resolvePostInput(client, {
+      projectArg,
+      postNumberArg,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+    });
     const { buffer, fileName } = await client.downloadPostFile(projectId, postId, fileId);
 
     const outputPath = join(opts.output, fileName);

--- a/src/commands/post/file/list.ts
+++ b/src/commands/post/file/list.ts
@@ -1,8 +1,7 @@
 import { Command } from "commander";
 import { getConfigOrThrow } from "../../../config/store.js";
 import { DoorayApiClient } from "../../../api/client.js";
-import { resolveProject } from "../../../resolvers/project.js";
-import { resolvePost } from "../../../resolvers/post.js";
+import { resolvePostInput } from "../../../resolvers/post-input.js";
 import { output, type OutputOptions } from "../../../formatters/table.js";
 import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
 
@@ -14,16 +13,22 @@ function formatSize(bytes: number): string {
 
 export const fileListCommand = new Command("list")
   .description("업무 첨부파일 목록 조회")
-  .argument("<project>", "프로젝트 코드 또는 ID")
-  .argument("<post-number>", "업무 번호")
-  .action(async (project, postNumberStr) => {
+  .argument("[project]", "프로젝트 코드 (또는 첫 인자에 Dooray URL)")
+  .argument("[post-number]", "업무 번호 (project와 함께 사용)")
+  .option("--id <postId>", "Dooray post ID (project/post-number 대신)")
+  .option("--url <url>", "Dooray 업무 URL (project/post-number 대신)")
+  .action(async (project, postNumberStr, opts) => {
     const globalOpts = fileListCommand.optsWithGlobals() as OutputOptions;
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
     startSpinner("첨부파일 목록 조회 중...");
-    const projectId = await resolveProject(client, project);
-    const postId = await resolvePost(client, projectId, Number(postNumberStr));
+    const { projectId, postId } = await resolvePostInput(client, {
+      projectArg: project,
+      postNumberArg: postNumberStr,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+    });
     const res = await client.getPostFiles(projectId, postId);
     stopSpinner(true, `첨부파일 ${res.result.length}개`);
 

--- a/src/commands/post/file/upload.ts
+++ b/src/commands/post/file/upload.ts
@@ -1,26 +1,73 @@
 import { Command } from "commander";
 import { getConfigOrThrow } from "../../../config/store.js";
 import { DoorayApiClient } from "../../../api/client.js";
-import { resolveProject } from "../../../resolvers/project.js";
-import { resolvePost } from "../../../resolvers/post.js";
+import { resolvePostInput } from "../../../resolvers/post-input.js";
 import { basename } from "node:path";
 import type { OutputOptions } from "../../../formatters/table.js";
 import { printJson } from "../../../formatters/table.js";
 import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
+import { DoorayCliError } from "../../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
 
 export const fileUploadCommand = new Command("upload")
   .description("첨부파일 업로드")
-  .argument("<project>", "프로젝트 코드 또는 ID")
-  .argument("<post-number>", "업무 번호")
-  .argument("<file-path>", "업로드할 파일 경로")
-  .action(async (project, postNumberStr, filePath) => {
+  .argument("[arg1]", "프로젝트 코드, Dooray URL, 또는 (`--id`/`--url` 모드일 때) 파일 경로")
+  .argument("[arg2]", "업무 번호 또는 (`--id`/`--url` 모드일 때) 파일 경로")
+  .argument("[arg3]", "파일 경로 (positional 모드)")
+  .option("--id <postId>", "Dooray post ID (project/post-number 대신)")
+  .option("--url <url>", "Dooray 업무 URL (project/post-number 대신)")
+  .option("--file <path>", "업로드할 파일 경로 (positional 대체)")
+  .action(async (arg1, arg2, arg3, opts) => {
     const globalOpts = fileUploadCommand.optsWithGlobals() as OutputOptions;
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
+    let projectArg: string | undefined;
+    let postNumberArg: string | undefined;
+    let filePath: string | undefined = opts.file;
+
+    if (opts.id || opts.url) {
+      if (arg2 || arg3) {
+        throw new DoorayCliError(
+          "--id/--url 모드에서는 파일 경로 외 positional 인자를 받지 않습니다. --file 옵션 사용을 권장합니다.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+      filePath = filePath ?? arg1;
+    } else if (arg3) {
+      projectArg = arg1;
+      postNumberArg = arg2;
+      filePath = filePath ?? arg3;
+    } else if (arg1 && !arg2) {
+      projectArg = arg1;
+      if (!filePath) {
+        throw new DoorayCliError(
+          "URL/--id 모드에서는 --file 옵션이 필요합니다.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+    } else {
+      projectArg = arg1;
+      postNumberArg = arg2;
+      if (!filePath) {
+        throw new DoorayCliError(
+          "<file-path>가 필요합니다. positional 3번째 또는 --file 옵션을 사용하세요.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+    }
+
+    if (!filePath) {
+      throw new DoorayCliError("파일 경로가 필요합니다.", EXIT_PARAM_ERROR);
+    }
+
     startSpinner("파일 업로드 중...");
-    const projectId = await resolveProject(client, project);
-    const postId = await resolvePost(client, projectId, Number(postNumberStr));
+    const { projectId, postId } = await resolvePostInput(client, {
+      projectArg,
+      postNumberArg,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+    });
     const res = await client.uploadPostFile(projectId, postId, filePath);
     stopSpinner(true, "업로드 완료");
 

--- a/src/commands/post/get.ts
+++ b/src/commands/post/get.ts
@@ -1,24 +1,29 @@
 import { Command } from "commander";
 import { getConfigOrThrow } from "../../config/store.js";
 import { DoorayApiClient } from "../../api/client.js";
-import { resolveProject } from "../../resolvers/project.js";
-import { resolvePost } from "../../resolvers/post.js";
+import { resolvePostInput } from "../../resolvers/post-input.js";
 import { formatPostDetail } from "../../formatters/post.js";
 import type { OutputOptions } from "../../formatters/table.js";
 import { startSpinner, stopSpinner } from "../../utils/spinner.js";
 
 export const postGetCommand = new Command("get")
   .description("업무 상세 조회")
-  .argument("<project>", "프로젝트 코드 또는 ID")
-  .argument("<post-number>", "업무 번호")
-  .action(async (project, postNumberStr) => {
+  .argument("[project]", "프로젝트 코드 (또는 첫 인자에 Dooray URL)")
+  .argument("[post-number]", "업무 번호 (project와 함께 사용)")
+  .option("--id <postId>", "Dooray post ID (project/post-number 대신)")
+  .option("--url <url>", "Dooray 업무 URL (project/post-number 대신)")
+  .action(async (project, postNumberStr, opts) => {
     const globalOpts = postGetCommand.optsWithGlobals() as OutputOptions;
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
     startSpinner("업무 조회 중...");
-    const projectId = await resolveProject(client, project);
-    const postId = await resolvePost(client, projectId, Number(postNumberStr));
+    const { projectId, postId } = await resolvePostInput(client, {
+      projectArg: project,
+      postNumberArg: postNumberStr,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+    });
     const res = await client.getPost(projectId, postId);
     stopSpinner(true, "업무 조회 완료");
 

--- a/src/commands/post/workflow.ts
+++ b/src/commands/post/workflow.ts
@@ -1,26 +1,64 @@
 import { Command } from "commander";
 import { getConfigOrThrow } from "../../config/store.js";
 import { DoorayApiClient } from "../../api/client.js";
-import { resolveProject } from "../../resolvers/project.js";
-import { resolvePost } from "../../resolvers/post.js";
+import { resolvePostInput } from "../../resolvers/post-input.js";
 import { resolveWorkflow } from "../../resolvers/workflow.js";
 import { startSpinner, stopSpinner } from "../../utils/spinner.js";
+import { DoorayCliError } from "../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../utils/exit-codes.js";
+import { isLikelyDoorayUrl } from "../../utils/dooray-url.js";
 
 export const postWorkflowCommand = new Command("workflow")
   .description("업무 워크플로우 변경")
-  .argument("<project>", "프로젝트 코드 또는 ID")
-  .argument("<post-number>", "업무 번호")
-  .argument("<workflow>", "워크플로우 이름 또는 클래스")
-  .action(async (project, postNumberStr, workflow) => {
+  .argument("[project]", "프로젝트 코드 (또는 첫 인자에 Dooray URL)")
+  .argument("[post-number]", "업무 번호 (project와 함께 사용)")
+  .argument("[workflow]", "워크플로우 이름 또는 클래스 (또는 --workflow 사용)")
+  .option("--id <postId>", "Dooray post ID (project/post-number 대신)")
+  .option("--url <url>", "Dooray 업무 URL (project/post-number 대신)")
+  .option("--workflow <name>", "워크플로우 이름 (positional 대체)")
+  .action(async (project, postNumber, workflowArg, opts) => {
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
+    // workflow 인자 결정
+    let workflowInput: string | undefined = opts.workflow;
+    let projectArg: string | undefined = project;
+    let postNumberArg: string | undefined = postNumber;
+
+    if (!workflowInput) {
+      if (workflowArg) {
+        // positional 3개 모드: project + post-number + workflow
+        workflowInput = workflowArg;
+      } else if ((opts.id || opts.url) && projectArg && !postNumberArg) {
+        // --id/--url 모드 + positional 1개 → 그 positional이 workflow
+        workflowInput = projectArg;
+        projectArg = undefined;
+      } else if (!opts.id && !opts.url && projectArg && postNumberArg && !workflowArg) {
+        // URL positional 2-arg 모드: arg1=URL, arg2=workflow
+        if (isLikelyDoorayUrl(projectArg)) {
+          workflowInput = postNumberArg;
+          postNumberArg = undefined;
+        }
+      }
+    }
+
+    if (!workflowInput) {
+      throw new DoorayCliError(
+        "workflow가 필요합니다. positional 또는 --workflow로 입력하세요.",
+        EXIT_PARAM_ERROR,
+      );
+    }
+
     startSpinner("워크플로우 변경 중...");
-    const projectId = await resolveProject(client, project);
-    const postId = await resolvePost(client, projectId, Number(postNumberStr));
-    const workflowId = await resolveWorkflow(client, projectId, workflow);
+    const { projectId, postId, postNumber: resolvedPostNumber } = await resolvePostInput(client, {
+      projectArg,
+      postNumberArg,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+    });
+    const workflowId = await resolveWorkflow(client, projectId, workflowInput);
     await client.setPostWorkflow(projectId, postId, workflowId);
     stopSpinner(true, "워크플로우 변경 완료");
 
-    process.stdout.write(`#${postNumberStr} 워크플로우가 "${workflow}"(으)로 변경되었습니다.\n`);
+    process.stdout.write(`#${resolvedPostNumber} 워크플로우가 "${workflowInput}"(으)로 변경되었습니다.\n`);
   });

--- a/src/resolvers/post-input.test.ts
+++ b/src/resolvers/post-input.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from "vitest";
+import { resolvePostInput } from "./post-input.js";
+import { DoorayCliError } from "../utils/errors.js";
+
+vi.mock("./project.js");
+vi.mock("./post.js");
+
+import { resolveProject } from "./project.js";
+import { resolvePost } from "./post.js";
+
+function makeClient(opts: {
+  standalone?: { id: string; projectId: string; projectCode: string; number: number };
+}) {
+  return {
+    getPostStandalone: vi.fn().mockResolvedValue({
+      result: opts.standalone
+        ? {
+            id: opts.standalone.id,
+            number: opts.standalone.number,
+            project: { id: opts.standalone.projectId, code: opts.standalone.projectCode },
+          }
+        : { id: "stub", number: 1, project: { id: "p1", code: "stub" } },
+    }),
+  } as any;
+}
+
+describe("resolvePostInput", () => {
+  it("--id + --url 동시 → 에러", async () => {
+    await expect(
+      resolvePostInput(makeClient({}), { idOpt: "1", urlOpt: "https://x.dooray.com/task/to/2" }),
+    ).rejects.toBeInstanceOf(DoorayCliError);
+  });
+
+  it("--id + positional 동시 → 에러", async () => {
+    await expect(
+      resolvePostInput(makeClient({}), { idOpt: "1", projectArg: "tc-ocr" }),
+    ).rejects.toBeInstanceOf(DoorayCliError);
+  });
+
+  it("--url + positional 동시 → 에러", async () => {
+    await expect(
+      resolvePostInput(makeClient({}), { urlOpt: "https://x.dooray.com/task/to/1", projectArg: "tc-ocr" }),
+    ).rejects.toBeInstanceOf(DoorayCliError);
+  });
+
+  it("--url 단독 → standalone 호출", async () => {
+    const c = makeClient({
+      standalone: { id: "999", projectId: "p1", projectCode: "tc-ocr", number: 337 },
+    });
+    const out = await resolvePostInput(c, {
+      urlOpt: "https://x.dooray.com/task/to/999",
+    });
+    expect(out).toEqual({ projectId: "p1", projectCode: "tc-ocr", postId: "999", postNumber: 337 });
+    expect(c.getPostStandalone).toHaveBeenCalledWith("999");
+  });
+
+  it("--id 단독 → standalone 호출", async () => {
+    const c = makeClient({
+      standalone: { id: "999", projectId: "p1", projectCode: "tc-ocr", number: 337 },
+    });
+    const out = await resolvePostInput(c, { idOpt: "999" });
+    expect(out.postId).toBe("999");
+    expect(c.getPostStandalone).toHaveBeenCalledWith("999");
+  });
+
+  it("positional 1개가 URL이면 standalone", async () => {
+    const c = makeClient({
+      standalone: { id: "999", projectId: "p1", projectCode: "tc-ocr", number: 337 },
+    });
+    const out = await resolvePostInput(c, {
+      projectArg: "https://x.dooray.com/task/to/999",
+    });
+    expect(out.postId).toBe("999");
+  });
+
+  it("positional 2개 (기존 경로) → resolveProject + resolvePost 호출", async () => {
+    vi.mocked(resolveProject).mockResolvedValue("proj-id-abc");
+    vi.mocked(resolvePost).mockResolvedValue("post-id-123");
+
+    const c = makeClient({});
+    const out = await resolvePostInput(c, { projectArg: "tc-ocr", postNumberArg: "337" });
+    expect(out.projectId).toBe("proj-id-abc");
+    expect(out.postId).toBe("post-id-123");
+    expect(out.projectCode).toBe("tc-ocr");
+    expect(out.postNumber).toBe(337);
+    expect(resolveProject).toHaveBeenCalledWith(c, "tc-ocr");
+    expect(resolvePost).toHaveBeenCalledWith(c, "proj-id-abc", 337);
+  });
+
+  it("post-number 비정수 → 에러", async () => {
+    await expect(
+      resolvePostInput(makeClient({}), { projectArg: "tc-ocr", postNumberArg: "abc" }),
+    ).rejects.toBeInstanceOf(DoorayCliError);
+  });
+
+  it("--url 형식 오류 → 에러", async () => {
+    await expect(
+      resolvePostInput(makeClient({}), { urlOpt: "https://other.com/task/to/1" }),
+    ).rejects.toBeInstanceOf(DoorayCliError);
+  });
+
+  it("입력 전혀 없음 → 안내 에러", async () => {
+    await expect(resolvePostInput(makeClient({}), {})).rejects.toThrow(
+      /업무를 식별할 정보가 부족합니다/,
+    );
+  });
+});

--- a/src/resolvers/post-input.ts
+++ b/src/resolvers/post-input.ts
@@ -1,0 +1,110 @@
+import { DoorayApiClient } from "../api/client.js";
+import { resolveProject } from "./project.js";
+import { resolvePost } from "./post.js";
+import { parseDoorayTaskUrl, isLikelyDoorayUrl } from "../utils/dooray-url.js";
+import { DoorayCliError } from "../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../utils/exit-codes.js";
+
+export interface PostInputArgs {
+  projectArg?: string;
+  postNumberArg?: string;
+  idOpt?: string;
+  urlOpt?: string;
+}
+
+export interface ResolvedPostInput {
+  projectId: string;
+  postId: string;
+  projectCode: string;
+  postNumber: number;
+}
+
+const INPUT_HELP =
+  "업무를 식별할 정보가 부족합니다. 다음 중 하나를 입력하세요:\n" +
+  "  - <project> <post-number>     예: tc-ocr 337\n" +
+  "  - --id <postId>                예: --id 4319587406666362045\n" +
+  "  - <Dooray URL>                 예: https://x.dooray.com/task/to/4319587406666362045";
+
+async function resolveByPostId(
+  client: DoorayApiClient,
+  postId: string,
+): Promise<ResolvedPostInput> {
+  const res = await client.getPostStandalone(postId);
+  const d = res.result;
+  return {
+    projectId: d.project.id,
+    projectCode: d.project.code,
+    postId: d.id,
+    postNumber: d.number,
+  };
+}
+
+export async function resolvePostInput(
+  client: DoorayApiClient,
+  args: PostInputArgs,
+): Promise<ResolvedPostInput> {
+  const { projectArg, postNumberArg, idOpt, urlOpt } = args;
+  const hasPositional = !!projectArg || !!postNumberArg;
+
+  // 1. --id + --url 동시 → 에러
+  if (idOpt && urlOpt) {
+    throw new DoorayCliError(
+      "--id와 --url은 동시에 사용할 수 없습니다.",
+      EXIT_PARAM_ERROR,
+    );
+  }
+
+  // 2. 옵션 + positional 동시 → 에러
+  if ((idOpt || urlOpt) && hasPositional) {
+    throw new DoorayCliError(
+      "--id/--url과 positional 인자(<project> <post-number>)는 동시에 사용할 수 없습니다.",
+      EXIT_PARAM_ERROR,
+    );
+  }
+
+  // 3. --url 단독
+  if (urlOpt) {
+    const postId = parseDoorayTaskUrl(urlOpt);
+    if (!postId) {
+      throw new DoorayCliError(
+        `--url 형식이 올바르지 않습니다: "${urlOpt}"\n예: https://x.dooray.com/task/to/4319587406666362045`,
+        EXIT_PARAM_ERROR,
+      );
+    }
+    return resolveByPostId(client, postId);
+  }
+
+  // 4. --id 단독
+  if (idOpt) {
+    return resolveByPostId(client, idOpt);
+  }
+
+  // 5. positional 1개이고 URL 형태
+  if (projectArg && !postNumberArg && isLikelyDoorayUrl(projectArg)) {
+    const postId = parseDoorayTaskUrl(projectArg);
+    if (!postId) {
+      throw new DoorayCliError(
+        `Dooray URL 형식이 올바르지 않습니다: "${projectArg}"\n예: https://x.dooray.com/task/to/4319587406666362045`,
+        EXIT_PARAM_ERROR,
+      );
+    }
+    return resolveByPostId(client, postId);
+  }
+
+  // 6. positional 2개 (기존 경로)
+  if (projectArg && postNumberArg) {
+    const projectId = await resolveProject(client, projectArg);
+    const num = Number(postNumberArg);
+    if (!Number.isFinite(num) || num <= 0) {
+      throw new DoorayCliError(
+        `<post-number>가 올바르지 않습니다: "${postNumberArg}"`,
+        EXIT_PARAM_ERROR,
+      );
+    }
+    const postId = await resolvePost(client, projectId, num);
+    return { projectId, projectCode: projectArg, postId, postNumber: num };
+  }
+
+  // 7. 기타: 명시적 안내 에러
+  throw new DoorayCliError(INPUT_HELP, EXIT_PARAM_ERROR);
+}

--- a/src/utils/dooray-url.test.ts
+++ b/src/utils/dooray-url.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { parseDoorayTaskUrl, isLikelyDoorayUrl } from "./dooray-url.js";
+
+describe("parseDoorayTaskUrl", () => {
+  it("정상 URL에서 postId 추출", () => {
+    expect(parseDoorayTaskUrl("https://nhnent.dooray.com/task/to/4319587406666362045"))
+      .toBe("4319587406666362045");
+  });
+  it("query string 무시", () => {
+    expect(parseDoorayTaskUrl("https://x.dooray.com/task/to/123?projectScope=from_to_cc"))
+      .toBe("123");
+  });
+  it("hash 무시", () => {
+    expect(parseDoorayTaskUrl("https://x.dooray.com/task/to/123#section"))
+      .toBe("123");
+  });
+  it("trailing slash 허용", () => {
+    expect(parseDoorayTaskUrl("https://x.dooray.com/task/to/123/")).toBe("123");
+  });
+  it("dooray.com 도메인이 아니면 null", () => {
+    expect(parseDoorayTaskUrl("https://other.com/task/to/123")).toBeNull();
+  });
+  it("/task/to/ 경로가 아니면 null", () => {
+    expect(parseDoorayTaskUrl("https://x.dooray.com/wiki/123")).toBeNull();
+  });
+  it("URL 형식이 아니면 null", () => {
+    expect(parseDoorayTaskUrl("tc-ocr/337")).toBeNull();
+    expect(parseDoorayTaskUrl("12345")).toBeNull();
+  });
+});
+
+describe("isLikelyDoorayUrl", () => {
+  it("http(s) prefix 인식", () => {
+    expect(isLikelyDoorayUrl("https://x.com")).toBe(true);
+    expect(isLikelyDoorayUrl("http://x.com")).toBe(true);
+  });
+  it("URL 아니면 false", () => {
+    expect(isLikelyDoorayUrl("tc-ocr")).toBe(false);
+    expect(isLikelyDoorayUrl("12345")).toBe(false);
+  });
+});

--- a/src/utils/dooray-url.ts
+++ b/src/utils/dooray-url.ts
@@ -1,0 +1,10 @@
+const TASK_URL_RE = /^https?:\/\/[\w.-]+\.dooray\.com\/task\/to\/(\d+)(?:[/?#].*)?$/;
+
+export function parseDoorayTaskUrl(input: string): string | null {
+  const m = TASK_URL_RE.exec(input);
+  return m ? m[1] : null;
+}
+
+export function isLikelyDoorayUrl(input: string): boolean {
+  return /^https?:\/\//.test(input);
+}

--- a/tasks/011-feat-post-input-unification/index.json
+++ b/tasks/011-feat-post-input-unification/index.json
@@ -2,8 +2,8 @@
   "name": "011-feat-post-input-unification",
   "description": "Issue #16 — post 하위 12개 명령에 통합 입력 방식 도입(--id/--url/URL positional). standalone API 활용. comment/file의 sub-id 옵션화. 첫 테스트 인프라(vitest) 도입. ADR-020.",
   "created_at": "2026-04-27T00:00:00Z",
-  "status": "pending",
-  "current_phase": 1,
+  "status": "completed",
+  "current_phase": 5,
   "total_phases": 5,
   "error_message": null,
   "blocked_reason": null,
@@ -12,37 +12,37 @@
       "number": 1,
       "title": "vitest setup + URL parser + standalone API + resolvePostInput 헬퍼",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 2,
       "title": "post get/edit/done/workflow 통합 적용",
       "file": "phase-02.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 3,
       "title": "post comment 4개 명령 + --comment-id 옵션화",
       "file": "phase-03.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 4,
       "title": "post file 5개 명령 + --file-id 옵션화",
       "file": "phase-04.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 5,
       "title": "빌드 + 테스트 + help/docs 정합성 + 시나리오 검증",
       "file": "phase-05.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],
-  "updated_at": "2026-04-27T00:00:00Z"
+  "updated_at": "2026-04-27T18:00:00Z"
 }


### PR DESCRIPTION
## Summary

- Issue #16 해결: post 하위 12개 명령(`get`/`edit`/`done`/`workflow` + `comment` 4개 + `file` 5개)에 공통 입력 방식 도입.
- 4가지 입력 방식 지원: `<project> <number>` (기존) / Dooray URL positional / `--id <postId>` / `--url <url>`.
- comment/file의 sub-id를 옵션화: `--comment-id`, `--file-id`, `--file` (기존 3-arg positional도 호환 유지).
- `getPostStandalone(postId)` standalone API로 URL/`--id`/`--url` 모드의 resolve 단계 단축.
- vitest 도입: 19개 단위 테스트 (URL parser 9 + 7-branch 분기 10).

## ADR

- `docs/adr.md` ADR-020 — 분기 규칙(7-branch) / standalone API 사용 / sub-id 옵션화 / vitest 도입 근거

## Test plan

- [x] `pnpm run build` 성공 (120 KB)
- [x] `pnpm test` — 19 passed
- [x] `node dist/index.js post get --help` — `--id`/`--url` 노출
- [x] 충돌 시나리오 (`--id`+`--url`, `--id|--url`+positional, 빈 입력) → exit=3
- [ ] 시나리오 B (필수): `dooray post get --id <postId>` — standalone API 응답 shape 검증
- [ ] 시나리오 C: `dooray post workflow --id <id> --workflow <name>` 및 `<URL> <workflow>` 양쪽
- [ ] 시나리오 D: `dooray post comment edit --url <url> --comment-id <id> --body "..."`
- [ ] 시나리오 E: `dooray post file download --url <url> --file-id <id>`

## Notes

- 코드 리뷰: `code-reviewer` round 1에서 1 HIGH (Branch 6 테스트 누락) + 2 MEDIUM (workflow URL 2-arg / `--url + positional` 테스트) → 모두 fix → round 2 PASS
- docs 정합성: `docs-verifier`(architect) round 1 UPDATE_NEEDED 3건(code-architecture/README/SKILL) → 갱신 → round 2 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)