### PR TITLE
feat(commands): add member get/list + post comment Creator enrich

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ dooray project members tc-ocr              # 멤버 목록
 dooray project workflows tc-ocr            # 워크플로우 목록
 ```
 
+### 멤버
+
+```bash
+dooray member list tc-ocr                  # 프로젝트 멤버 목록 (이름·organizationMemberId)
+dooray member get <organizationMemberId>   # 멤버 상세 (cache 우회, ADR-021)
+```
+
 ### 업무
 
 ```bash
@@ -104,6 +111,8 @@ dooray post comment list tc-ocr 42
 dooray post comment add tc-ocr 42 --body "댓글 내용"
 dooray post comment add tc-ocr 42 --body-file ./comment.md
 ```
+
+> table 출력의 Creator 컬럼은 프로젝트 멤버 캐시로 자동 enrich되며, `--json`은 raw 응답을 유지한다 (ADR-021).
 
 ### 상태 변경
 

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -31,7 +31,7 @@ src/
   resolvers/
     me.ts                   # /common/v1/members/me → CachedMe
     project.ts              # code·id → projectId
-    member.ts               # name → organizationMemberId
+    member.ts               # name → organizationMemberId + lookupMemberName / buildMemberNameMap (ADR-021)
     workflow.ts             # name·class → workflowId
     post.ts                 # postNumber → postId (API 호출)
     wiki.ts                 # projectCode → wikiId / wikiId → homePageId (캐시)
@@ -56,6 +56,7 @@ src/
     table.ts                # cli-table3 기반 테이블 출력
     post.ts                 # Post 전용 포맷 (workflow 이름 등)
     wiki.ts                 # Wiki 전용 포맷
+    member.ts               # Member 상세/목록 포맷 (ADR-021)
 
   utils/
     errors.ts               # DoorayCliError (message + exitCode)
@@ -63,6 +64,7 @@ src/
     exit-codes.ts           # 0 성공 / 1 API오류 / 2 인증실패 / 3 파라미터오류 / 4 설정오류
     body-input.ts           # --body / --body-file → string (stdin "-" + 충돌 가드)
     dooray-url.ts           # https://*.dooray.com/task/to/<postId> URL parser (ADR-020)
+    comment-enrich.ts       # PostComment[] Creator 이름 채우기 (ADR-021, immutable)
 
   commands/
     setup.ts                # dooray setup — 대화형 초기 설정 마법사 (스킬 설치 포함)
@@ -74,6 +76,11 @@ src/
       list.ts
       members.ts
       workflows.ts
+
+    member/
+      index.ts              # member 서브커맨드 등록
+      get.ts                # dooray member get <member-id> (cache 우회, ADR-021)
+      list.ts               # dooray member list <project> (project 캐시 활용)
 
     post/
       list.ts

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -52,7 +52,8 @@ dooray doctor                                 # 설정 검증
 | 초기 설정 (대화형) | `dooray setup` |
 | 프로젝트 찾기 | `dooray project list --search <keyword>` |
 | 개인 프로젝트 목록 | `dooray project list --type private` |
-| 프로젝트 멤버 보기 | `dooray project members <project>` |
+| 프로젝트 멤버 보기 | `dooray project members <project>` 또는 `dooray member list <project>` (이름·organizationMemberId) |
+| 멤버 상세 (organizationMemberId) | `dooray member get <organizationMemberId>` (cache 우회, ADR-021) |
 | 업무 목록 조회 | `dooray post list <project>` |
 | 업무 검색 | `dooray post search <project> "<keyword>"` |
 | 업무 상세 보기 | `dooray post get <project> <number>` |
@@ -60,7 +61,7 @@ dooray doctor                                 # 설정 검증
 | 업무 제목/본문 수정 | `dooray post edit <project> <number> --title "..." --body "..."` 또는 `--body-file <path>` |
 | 업무 완료 처리 | `dooray post done <project> <number>` |
 | 업무 워크플로우 변경 | `dooray post workflow <project> <number> <workflow>` |
-| 댓글 조회 | `dooray post comment list <project> <number>` |
+| 댓글 조회 | `dooray post comment list <project> <number>` (table 출력은 Creator 이름 자동 채움, `--json`은 raw 유지 — ADR-021) |
 | 댓글 추가 | `dooray post comment add <project> <number> --body "..."` 또는 `--body-file <path>` |
 | 댓글 수정 | `dooray post comment edit <project> <number> <comment-id> --body "..."` 또는 `--body-file <path>` |
 | 댓글 삭제 | `dooray post comment delete <project> <number> <comment-id>` |
@@ -106,7 +107,7 @@ CLI로 처리 **불가능한** 작업. 아래 항목을 요청받으면 웹 UI �
 2. **프로젝트 코드를 모르면** → `dooray project list --search <keyword>` 로 먼저 찾기
 3. **업무 번호를 모르면** → `dooray post search <project> "<keyword>"` 로 검색
 4. **워크플로우 이름을 모르면** → `dooray project workflows <project>` 로 확인
-5. **멤버 이름을 모르면** → `dooray project members <project>` 로 확인
+5. **멤버 이름을 모르면** → `dooray member list <project>` (또는 `dooray project members <project>`) 로 확인
 6. **결과를 다음 액션에 사용하려면** → `--json` 플래그로 구조화된 데이터 획득
 
 ---

--- a/src/commands/member/get.ts
+++ b/src/commands/member/get.ts
@@ -1,0 +1,16 @@
+import { Command } from "commander";
+import { getConfigOrThrow } from "../../config/store.js";
+import { DoorayApiClient } from "../../api/client.js";
+import { formatMemberDetail } from "../../formatters/member.js";
+import type { OutputOptions } from "../../formatters/table.js";
+
+export const memberGetCommand = new Command("get")
+  .description("멤버 상세 정보 조회 (organizationMemberId)")
+  .argument("<member-id>", "조회할 organization member ID")
+  .action(async (memberId) => {
+    const globalOpts = memberGetCommand.optsWithGlobals() as OutputOptions;
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+    const res = await client.getMemberDetail(memberId);
+    formatMemberDetail(res.result, globalOpts);
+  });

--- a/src/commands/member/index.ts
+++ b/src/commands/member/index.ts
@@ -1,0 +1,8 @@
+import { Command } from "commander";
+import { memberGetCommand } from "./get.js";
+import { memberListCommand } from "./list.js";
+
+export const memberCommand = new Command("member")
+  .description("Dooray 멤버 조회");
+memberCommand.addCommand(memberGetCommand);
+memberCommand.addCommand(memberListCommand);

--- a/src/commands/member/list.ts
+++ b/src/commands/member/list.ts
@@ -1,0 +1,25 @@
+import { Command } from "commander";
+import { getConfigOrThrow } from "../../config/store.js";
+import { DoorayApiClient } from "../../api/client.js";
+import { resolveProject } from "../../resolvers/project.js";
+import { ensureMembers } from "../../resolvers/member.js";
+import { formatMemberList } from "../../formatters/member.js";
+import { startSpinner, stopSpinner } from "../../utils/spinner.js";
+import type { OutputOptions } from "../../formatters/table.js";
+
+export const memberListCommand = new Command("list")
+  .description("프로젝트 멤버 목록")
+  .argument("<project>", "프로젝트 코드 또는 ID")
+  .action(async (project) => {
+    const globalOpts = memberListCommand.optsWithGlobals() as OutputOptions;
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+    startSpinner("멤버 목록 조회 중...");
+    const projectId = await resolveProject(client, project);
+    const members = await ensureMembers(client, projectId);
+    stopSpinner(true, `${members.length}명`);
+    formatMemberList(
+      members.map((m) => ({ id: m.organizationMemberId, name: m.name })),
+      globalOpts,
+    );
+  });

--- a/src/commands/post/comment/list.ts
+++ b/src/commands/post/comment/list.ts
@@ -2,6 +2,8 @@ import { Command } from "commander";
 import { getConfigOrThrow } from "../../../config/store.js";
 import { DoorayApiClient } from "../../../api/client.js";
 import { resolvePostInput } from "../../../resolvers/post-input.js";
+import { buildMemberNameMap } from "../../../resolvers/member.js";
+import { enrichCommentCreators } from "../../../utils/comment-enrich.js";
 import { formatCommentList } from "../../../formatters/post.js";
 import type { OutputOptions } from "../../../formatters/table.js";
 import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
@@ -32,5 +34,14 @@ export const commentListCommand = new Command("list")
     });
     stopSpinner(true, "댓글 목록 조회 완료");
 
-    formatCommentList(res.result, globalOpts);
+    let comments = res.result;
+    if (!globalOpts.json) {
+      // table/quiet 출력일 때만 enrich (--json은 raw 유지 — ADR-021)
+      let nameMap = new Map<string, string>();
+      try {
+        nameMap = await buildMemberNameMap(client, projectId);
+      } catch { /* enrich 실패 시 빈 map → 표시명 비어있음, 명령은 정상 동작 */ }
+      comments = enrichCommentCreators(comments, nameMap);
+    }
+    formatCommentList(comments, globalOpts);
   });

--- a/src/formatters/member.ts
+++ b/src/formatters/member.ts
@@ -1,0 +1,32 @@
+import type { MemberDetail } from "../api/types.js";
+import type { OutputOptions } from "./table.js";
+import { output, printJson } from "./table.js";
+
+export function formatMemberDetail(member: MemberDetail, opts: OutputOptions): void {
+  if (opts.json) { printJson(member); return; }
+  if (opts.quiet) { process.stdout.write(member.id + "\n"); return; }
+  const lines = [
+    `이름: ${member.name}`,
+    ...(member.englishName ? [`영문명: ${member.englishName}`] : []),
+    ...(member.nickname ? [`별명: ${member.nickname}`] : []),
+    ...(member.userCode ? [`사번/ID: ${member.userCode}`] : []),
+    ...(member.externalEmailAddress ? [`외부 이메일: ${member.externalEmailAddress}`] : []),
+    `member-id: ${member.id}`,
+  ];
+  process.stdout.write(lines.join("\n") + "\n");
+}
+
+export interface MemberListRow {
+  id: string;
+  name: string;
+  role?: string;
+}
+
+export function formatMemberList(rows: MemberListRow[], opts: OutputOptions): void {
+  output(opts, {
+    headers: ["ID", "Name", "Role"],
+    rows: rows.map((r) => [r.id, r.name, r.role ?? ""]),
+    raw: rows,
+    ids: rows.map((r) => r.id),
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { wikiPagesCommand } from "./commands/wiki/pages.js";
 import { wikiPageGetCommand } from "./commands/wiki/page-get.js";
 import { wikiPageCreateCommand } from "./commands/wiki/page-create.js";
 import { wikiPageEditCommand } from "./commands/wiki/page-edit.js";
+import { memberCommand } from "./commands/member/index.js";
 import { mailListCommand } from "./commands/mail/list.js";
 import { mailGetCommand } from "./commands/mail/get.js";
 import { mailSendCommand } from "./commands/mail/send.js";
@@ -106,6 +107,7 @@ mailCommand.addCommand(mailReplyCommand);
 
 program.addCommand(setupCommand);
 program.addCommand(configCommand);
+program.addCommand(memberCommand);
 program.addCommand(cacheCommand);
 program.addCommand(doctorCommand);
 program.addCommand(projectCommand);

--- a/src/resolvers/member.ts
+++ b/src/resolvers/member.ts
@@ -57,6 +57,47 @@ export async function ensureMembers(
   return items;
 }
 
+/**
+ * organizationMemberId → 표시명.
+ * 1. project 캐시에서 hit하면 해당 name 반환 (캐시 신선도는 resolveMember와 동일)
+ * 2. miss 또는 캐시 stale이면 getMemberDetail 직접 호출 (결과 캐시는 안 함 — ADR-021)
+ * 3. API도 실패하면 빈 문자열 반환 (호출자가 fallback 표시)
+ *
+ * `buildMemberNameMap`은 같은 projectId의 여러 id를 한 번의 ensureMembers로 lookup.
+ */
+export async function lookupMemberName(
+  client: DoorayApiClient,
+  projectId: string,
+  organizationMemberId: string,
+): Promise<string> {
+  const members = await ensureMembers(client, projectId);
+  const cached = members.find((m) => m.organizationMemberId === organizationMemberId);
+  if (cached?.name) return cached.name;
+  try {
+    const detail = await client.getMemberDetail(organizationMemberId);
+    return detail.result.name ?? "";
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * 한 projectId 컨텍스트에서 여러 organizationMemberId의 표시명을 한 번에 조회.
+ * 단일 ensureMembers 호출 후 in-memory map으로 반환. 캐시 miss는
+ * 추가 API 호출하지 않음 — 호출자가 빈 문자열을 보고 표시 처리.
+ */
+export async function buildMemberNameMap(
+  client: DoorayApiClient,
+  projectId: string,
+): Promise<Map<string, string>> {
+  const members = await ensureMembers(client, projectId);
+  const map = new Map<string, string>();
+  for (const m of members) {
+    if (m.name) map.set(m.organizationMemberId, m.name);
+  }
+  return map;
+}
+
 export async function resolveMember(
   client: DoorayApiClient,
   projectId: string,

--- a/src/utils/comment-enrich.test.ts
+++ b/src/utils/comment-enrich.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { enrichCommentCreators } from "./comment-enrich.js";
+import type { PostComment } from "../api/types.js";
+
+function makeComment(opts: { id: string; memberId?: string; name?: string }): PostComment {
+  return {
+    id: opts.id,
+    post: { id: "p1" },
+    type: "log", subtype: "comment",
+    createdAt: "2026-04-27T00:00:00Z",
+    creator: opts.memberId
+      ? { type: "member", member: { organizationMemberId: opts.memberId, ...(opts.name && { name: opts.name }) } }
+      : { type: "system" },
+    body: { mimeType: "text/x-markdown", content: "" },
+  };
+}
+
+describe("enrichCommentCreators", () => {
+  it("name 비어있고 nameMap hit → 채움", () => {
+    const map = new Map([["m1", "홍길동"]]);
+    const out = enrichCommentCreators([makeComment({ id: "c1", memberId: "m1" })], map);
+    expect(out[0].creator.member?.name).toBe("홍길동");
+  });
+  it("name 이미 있으면 변경 안 함", () => {
+    const map = new Map([["m1", "다른이름"]]);
+    const out = enrichCommentCreators([makeComment({ id: "c1", memberId: "m1", name: "원래이름" })], map);
+    expect(out[0].creator.member?.name).toBe("원래이름");
+  });
+  it("nameMap miss → 변경 안 함 (name 비어있음 그대로)", () => {
+    const map = new Map<string, string>();
+    const out = enrichCommentCreators([makeComment({ id: "c1", memberId: "m1" })], map);
+    expect(out[0].creator.member?.name).toBeUndefined();
+  });
+  it("creator.member 없음 (system 등) → 변경 안 함", () => {
+    const map = new Map([["m1", "홍길동"]]);
+    const out = enrichCommentCreators([makeComment({ id: "c1" })], map);
+    expect(out[0]).toEqual(makeComment({ id: "c1" }));
+  });
+  it("원본 배열 mutation 없음", () => {
+    const map = new Map([["m1", "홍길동"]]);
+    const original = [makeComment({ id: "c1", memberId: "m1" })];
+    enrichCommentCreators(original, map);
+    expect(original[0].creator.member?.name).toBeUndefined();
+  });
+});

--- a/src/utils/comment-enrich.ts
+++ b/src/utils/comment-enrich.ts
@@ -1,0 +1,25 @@
+import type { PostComment } from "../api/types.js";
+
+/**
+ * PostComment[]의 creator.member.name 비어있는 항목을 nameMap으로 채워서 반환.
+ * 원본 변경 없음 (immutable). table 출력 직전에 호출.
+ */
+export function enrichCommentCreators(
+  comments: PostComment[],
+  nameMap: Map<string, string>,
+): PostComment[] {
+  return comments.map((c) => {
+    const id = c.creator?.member?.organizationMemberId;
+    const existing = c.creator?.member?.name;
+    if (existing || !id) return c;
+    const filled = nameMap.get(id);
+    if (!filled) return c;
+    return {
+      ...c,
+      creator: {
+        ...c.creator,
+        member: { ...c.creator.member!, name: filled },
+      },
+    };
+  });
+}

--- a/tasks/012-feat-member-name-display/index.json
+++ b/tasks/012-feat-member-name-display/index.json
@@ -2,8 +2,8 @@
   "name": "012-feat-member-name-display",
   "description": "Issue #17 — member get/list 명령 신설 + post comment list table 출력 Creator 컬럼 enrich. project 캐시 활용. ADR-021. (member search, --mention은 후속 issue로 분리.)",
   "created_at": "2026-04-27T00:00:00Z",
-  "status": "pending",
-  "current_phase": 1,
+  "status": "completed",
+  "current_phase": 4,
   "total_phases": 4,
   "error_message": null,
   "blocked_reason": null,
@@ -12,30 +12,30 @@
       "number": 1,
       "title": "member resolver 역방향 lookup + comment Creator enrich 헬퍼",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 2,
       "title": "member 명령 신설 (get/list) + formatter",
       "file": "phase-02.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 3,
       "title": "comment list 적용 + 단위 테스트",
       "file": "phase-03.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 4,
       "title": "빌드 + help/시나리오 검증 + task 완료 처리",
       "file": "phase-04.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],
-  "updated_at": "2026-04-27T00:00:00Z"
+  "updated_at": "2026-04-27T10:37:00Z"
 }


### PR DESCRIPTION
## Summary

- `dooray member get/list` 신설 — 표시명 조회 (project 캐시 활용, `member get`은 cache 우회)
- `post comment list` table 출력의 Creator 컬럼 자동 enrich (`--json`은 raw 유지)
- Issue #17, ADR-021 기반

## 변경 파일

**신규**
- `src/commands/member/{index,get,list}.ts` — 서브커맨드
- `src/formatters/member.ts` — 상세/목록 포맷
- `src/utils/comment-enrich.ts` (+ `.test.ts`) — immutable enrich 헬퍼

**수정**
- `src/resolvers/member.ts` — `lookupMemberName` + `buildMemberNameMap` 추가
- `src/commands/post/comment/list.ts` — table-only enrich (try/catch fallback)
- `src/index.ts` — memberCommand 등록
- `docs/code-architecture.md`, `README.md`, `skills/dooray-cli/SKILL.md` — 신규 명령 반영

## Test plan

- [x] `pnpm run build` 성공 (123.91 KB)
- [x] `pnpm test` — 24 passed (enrichCommentCreators 5건 포함)
- [x] `dooray member --help` / `member get --help` / `member list --help` 정상 노출
- [ ] 실 환경에서 `dooray post comment list <project> <number>` table 출력의 Creator 컬럼 enrich 확인
- [ ] `dooray post comment list <project> <number> --json` raw 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)