### PR TITLE
feat(commands): add project groups/tags commands (Issue #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ dooray project list --search ocr           # 코드로 검색
 dooray project list --type private         # 개인 프로젝트 목록
 dooray project members tc-ocr              # 멤버 목록
 dooray project workflows tc-ocr            # 워크플로우 목록
+dooray project groups tc-ocr              # 멤버 그룹 목록 (ID / Code)
+dooray project tags tc-ocr                # 태그 목록 (ID / Color / Name / Group / Mandatory)
 ```
+
+> **태그 캐시 갱신**: 이전 버전에서 캐시한 태그가 색상 없이 표시되면 `dooray cache clear` 실행 후 다시 조회하세요.
 
 ### 멤버
 

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -40,9 +40,11 @@ src/
     milestone.ts            # name → milestoneId
     match.ts                # 공용: 정확일치 → 부분일치 → 모호 시 에러
     post-input.ts           # --id / --url / positional / Dooray URL → {projectId, postId, ...} 단일 헬퍼 (ADR-020)
+    member-group.ts         # projectId → CachedMemberGroup[] (캐시 우선)
 
   cache/
     store.ts                # ~/.dooray/cache/ 디렉토리 기반 CRUD + TTL 체크
+                            #   MEMBER_GROUPS_DIR = ~/.dooray/cache/member-groups/
     types.ts                # CacheEntry·Cached* 인터페이스
 
   config/
@@ -76,6 +78,8 @@ src/
       list.ts
       members.ts
       workflows.ts
+      groups.ts               # dooray project groups <project>
+      tags.ts                 # dooray project tags <project>
 
     member/
       index.ts              # member 서브커맨드 등록
@@ -140,6 +144,7 @@ class DoorayApiClient {
   getMe(): Promise<MemberDetailResponse>;
   getMemberDetail(memberId): Promise<MemberDetailResponse>;
   getProjects(params?): Promise<ProjectListResponse>;
+  getProjectMemberGroups(projectId, params?): Promise<MemberGroupListResponse>;
   getPosts(projectId, params?): Promise<PostListResponse>;
   getPost(projectId, postId): Promise<PostDetailResponse>;
   getPostStandalone(postId): Promise<PostDetailResponse>;  // GET /project/v1/posts/{postId} — projectId 불명일 때 (ADR-020)

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -53,6 +53,8 @@ dooray doctor                                 # 설정 검증
 | 프로젝트 찾기 | `dooray project list --search <keyword>` |
 | 개인 프로젝트 목록 | `dooray project list --type private` |
 | 프로젝트 멤버 보기 | `dooray project members <project>` 또는 `dooray member list <project>` (이름·organizationMemberId) |
+| 프로젝트 멤버 그룹 목록 | `dooray project groups <project>` (ID / Code) |
+| 프로젝트 태그 목록 | `dooray project tags <project>` (ID / Color / Name / Group / Mandatory) |
 | 멤버 상세 (organizationMemberId) | `dooray member get <organizationMemberId>` (cache 우회, ADR-021) |
 | 업무 목록 조회 | `dooray post list <project>` |
 | 업무 검색 | `dooray post search <project> "<keyword>"` |

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -26,6 +26,7 @@ import type {
   MemberDetailResponse,
   TagListResponse,
   MilestoneListResponse,
+  MemberGroupListResponse,
   WikiListResponse,
   WikiPagesResponse,
   WikiPageResponse,
@@ -369,6 +370,26 @@ export class DoorayApiClient {
           },
         })
         .json<TagListResponse>();
+    } catch (e) {
+      return toDoorayCliError(e);
+    }
+  }
+
+  // ─── Member Groups ──────────────────────────────────
+
+  async getProjectMemberGroups(
+    projectId: string,
+    params?: { page?: number; size?: number },
+  ): Promise<MemberGroupListResponse> {
+    try {
+      return await this.api
+        .get(`project/v1/projects/${projectId}/member-groups`, {
+          searchParams: {
+            ...(params?.page != null && { page: params.page }),
+            ...(params?.size != null && { size: params.size }),
+          },
+        })
+        .json<MemberGroupListResponse>();
     } catch (e) {
       return toDoorayCliError(e);
     }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -361,6 +361,22 @@ export interface ProjectMemberListResponse {
   totalCount?: number;
 }
 
+// ─── Project Member Group ───────────────────────────────
+
+export interface MemberGroup {
+  id: string;
+  code: string;
+  project: ProjectInfo;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MemberGroupListResponse {
+  header: DoorayApiHeader;
+  result: MemberGroup[];
+  totalCount: number;
+}
+
 // ─── Project Workflow ───────────────────────────────────
 
 export interface ProjectWorkflow {

--- a/src/cache/store.ts
+++ b/src/cache/store.ts
@@ -10,6 +10,7 @@ import type {
   CachedTag,
   CachedMilestone,
   CachedWiki,
+  CachedMemberGroup,
 } from "./types.js";
 
 const CACHE_DIR = join(homedir(), ".dooray", "cache");
@@ -20,6 +21,7 @@ const MEMBERS_DIR = join(CACHE_DIR, "members");
 const WORKFLOWS_DIR = join(CACHE_DIR, "workflows");
 const TAGS_DIR = join(CACHE_DIR, "tags");
 const MILESTONES_DIR = join(CACHE_DIR, "milestones");
+const MEMBER_GROUPS_DIR = join(CACHE_DIR, "member-groups");
 const WIKIS_PATH = join(CACHE_DIR, "wikis.json");
 
 // ─── Helpers ──────────────────────────────────────────────
@@ -136,6 +138,20 @@ export async function setMilestones(projectId: string, items: CachedMilestone[])
   await writeJson(milestonesPath(projectId), { updatedAt: now(), data: items } satisfies CacheEntry<CachedMilestone[]>);
 }
 
+// ─── Member Groups (per project) ─────────────────────────
+
+function memberGroupsPath(projectId: string): string {
+  return join(MEMBER_GROUPS_DIR, `${projectId}.json`);
+}
+
+export async function getMemberGroups(projectId: string): Promise<CacheEntry<CachedMemberGroup[]> | null> {
+  return readJson<CacheEntry<CachedMemberGroup[]>>(memberGroupsPath(projectId));
+}
+
+export async function setMemberGroups(projectId: string, items: CachedMemberGroup[]): Promise<void> {
+  await writeJson(memberGroupsPath(projectId), { updatedAt: now(), data: items } satisfies CacheEntry<CachedMemberGroup[]>);
+}
+
 // ─── Wikis ────────────────────────────────────────────────
 
 export async function getWikis(): Promise<CacheEntry<CachedWiki[]> | null> {
@@ -164,6 +180,7 @@ export async function getCacheStats(): Promise<{
   workflowProjectCount: number;
   tagProjectCount: number;
   milestoneProjectCount: number;
+  memberGroupProjectCount: number;
   me: CachedMe | null;
 }> {
   const projects = await getProjects();
@@ -193,7 +210,13 @@ export async function getCacheStats(): Promise<{
     milestoneProjectCount = files.filter((f) => f.endsWith(".json")).length;
   } catch { /* dir doesn't exist */ }
 
+  let memberGroupProjectCount = 0;
+  try {
+    const files = await readdir(MEMBER_GROUPS_DIR);
+    memberGroupProjectCount = files.filter((f) => f.endsWith(".json")).length;
+  } catch { /* dir doesn't exist */ }
+
   const me = await getMe();
 
-  return { projectCount, memberProjectCount, workflowProjectCount, tagProjectCount, milestoneProjectCount, me: me?.data ?? null };
+  return { projectCount, memberProjectCount, workflowProjectCount, tagProjectCount, milestoneProjectCount, memberGroupProjectCount, me: me?.data ?? null };
 }

--- a/src/cache/types.ts
+++ b/src/cache/types.ts
@@ -38,6 +38,7 @@ export const RESOLVER_FETCH_PAGE_SIZE = 100;
 export interface CachedTag {
   id: string;
   name: string;
+  color: string;                 // 태그 색상 (hex, 예: "ffcedd")
   groupId: string | null;        // tagGroup.id (null이면 미소속)
   groupName: string | null;
   groupMandatory: boolean;       // mandatory 검증에 필요
@@ -47,6 +48,13 @@ export interface CachedTag {
 export interface CachedMilestone {
   id: string;
   name: string;
+}
+
+export const MEMBER_GROUPS_TTL_MS = 86_400_000; // 24h
+
+export interface CachedMemberGroup {
+  id: string;
+  code: string;
 }
 
 export const WIKIS_TTL_MS = 86_400_000; // 24h — wiki home은 거의 불변

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -45,6 +45,7 @@ export const doctorCommand = new Command("doctor")
     console.log(`  워크플로우: ${stats.workflowProjectCount}개 프로젝트`);
     console.log(`  Tag 캐시 (프로젝트 수): ${stats.tagProjectCount}`);
     console.log(`  Milestone 캐시 (프로젝트 수): ${stats.milestoneProjectCount}`);
+    console.log(`  Member Group 캐시 (프로젝트 수): ${stats.memberGroupProjectCount}`);
 
     // Claude Code 스킬 검증
     const claudeDir = path.join(

--- a/src/commands/project/groups.ts
+++ b/src/commands/project/groups.ts
@@ -1,0 +1,28 @@
+import { Command } from "commander";
+import { getConfigOrThrow } from "../../config/store.js";
+import { DoorayApiClient } from "../../api/client.js";
+import { resolveProject } from "../../resolvers/project.js";
+import { ensureMemberGroups } from "../../resolvers/member-group.js";
+import { output, type OutputOptions } from "../../formatters/table.js";
+import { startSpinner, stopSpinner } from "../../utils/spinner.js";
+
+export const projectGroupsCommand = new Command("groups")
+  .description("프로젝트 멤버 그룹 목록 조회")
+  .argument("<project>", "프로젝트 코드 또는 ID")
+  .action(async (project: string) => {
+    const globalOpts = projectGroupsCommand.optsWithGlobals() as OutputOptions;
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+
+    startSpinner("멤버 그룹 목록 조회 중...");
+    const projectId = await resolveProject(client, project);
+    const groups = await ensureMemberGroups(client, projectId);
+    stopSpinner(true, "멤버 그룹 목록 조회 완료");
+
+    output(globalOpts, {
+      headers: ["ID", "Code"],
+      rows: groups.map((g) => [g.id, g.code]),
+      raw: groups,
+      ids: groups.map((g) => g.id),
+    });
+  });

--- a/src/commands/project/tags.ts
+++ b/src/commands/project/tags.ts
@@ -1,0 +1,34 @@
+import { Command } from "commander";
+import { getConfigOrThrow } from "../../config/store.js";
+import { DoorayApiClient } from "../../api/client.js";
+import { resolveProject } from "../../resolvers/project.js";
+import { ensureTags } from "../../resolvers/tag.js";
+import { output, type OutputOptions } from "../../formatters/table.js";
+import { startSpinner, stopSpinner } from "../../utils/spinner.js";
+
+export const projectTagsCommand = new Command("tags")
+  .description("프로젝트 태그 목록 조회")
+  .argument("<project>", "프로젝트 코드 또는 ID")
+  .action(async (project: string) => {
+    const globalOpts = projectTagsCommand.optsWithGlobals() as OutputOptions;
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+
+    startSpinner("태그 목록 조회 중...");
+    const projectId = await resolveProject(client, project);
+    const tags = await ensureTags(client, projectId);
+    stopSpinner(true, "태그 목록 조회 완료");
+
+    output(globalOpts, {
+      headers: ["ID", "Color", "Name", "Group", "Mandatory"],
+      rows: tags.map((t) => [
+        t.id,
+        t.color,
+        t.name,
+        t.groupName ?? "",
+        t.groupMandatory ? "Y" : "",
+      ]),
+      raw: tags,
+      ids: tags.map((t) => t.id),
+    });
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import { setupCommand } from "./commands/setup.js";
 import { projectListCommand } from "./commands/project/list.js";
 import { projectMembersCommand } from "./commands/project/members.js";
 import { projectWorkflowsCommand } from "./commands/project/workflows.js";
+import { projectGroupsCommand } from "./commands/project/groups.js";
+import { projectTagsCommand } from "./commands/project/tags.js";
 import { postListCommand } from "./commands/post/list.js";
 import { postSearchCommand } from "./commands/post/search.js";
 import { postGetCommand } from "./commands/post/get.js";
@@ -59,6 +61,8 @@ const projectCommand = new Command("project").description("프로젝트 관련 �
 projectCommand.addCommand(projectListCommand);
 projectCommand.addCommand(projectMembersCommand);
 projectCommand.addCommand(projectWorkflowsCommand);
+projectCommand.addCommand(projectGroupsCommand);
+projectCommand.addCommand(projectTagsCommand);
 
 // post 커맨드 그룹
 const postCommand = new Command("post").description("업무 관련 명령");

--- a/src/resolvers/member-group.ts
+++ b/src/resolvers/member-group.ts
@@ -1,0 +1,31 @@
+import { DoorayApiClient } from "../api/client.js";
+import type { CachedMemberGroup } from "../cache/types.js";
+import { getMemberGroups, setMemberGroups, isExpired } from "../cache/store.js";
+import { MEMBER_GROUPS_TTL_MS, RESOLVER_FETCH_PAGE_SIZE } from "../cache/types.js";
+
+async function fetchAllMemberGroups(client: DoorayApiClient, projectId: string): Promise<CachedMemberGroup[]> {
+  const all: CachedMemberGroup[] = [];
+  let page = 0;
+  const size = RESOLVER_FETCH_PAGE_SIZE;
+  while (true) {
+    const res = await client.getProjectMemberGroups(projectId, { page, size });
+    for (const g of res.result) {
+      all.push({ id: g.id, code: g.code });
+    }
+    const total = res.totalCount ?? all.length;
+    if (all.length >= total) break;
+    page++;
+  }
+  return all;
+}
+
+export async function ensureMemberGroups(
+  client: DoorayApiClient,
+  projectId: string,
+): Promise<CachedMemberGroup[]> {
+  const entry = await getMemberGroups(projectId);
+  if (entry && !isExpired(entry.updatedAt, MEMBER_GROUPS_TTL_MS)) return entry.data;
+  const items = await fetchAllMemberGroups(client, projectId);
+  await setMemberGroups(projectId, items);
+  return items;
+}

--- a/src/resolvers/tag.ts
+++ b/src/resolvers/tag.ts
@@ -16,6 +16,7 @@ async function fetchAllTags(client: DoorayApiClient, projectId: string): Promise
       all.push({
         id: t.id,
         name: t.name ?? "",
+        color: t.color ?? "",
         groupId: t.tagGroup?.id ?? null,
         groupName: t.tagGroup?.name ?? null,
         groupMandatory: t.tagGroup?.mandatory ?? false,

--- a/tasks/014-feat-project-groups-tags/index.json
+++ b/tasks/014-feat-project-groups-tags/index.json
@@ -2,8 +2,8 @@
   "name": "014-feat-project-groups-tags",
   "description": "Issue #20 — `dooray project groups`/`project tags` 명령 신설. groups MVP는 ID+Code만(Members는 후속 --with-members), tags는 010의 캐시·resolver 재사용하되 CachedTag에 color 필드 추가. project members/workflows 패턴 답습.",
   "created_at": "2026-04-28T00:00:00Z",
-  "status": "pending",
-  "current_phase": 1,
+  "status": "completed",
+  "current_phase": 3,
   "total_phases": 3,
   "error_message": null,
   "blocked_reason": null,
@@ -12,23 +12,23 @@
       "number": 1,
       "title": "API/types/cache/resolver — member-groups 신규 + CachedTag color 추가",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 2,
       "title": "project groups/tags 명령 + formatter + index.ts 등록 + README/SKILL.md 갱신",
       "file": "phase-02.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 3,
       "title": "빌드 + smoke + task 완료 처리",
       "file": "phase-03.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],
-  "updated_at": "2026-04-28T00:00:00Z"
+  "updated_at": "2026-04-28T12:01:00Z"
 }


### PR DESCRIPTION
## Summary
- `dooray project groups <project>` — 멤버 그룹 ID/Code 목록 (MVP, members는 후속 `--with-members`)
- `dooray project tags <project>` — 태그 ID/Color/Name/Group/Mandatory 목록
- `CachedTag`에 `color` 필드 추가 (010 캐시 invalidation: `dooray cache clear`)

## Changes
- `src/api/{types,client}.ts`: `MemberGroup` / `MemberGroupListResponse` + `getProjectMemberGroups`
- `src/cache/{types,store}.ts`: `MEMBER_GROUPS_TTL_MS`, `CachedMemberGroup`, member-groups/ 캐시 디렉토리, `memberGroupProjectCount`
- `src/resolvers/member-group.ts` (신규), `src/resolvers/tag.ts`: color 채우기
- `src/commands/project/{groups,tags}.ts` (신규) + `src/index.ts` 등록
- `src/commands/doctor.ts`: Member Group 캐시 라인
- README.md / `skills/dooray-cli/SKILL.md` / `docs/code-architecture.md` 갱신

## Pipeline
- critic APPROVE (opus)
- executor sonnet, FIX (RESOLVER_FETCH_PAGE_SIZE 적용) → code-reviewer PASS
- docs-verifier UPDATE (code-architecture.md 4개 섹션) → 재검증 PASS

## Test plan
- [x] `pnpm run build` (134.15 KB)
- [x] `pnpm test` (30 tests passed)
- [x] `node dist/index.js project --help` → groups/tags 노출
- [x] `node dist/index.js doctor` → Member Group 캐시 라인 노출
- [ ] 실호출: `project groups <project>` (API 키 필요)
- [ ] 실호출: `cache clear && project tags <project>` → Color 컬럼 hex 확인

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)