### PR TITLE
feat(commands): add --mention/--mention-group to post comment add/edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,32 @@ dooray post comment add tc-ocr 42 --body-file ./comment.md
 
 > table 출력의 Creator 컬럼은 프로젝트 멤버 캐시로 자동 enrich되며, `--json`은 raw 응답을 유지한다 (ADR-021).
 
+#### 멘션 (comment add / comment edit)
+
+`--mention <name>` (반복), `--mention-group <code>` (반복)으로 본문 앞에 멘션 마크업을 자동 prepend한다.
+
+```bash
+# 멤버 멘션 1명
+dooray post comment add P 1 --mention 홍길동 --body "확인 부탁드립니다"
+
+# 여러 명
+dooray post comment add P 1 --mention 홍길동 --mention 김철수 --body "..."
+
+# 그룹 멘션
+dooray post comment add P 1 --mention-group 개발 --body "검토 요청"
+
+# 멤버 + 그룹 혼합
+dooray post comment add P 1 \
+  --mention 홍길동 \
+  --mention-group 개발 \
+  --body "검토 부탁드립니다"
+
+# comment edit에도 동일 옵션 사용 가능
+dooray post comment edit P 1 <commentId> --mention 홍길동 --body "수정 내용"
+```
+
+> 이전 버전 캐시는 orgId가 없으므로 첫 호출 시 자동 갱신됩니다 (또는 `dooray cache clear`).
+
 #### comment list 필터 옵션
 
 ```bash

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -29,7 +29,7 @@ src/
     types.ts                # 모든 API 요청/응답 타입
 
   resolvers/
-    me.ts                   # /common/v1/members/me → CachedMe
+    me.ts                   # /common/v1/members/me → CachedMe (id·name·orgId; orgId 없으면 캐시 갱신)
     project.ts              # code·id → projectId
     member.ts               # name → organizationMemberId + lookupMemberName / buildMemberNameMap (ADR-021)
     workflow.ts             # name·class → workflowId
@@ -67,6 +67,7 @@ src/
     body-input.ts           # --body / --body-file → string (stdin "-" + 충돌 가드)
     dooray-url.ts           # https://*.dooray.com/task/to/<postId> URL parser (ADR-020)
     comment-enrich.ts       # PostComment[] Creator 이름 채우기 (ADR-021, immutable)
+    mention.ts              # 멤버·그룹 멘션 마크업 빌더 + prependMentions (Issue #25)
 
   commands/
     setup.ts                # dooray setup — 대화형 초기 설정 마법사 (스킬 설치 포함)

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -261,6 +261,19 @@ dooray post comment latest <project> <number>
 
 ---
 
+## 멘션 자동 작성 (post comment add/edit)
+
+`--mention <name>` (반복) 또는 `--mention-group <code>` (반복)으로 본문 앞에 멘션 마크업을 자동 prepend한다. 아래 "Dooray 마크다운 링크 형식" 섹션의 URL 형식을 자동 출력한다.
+
+```bash
+dooray post comment add P 1 --mention 홍길동 --mention-group 개발 --body "..."
+# 결과 본문: [@홍길동](dooray://orgId/members/m1 "member") [@P/개발](dooray://orgId/member-groups/g1) ...
+```
+
+- 이름 부분일치 지원 (모호하면 에러 + 후보 목록 출력)
+- 멤버 먼저, 그룹 다음 순서 고정
+- comment edit에도 동일 옵션 사용 (`$EDITOR` 모드에서는 EDITOR 진입 전에 prepend)
+
 ## Dooray 마크다운 링크 형식 (멤버·그룹·업무 멘션)
 
 댓글/본문 작성 시 다음 형식으로 마크업하면 Dooray 앱이 인식해 inline 멘션·navigation으로 렌더링한다. ID는 본인 환경 값으로 채워 사용 — `dooray member get` / `project groups` / `post get` 등으로 조회.

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -24,6 +24,7 @@ import type {
   ProjectMemberListResponse,
   ProjectWorkflowListResponse,
   MemberDetailResponse,
+  MeResponse,
   TagListResponse,
   MilestoneListResponse,
   MemberGroupListResponse,
@@ -131,11 +132,11 @@ export class DoorayApiClient {
 
   // ─── Me ─────────────────────────────────────────────
 
-  async getMe(): Promise<MemberDetailResponse> {
+  async getMe(): Promise<MeResponse> {
     try {
       return await this.api
         .get("common/v1/members/me")
-        .json<MemberDetailResponse>();
+        .json<MeResponse>();
     } catch (e) {
       return toDoorayCliError(e);
     }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -355,6 +355,18 @@ export interface MemberDetail {
 
 export type MemberDetailResponse = DoorayApiResponse<MemberDetail>;
 
+export interface MeDetail extends MemberDetail {
+  defaultOrganization: { id: string };
+  idProviderType?: string;
+  idProviderUserId?: string;
+  locale?: string;
+  timezoneName?: string;
+  nativeName?: string;
+  displayMemberId?: string;
+}
+
+export type MeResponse = DoorayApiResponse<MeDetail>;
+
 export interface ProjectMemberListResponse {
   header: DoorayApiHeader;
   result: ProjectMember[];

--- a/src/cache/types.ts
+++ b/src/cache/types.ts
@@ -11,6 +11,7 @@ export interface CacheEntry<T> {
 export interface CachedMe {
   id: string;
   name: string;
+  orgId: string;
 }
 
 export interface CachedProject {

--- a/src/commands/post/comment/add.ts
+++ b/src/commands/post/comment/add.ts
@@ -7,6 +7,10 @@ import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
 import { readBodyInputOrNull } from "../../../utils/body-input.js";
 import type { OutputOptions } from "../../../formatters/table.js";
 import { printJson } from "../../../formatters/table.js";
+import { resolveMember, buildMemberNameMap } from "../../../resolvers/member.js";
+import { resolveMemberGroup } from "../../../resolvers/member-group.js";
+import { ensureMe } from "../../../resolvers/me.js";
+import { prependMentions } from "../../../utils/mention.js";
 
 export const commentAddCommand = new Command("add")
   .description("댓글 추가")
@@ -16,6 +20,18 @@ export const commentAddCommand = new Command("add")
   .option("--url <url>", "Dooray 업무 URL (project/post-number 대신)")
   .option("--body <text>", "댓글 본문 (- 입력 시 stdin에서 읽기)")
   .option("--body-file <path>", "본문 파일 경로 (- 입력 시 stdin에서 읽기)")
+  .option(
+    "--mention <name>",
+    "멤버 멘션 (반복 가능, 이름 부분일치)",
+    (value: string, prev: string[]) => [...prev, value],
+    [] as string[],
+  )
+  .option(
+    "--mention-group <code>",
+    "그룹 멘션 (반복 가능, code 부분일치)",
+    (value: string, prev: string[]) => [...prev, value],
+    [] as string[],
+  )
   .action(async (project, postNumberStr, opts) => {
     const globalOpts = commentAddCommand.optsWithGlobals() as OutputOptions;
     const config = await getConfigOrThrow();
@@ -32,12 +48,36 @@ export const commentAddCommand = new Command("add")
     }
 
     startSpinner("댓글 추가 중...");
-    const { projectId, postId } = await resolvePostInput(client, {
+    const { projectId, postId, projectCode } = await resolvePostInput(client, {
       projectArg: project,
       postNumberArg: postNumberStr,
       idOpt: opts.id,
       urlOpt: opts.url,
     });
+
+    const mentionInputs: string[] = (opts.mention ?? []).filter((s: string) => s.length > 0);
+    const groupInputs: string[] = (opts.mentionGroup ?? []).filter((s: string) => s.length > 0);
+
+    if (mentionInputs.length > 0 || groupInputs.length > 0) {
+      const me = await ensureMe(client);
+      const memberIds = await Promise.all(
+        mentionInputs.map((name) => resolveMember(client, projectId, name)),
+      );
+      const nameMap = await buildMemberNameMap(client, projectId);
+      const members = memberIds.map((memberId) => ({
+        memberId,
+        name: nameMap.get(memberId) ?? memberId,
+      }));
+
+      const groups = await Promise.all(
+        groupInputs.map(async (code) => {
+          const g = await resolveMemberGroup(client, projectId, code);
+          return { groupId: g.id, code: g.code, projectCode };
+        }),
+      );
+      bodyContent = prependMentions(bodyContent, members, groups, me);
+    }
+
     const res = await client.createPostComment(projectId, postId, {
       body: { mimeType: "text/x-markdown", content: bodyContent },
     });

--- a/src/commands/post/comment/edit.ts
+++ b/src/commands/post/comment/edit.ts
@@ -7,6 +7,10 @@ import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
 import { readBodyInputOrNull } from "../../../utils/body-input.js";
 import { DoorayCliError } from "../../../utils/errors.js";
 import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
+import { resolveMember, buildMemberNameMap } from "../../../resolvers/member.js";
+import { resolveMemberGroup } from "../../../resolvers/member-group.js";
+import { ensureMe } from "../../../resolvers/me.js";
+import { prependMentions } from "../../../utils/mention.js";
 
 export const commentEditCommand = new Command("edit")
   .description("댓글 수정 ($EDITOR 또는 --body 옵션)")
@@ -18,6 +22,18 @@ export const commentEditCommand = new Command("edit")
   .option("--comment-id <commentId>", "댓글 ID (positional 대체)")
   .option("--body <text>", "댓글 본문 변경 (- 입력 시 stdin, non-interactive)")
   .option("--body-file <path>", "본문 파일 경로 (- 입력 시 stdin, non-interactive)")
+  .option(
+    "--mention <name>",
+    "멤버 멘션 (반복 가능, 이름 부분일치)",
+    (value: string, prev: string[]) => [...prev, value],
+    [] as string[],
+  )
+  .option(
+    "--mention-group <code>",
+    "그룹 멘션 (반복 가능, code 부분일치)",
+    (value: string, prev: string[]) => [...prev, value],
+    [] as string[],
+  )
   .action(async (arg1, arg2, arg3, opts) => {
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
@@ -69,7 +85,7 @@ export const commentEditCommand = new Command("edit")
     }
 
     startSpinner("댓글 조회 중...");
-    const { projectId, postId } = await resolvePostInput(client, {
+    const { projectId, postId, projectCode } = await resolvePostInput(client, {
       projectArg,
       postNumberArg,
       idOpt: opts.id,
@@ -84,17 +100,45 @@ export const commentEditCommand = new Command("edit")
       process.exit(1);
     }
 
+    // 멘션 옵션 처리
+    const mentionInputs: string[] = (opts.mention ?? []).filter((s: string) => s.length > 0);
+    const groupInputs: string[] = (opts.mentionGroup ?? []).filter((s: string) => s.length > 0);
+
+    let mentionPrefix = "";
+    if (mentionInputs.length > 0 || groupInputs.length > 0) {
+      const me = await ensureMe(client);
+      const memberIds = await Promise.all(
+        mentionInputs.map((name) => resolveMember(client, projectId, name)),
+      );
+      const nameMap = await buildMemberNameMap(client, projectId);
+      const members = memberIds.map((memberId) => ({
+        memberId,
+        name: nameMap.get(memberId) ?? memberId,
+      }));
+
+      const groups = await Promise.all(
+        groupInputs.map(async (code) => {
+          const g = await resolveMemberGroup(client, projectId, code);
+          return { groupId: g.id, code: g.code, projectCode };
+        }),
+      );
+      mentionPrefix = prependMentions("", members, groups, me).trimEnd();
+    }
+
     let edited = await readBodyInputOrNull(opts);
 
     if (edited == null) {
       // Interactive mode: $EDITOR
-      const original = comment.body.content;
-      edited = await openInEditor(original);
+      const rawContent = comment.body.content;
+      const editorSeed = mentionPrefix ? mentionPrefix + " " + rawContent : rawContent;
+      edited = await openInEditor(editorSeed);
 
-      if (original === edited) {
+      if (rawContent === edited) {
         process.stdout.write("변경사항 없음\n");
         return;
       }
+    } else if (mentionPrefix) {
+      edited = mentionPrefix + " " + edited;
     }
 
     startSpinner("댓글 수정 중...");

--- a/src/resolvers/me.ts
+++ b/src/resolvers/me.ts
@@ -2,14 +2,27 @@ import { DoorayApiClient } from "../api/client.js";
 import type { CachedMe } from "../cache/types.js";
 import { getMe, setMe, isExpired } from "../cache/store.js";
 import { ME_TTL_MS } from "../cache/types.js";
+import { DoorayCliError } from "../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../utils/exit-codes.js";
 
 export async function ensureMe(client: DoorayApiClient): Promise<CachedMe> {
   const entry = await getMe();
-  if (entry && !isExpired(entry.updatedAt, ME_TTL_MS)) {
+  if (entry && !isExpired(entry.updatedAt, ME_TTL_MS) && entry.data.orgId) {
     return entry.data;
   }
   const res = await client.getMe();
-  const me: CachedMe = { id: res.result.id, name: res.result.name };
-  await setMe(me);
-  return me;
+  const orgId = res.result.defaultOrganization?.id ?? "";
+  if (!orgId) {
+    throw new DoorayCliError(
+      "orgId를 확인할 수 없습니다 (getMe 응답에 defaultOrganization.id 누락). dooray cache clear 후 재시도하세요.",
+      EXIT_PARAM_ERROR,
+    );
+  }
+  const cached: CachedMe = {
+    id: res.result.id,
+    name: res.result.name,
+    orgId,
+  };
+  await setMe(cached);
+  return cached;
 }

--- a/src/resolvers/member-group.ts
+++ b/src/resolvers/member-group.ts
@@ -2,6 +2,7 @@ import { DoorayApiClient } from "../api/client.js";
 import type { CachedMemberGroup } from "../cache/types.js";
 import { getMemberGroups, setMemberGroups, isExpired } from "../cache/store.js";
 import { MEMBER_GROUPS_TTL_MS, RESOLVER_FETCH_PAGE_SIZE } from "../cache/types.js";
+import { matchByName } from "./match.js";
 
 async function fetchAllMemberGroups(client: DoorayApiClient, projectId: string): Promise<CachedMemberGroup[]> {
   const all: CachedMemberGroup[] = [];
@@ -28,4 +29,17 @@ export async function ensureMemberGroups(
   const items = await fetchAllMemberGroups(client, projectId);
   await setMemberGroups(projectId, items);
   return items;
+}
+
+export async function resolveMemberGroup(
+  client: DoorayApiClient,
+  projectId: string,
+  input: string,
+): Promise<{ id: string; code: string }> {
+  const groups = await ensureMemberGroups(client, projectId);
+  // CachedMemberGroup은 { id, code } — name 필드 없음. matchByName은 name 필드 사용
+  // → 어댑터: code를 name처럼 사용
+  const adapter = groups.map((g) => ({ name: g.code, id: g.id, code: g.code }));
+  const match = matchByName(adapter, input, "그룹", (g) => `${g.code} (${g.id})`);
+  return { id: match.id, code: match.code };
 }

--- a/src/utils/mention.test.ts
+++ b/src/utils/mention.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { buildMemberMention, buildGroupMention, prependMentions } from "./mention.js";
+
+const ME = { id: "100", name: "본인", orgId: "1" };
+
+describe("buildMemberMention", () => {
+  it("본인이면 me title", () => {
+    expect(buildMemberMention({ memberId: "100", name: "본인" }, ME))
+      .toBe('[@본인](dooray://1/members/100 "me")');
+  });
+  it("타인이면 member title", () => {
+    expect(buildMemberMention({ memberId: "200", name: "홍길동" }, ME))
+      .toBe('[@홍길동](dooray://1/members/200 "member")');
+  });
+});
+
+describe("buildGroupMention", () => {
+  it("project/code 형식 + title 없음", () => {
+    expect(buildGroupMention({ groupId: "g1", code: "개발", projectCode: "P" }, ME))
+      .toBe("[@P/개발](dooray://1/member-groups/g1)");
+  });
+});
+
+describe("prependMentions", () => {
+  it("본문 앞에 prepend, 공백 구분", () => {
+    const out = prependMentions(
+      "확인 부탁드립니다",
+      [{ memberId: "200", name: "홍길동" }],
+      [{ groupId: "g1", code: "개발", projectCode: "P" }],
+      ME,
+    );
+    expect(out).toBe(
+      '[@홍길동](dooray://1/members/200 "member") [@P/개발](dooray://1/member-groups/g1) 확인 부탁드립니다',
+    );
+  });
+  it("멘션 없으면 본문 그대로", () => {
+    expect(prependMentions("본문", [], [], ME)).toBe("본문");
+  });
+  it("빈 본문 + 멘션만 → trailing 공백", () => {
+    expect(prependMentions("", [{ memberId: "200", name: "A" }], [], ME))
+      .toBe('[@A](dooray://1/members/200 "member") ');
+  });
+  it("멤버만 또는 그룹만도 동작", () => {
+    expect(prependMentions("X", [{ memberId: "100", name: "본인" }], [], ME))
+      .toBe('[@본인](dooray://1/members/100 "me") X');
+    expect(prependMentions("X", [], [{ groupId: "g1", code: "개발", projectCode: "P" }], ME))
+      .toBe("[@P/개발](dooray://1/member-groups/g1) X");
+  });
+  it("순서: 멤버 먼저, 그룹 다음", () => {
+    const out = prependMentions(
+      "X",
+      [{ memberId: "200", name: "A" }, { memberId: "300", name: "B" }],
+      [{ groupId: "g1", code: "개발", projectCode: "P" }],
+      ME,
+    );
+    expect(out.indexOf("members/200") < out.indexOf("members/300")).toBe(true);
+    expect(out.indexOf("members/300") < out.indexOf("member-groups/g1")).toBe(true);
+  });
+});

--- a/src/utils/mention.ts
+++ b/src/utils/mention.ts
@@ -1,0 +1,38 @@
+import type { CachedMe } from "../cache/types.js";
+
+export interface MentionMember {
+  memberId: string;
+  name: string;
+}
+
+export interface MentionGroup {
+  groupId: string;
+  code: string;
+  projectCode: string;
+}
+
+export function buildMemberMention(m: MentionMember, me: CachedMe): string {
+  const title = m.memberId === me.id ? "me" : "member";
+  return `[@${m.name}](dooray://${me.orgId}/members/${m.memberId} "${title}")`;
+}
+
+export function buildGroupMention(g: MentionGroup, me: CachedMe): string {
+  return `[@${g.projectCode}/${g.code}](dooray://${me.orgId}/member-groups/${g.groupId})`;
+}
+
+/**
+ * 멤버·그룹 멘션을 본문 앞에 prepend.
+ * 멤버가 먼저, 그룹이 다음. 각각 공백 1칸 구분. 본문이 비어있어도 형식 유지.
+ */
+export function prependMentions(
+  body: string,
+  members: MentionMember[],
+  groups: MentionGroup[],
+  me: CachedMe,
+): string {
+  const parts: string[] = [];
+  for (const m of members) parts.push(buildMemberMention(m, me));
+  for (const g of groups) parts.push(buildGroupMention(g, me));
+  if (parts.length === 0) return body;
+  return parts.join(" ") + " " + body;
+}

--- a/tasks/016-feat-comment-mention/index.json
+++ b/tasks/016-feat-comment-mention/index.json
@@ -2,8 +2,8 @@
   "name": "016-feat-comment-mention",
   "description": "Issue #25 — `post comment add/edit`에 `--mention <name>` (반복) + `--mention-group <code>` (반복) 옵션 추가. 이름→ID resolve + Dooray markdown 형식으로 본문 앞 prepend. orgId는 me 캐시에 저장(getMe.defaultOrganization.id 활용), 본인 vs 타인은 me ID 매칭으로 자동 분기. 014 member-group 캐시 + 012 member resolver 재활용.",
   "created_at": "2026-04-29T00:00:00Z",
-  "status": "pending",
-  "current_phase": 1,
+  "status": "completed",
+  "current_phase": 3,
   "total_phases": 3,
   "error_message": null,
   "blocked_reason": null,
@@ -12,23 +12,23 @@
       "number": 1,
       "title": "API/types/cache — MeDetail.defaultOrganization + CachedMe.orgId + resolveMemberGroup",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 2,
       "title": "mention helper + comment add/edit 옵션 통합 + 단위 테스트",
       "file": "phase-02.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 3,
       "title": "README/SKILL.md + 빌드/시나리오 검증 + task 완료",
       "file": "phase-03.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],
-  "updated_at": "2026-04-29T00:00:00Z"
+  "updated_at": "2026-04-29T08:14:45Z"
 }

--- a/tasks/016-feat-comment-mention/phase-01.md
+++ b/tasks/016-feat-comment-mention/phase-01.md
@@ -34,7 +34,7 @@ Issue #25 — 멘션 마크업 URL이 `dooray://{orgId}/...` 형식이라 orgId 
 
 `GET /common/v1/members/{id}` 는 `defaultOrganization` 미포함.
 
-## 작업 목록 (4개)
+## 작업 목록 (5개)
 
 ### 1) `src/api/types.ts` — MeDetail 별도 타입 + 응답 타입
 
@@ -85,7 +85,7 @@ export interface CachedMe {
 
 > 010(`CachedTag.color`) 패턴 답습. 이전 캐시는 `orgId` 미포함 — `cache clear`로 재생성. README 안내(phase 3).
 
-**`src/resolvers/me.ts` 신규**:
+**`src/resolvers/me.ts` 수정** (이미 존재 — 기존 `ensureMe`는 `{ id, name }`만 반환. 본문을 아래 패치로 교체. `getMe`/`setMe` 시그니처는 무변경 — `CachedMe` 타입 확장만으로 자동 전파):
 ```ts
 import { DoorayApiClient } from "../api/client.js";
 import type { CachedMe } from "../cache/types.js";

--- a/tasks/016-feat-comment-mention/phase-02.md
+++ b/tasks/016-feat-comment-mention/phase-02.md
@@ -104,6 +104,10 @@ describe("prependMentions", () => {
   it("멘션 없으면 본문 그대로", () => {
     expect(prependMentions("본문", [], [], ME)).toBe("본문");
   });
+  it("빈 본문 + 멘션만 → trailing 공백", () => {
+    expect(prependMentions("", [{ memberId: "200", name: "A" }], [], ME))
+      .toBe('[@A](dooray://1/members/200 "member") ');
+  });
   it("멤버만 또는 그룹만도 동작", () => {
     expect(prependMentions("X", [{ memberId: "100", name: "본인" }], [], ME))
       .toBe('[@본인](dooray://1/members/100 "me") X');
@@ -128,7 +132,7 @@ describe("prependMentions", () => {
 기존 흐름 (`bodyContent` 결정 → `resolvePostInput` → `createPostComment`) 사이에 mention 처리 끼워넣기:
 
 ```ts
-import { resolveMember } from "../../../resolvers/member.js";
+import { resolveMember, buildMemberNameMap } from "../../../resolvers/member.js";
 import { resolveMemberGroup } from "../../../resolvers/member-group.js";
 import { ensureMe } from "../../../resolvers/me.js";
 import { prependMentions } from "../../../utils/mention.js";
@@ -149,25 +153,30 @@ import { prependMentions } from "../../../utils/mention.js";
 .action(async (project, postNumberStr, opts) => {
   // 기존 config/client/bodyContent 흐름 그대로
 
-  // bodyContent 결정 후, resolvePostInput 후, createPostComment 직전에:
+  // bodyContent 결정 후, resolvePostInput 결과 destructure 시 projectCode 함께 추출:
+  const { projectId, postId, projectCode } = await resolvePostInput(client, { ... });
+
+  // createPostComment 직전에:
   const mentionInputs: string[] = (opts.mention ?? []).filter((s: string) => s.length > 0);
   const groupInputs: string[] = (opts.mentionGroup ?? []).filter((s: string) => s.length > 0);
 
   if (mentionInputs.length > 0 || groupInputs.length > 0) {
     const me = await ensureMe(client);
-    const members = await Promise.all(
-      mentionInputs.map(async (name) => {
-        const memberId = await resolveMember(client, projectId, name);
-        // resolveMember는 ID만 반환 — name은 입력값 그대로 마크업 표시
-        return { memberId, name };
-      }),
+    // 1차: 입력 → memberId resolve
+    const memberIds = await Promise.all(
+      mentionInputs.map((name) => resolveMember(client, projectId, name)),
     );
-    // 그룹 코드 resolve — projectCode는 입력값(부분일치 매칭된 code)으로 표시
+    // 2차: id → 정식 name lookup (사용자 입력이 부분일치 raw일 수 있음 → 정식 표시명으로 정규화)
+    const nameMap = await buildMemberNameMap(client, projectId, memberIds);
+    const members = memberIds.map((memberId) => ({
+      memberId,
+      name: nameMap.get(memberId) ?? memberId,
+    }));
+
     const groups = await Promise.all(
       groupInputs.map(async (code) => {
         const g = await resolveMemberGroup(client, projectId, code);
-        // projectCode는 명령 첫 인자 또는 resolvePostInput.projectCode (011 결과)
-        return { groupId: g.id, code: g.code, projectCode: resolved.projectCode };
+        return { groupId: g.id, code: g.code, projectCode };
       }),
     );
     bodyContent = prependMentions(bodyContent, members, groups, me);
@@ -177,13 +186,35 @@ import { prependMentions } from "../../../utils/mention.js";
 });
 ```
 
-> `resolved.projectCode`: `resolvePostInput`(011) 반환값에 `projectCode` 있는지 확인. 없으면 `resolveProject` 결과 또는 첫 positional 그대로 사용. 본 phase 작성 시 phase 1과 011 산출물 시그니처 정확히 점검.
+> `resolvePostInput.ResolvedPostInput.projectCode` 존재 확인됨 (`src/resolvers/post-input.ts:18`). destructure만 추가.
+> `buildMemberNameMap`은 `src/resolvers/member.ts:89`에 존재 — `ensureMembers` 캐시를 한 번에 활용 (네트워크 추가 호출 없음).
 
 ### 3) `src/commands/post/comment/edit.ts` — 동일 패턴
 
-`add.ts`와 같이 옵션 추가 + body 결정 직후 prepend. 기존 `--title`/`--body`/`--body-file` 흐름은 무변경. edit가 `--body` 미지정 시 기존 본문 fetch하는 흐름이 있으면, fetch된 본문 앞에 prepend (사용자 의도: "기존 본문에 멘션 추가").
+`add.ts`와 같이 옵션 추가. edit는 두 분기:
 
-> edit 본문 fetch 흐름 정확한 형태는 코드 확인 후 결정.
+- **`--body`/`--body-file` 모드** (`readBodyInputOrNull`이 non-null 반환): `edited` 결정 직후 `prependMentions`로 앞에 prepend. add.ts와 동일 패턴.
+- **`$EDITOR` 모드** (`readBodyInputOrNull`이 null → `comment.body.content`로 `original` 채움): **`openInEditor(original)` 호출 직전에** `original`에 prepend. 사용자가 EDITOR에서 멘션 마크업을 직접 보고 편집할 수 있도록.
+
+```ts
+let edited = await readBodyInputOrNull(opts);
+
+// 멘션 옵션 처리 (add.ts와 동일하게 me/members/groups 준비)
+const mentionPrefix = (members.length > 0 || groups.length > 0)
+  ? prependMentions("", members, groups, me).trimEnd()
+  : "";
+
+if (edited == null) {
+  let original = comment.body.content;
+  if (mentionPrefix) original = mentionPrefix + " " + original;
+  edited = await openInEditor(original);
+  if (original === edited) { /* 변경사항 없음 */ }
+} else if (mentionPrefix) {
+  edited = mentionPrefix + " " + edited;
+}
+```
+
+> `prependMentions(body="")` 결과는 `"{mentions} "` (trailing 공백) — `trimEnd()`로 한 번 정리. 빈 본문 + 멘션만인 케이스도 일관된 출력.
 
 ### 4) commander option key 점검
 
@@ -199,14 +230,15 @@ import { prependMentions } from "../../../utils/mention.js";
 - [ ] `node dist/index.js post comment add --help` → `--mention`, `--mention-group` 노출
 - [ ] `node dist/index.js post comment edit --help` → 동일
 - [ ] `grep -c "buildMemberMention\|buildGroupMention\|prependMentions" src/utils/mention.ts` → 3 이상
-- [ ] `grep -c "ensureMe\|resolveMemberGroup\|resolveMember" src/commands/post/comment/{add,edit}.ts` → 6 이상 (각 명령에 3개씩)
+- [ ] `grep -c "ensureMe\|resolveMemberGroup\|resolveMember\|buildMemberNameMap" src/commands/post/comment/add.ts src/commands/post/comment/edit.ts` → 8 이상 (각 명령에 4개씩)
 - [ ] `git diff --stat` — `src/utils/mention.ts(.test.ts)`, `src/commands/post/comment/{add,edit}.ts` 변경
 
 ## 주의사항
 
 - **prepend 위치**: 본문 앞 + 공백 1칸 구분 (`{mentions} {body}`). 이슈 #25 결정사항
 - **멤버 먼저, 그룹 다음** 순서 고정 — 단위 테스트로 가드
-- **본문 비어있으면 기존 에러**: 멘션만 있고 body 없으면 add는 에러 ("빈 댓글은 작성할 수 없습니다"). 멘션은 본문에 부수 효과만
+- **`add.ts`에서 `--body` 미지정 + 멘션만 지정한 케이스**: `bodyContent==null` → `openInEditor("")` 진입. 멘션 prepend는 EDITOR 진입 **전에** 빈 본문에 적용해서 사용자가 멘션 마크업을 보고 편집하도록 (edit.ts와 동일 정책). 사용자가 EDITOR에서 빈 본문으로 저장하면 기존 abort 로직("빈 댓글은 작성할 수 없습니다") 그대로 — 멘션만으로는 댓글 작성 불가
+- **prependMentions의 빈 본문 처리**: `prependMentions("", members, groups, me)`는 `"{mentions} "` (trailing 공백 1) 반환 → 호출자가 `trimEnd()` 또는 그대로 사용. 단위 테스트에 빈 body 케이스 추가
 - **`resolveMember` 부분일치 + 모호 에러는 그대로 throw** — 사용자가 정확한 이름 입력 유도
 - **`resolveMemberGroup`도 동일 패턴** (014 + phase 1)
 - **commander option key**: `--mention-group` → `opts.mentionGroup` (camelCase). README/SKILL.md(phase 3)는 kebab-case로 표기
@@ -215,5 +247,5 @@ import { prependMentions } from "../../../utils/mention.js";
 ## Blocked 조건
 
 - phase 1 산출물(`ensureMe`, `MeDetail`, `resolveMemberGroup`, `CachedMe.orgId`) 부재 → `PHASE_BLOCKED: phase 1 미완료`
-- 011의 `resolvePostInput` 반환값에 `projectCode` 부재 → `PHASE_BLOCKED: projectCode 획득 경로 결정 필요` (대안: 첫 positional 그대로 사용)
-- comment edit의 본문 fetch 흐름이 미존재(`--body` 필수)면 → 동일 패턴 적용, 본 phase에서 별도 분기 불필요
+- `resolvePostInput`이 `projectCode` 반환 중단 → `PHASE_BLOCKED: post-input 시그니처 변경` (현재는 `src/resolvers/post-input.ts:18`에서 보장됨)
+- `buildMemberNameMap` 시그니처 변경 → `PHASE_BLOCKED: member resolver 시그니처 변경`


### PR DESCRIPTION
## Summary
- Issue #25 — `post comment add`, `post comment edit`에 `--mention <name>` (반복) + `--mention-group <code>` (반복) 옵션 추가
- 이름 부분일치 → `buildMemberNameMap`으로 정식 표시명 정규화 후 Dooray markdown 마크업으로 본문 앞 prepend
- `MeDetail.defaultOrganization` → `CachedMe.orgId` 자가치유 (이전 캐시는 첫 호출 시 자동 갱신)
- editor 모드는 `rawContent` 별도 보존으로 멘션 prefix와 변경 감지를 분리

## 변경 파일
- 데이터: `src/api/types.ts`, `src/api/client.ts`, `src/cache/types.ts`, `src/resolvers/me.ts`, `src/resolvers/member-group.ts`
- 신규 유틸: `src/utils/mention.ts` + `mention.test.ts` (8 케이스)
- 명령: `src/commands/post/comment/{add,edit}.ts`
- docs: `README.md`, `skills/dooray-cli/SKILL.md`, `docs/code-architecture.md`

## Test plan
- [x] `pnpm run build` ⚡️ success (143.79 KB)
- [x] `pnpm test` 38 passed (5 files), mention 8 케이스 포함
- [x] `node dist/index.js post comment add --help` → `--mention`, `--mention-group` 노출
- [x] `node dist/index.js post comment edit --help` → 동일
- [ ] 실제 Dooray 환경에서 `--mention 홍길동 --body "확인 부탁드립니다"` 시나리오 검증
- [ ] `--mention` + EDITOR 모드 (본문 미수정/수정) 양 케이스 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)