### PR TITLE
feat(commands): add member search subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,14 @@ dooray project tags <project>                # 태그 목록 (ID / Color / Name 
 
 ```bash
 dooray member list <project>                  # 프로젝트 멤버 목록 (이름·organizationMemberId)
-dooray member get <organizationMemberId>   # 멤버 상세 (cache 우회, ADR-021)
+dooray member get <organizationMemberId>      # 멤버 상세 (cache 우회, ADR-021)
+
+# organization 전체 멤버 검색
+dooray member search 홍길동                   # 이름 검색
+dooray member search --email user@example.com # 이메일 (정확히 일치)
+dooray member search --user-code abc          # 사번 like 검색
+dooray member search --user-code-exact abc123 # 사번 exact match
+dooray member search 김 --size 50 --page 1   # 페이지네이션
 ```
 
 ### 업무

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -86,6 +86,7 @@ src/
       index.ts              # member 서브커맨드 등록
       get.ts                # dooray member get <member-id> (cache 우회, ADR-021)
       list.ts               # dooray member list <project> (project 캐시 활용)
+      search.ts             # dooray member search (org-wide, ad-hoc, 캐시 미사용)
 
     post/
       list.ts

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -56,6 +56,7 @@ dooray doctor                                 # 설정 검증
 | 프로젝트 멤버 그룹 목록 | `dooray project groups <project>` (ID / Code) |
 | 프로젝트 태그 목록 | `dooray project tags <project>` (ID / Color / Name / Group / Mandatory) |
 | 멤버 상세 (organizationMemberId) | `dooray member get <organizationMemberId>` (cache 우회, ADR-021) |
+| organization 전체 멤버 검색 | `dooray member search <keyword>` (이름 기본), `--email`(이메일 exact), `--user-code`(사번 like), `--user-code-exact`(사번 exact), `--page`/`--size` |
 | 업무 목록 조회 | `dooray post list <project>` |
 | 업무 검색 | `dooray post search <project> "<keyword>"` |
 | 업무 상세 보기 | `dooray post get <project> <number>` |
@@ -111,7 +112,8 @@ CLI로 처리 **불가능한** 작업. 아래 항목을 요청받으면 웹 UI �
 3. **업무 번호를 모르면** → `dooray post search <project> "<keyword>"` 로 검색
 4. **워크플로우 이름을 모르면** → `dooray project workflows <project>` 로 확인
 5. **멤버 이름을 모르면** → `dooray member list <project>` (또는 `dooray project members <project>`) 로 확인
-6. **결과를 다음 액션에 사용하려면** → `--json` 플래그로 구조화된 데이터 획득
+6. **org 전체 멤버를 찾으려면** → `dooray member search <keyword>` (이름), `--email <addr>`, `--user-code <code>` 중 하나 사용
+7. **결과를 다음 액션에 사용하려면** → `--json` 플래그로 구조화된 데이터 획득
 
 ---
 
@@ -308,7 +310,7 @@ dooray post comment add P 1 --mention 홍길동 --mention-group 개발 --body ".
 | ID | 조회 |
 |---|---|
 | `orgId` | Dooray 앱/웹 URL에서 추출 (`https://{org}.dooray.com/...`의 도메인 + 별도 확인 필요) |
-| `memberId` | `dooray member get <id>` 또는 `dooray project members <project>` |
+| `memberId` | `dooray member get <id>`, `dooray member search <name>`, `--email <addr>`, `--user-code <code>` 등으로 검색 |
 | `groupId` | `dooray project groups <project>` |
 | `postId` | `dooray post get <project> <number> --json` 의 `id` 필드 |
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -24,6 +24,7 @@ import type {
   ProjectMemberListResponse,
   ProjectWorkflowListResponse,
   MemberDetailResponse,
+  MemberSearchResponse,
   MeResponse,
   TagListResponse,
   MilestoneListResponse,
@@ -77,6 +78,16 @@ export interface GetPostCommentsParams {
 }
 
 export interface GetMembersParams {
+  page?: number;
+  size?: number;
+}
+
+export interface SearchMembersParams {
+  name?: string;
+  externalEmailAddresses?: string;
+  userCode?: string;
+  userCodeExact?: string;
+  idProviderUserId?: string;
   page?: number;
   size?: number;
 }
@@ -339,6 +350,26 @@ export class DoorayApiClient {
       return await this.api
         .get(`common/v1/members/${memberId}`)
         .json<MemberDetailResponse>();
+    } catch (e) {
+      return toDoorayCliError(e);
+    }
+  }
+
+  async searchMembers(params: SearchMembersParams): Promise<MemberSearchResponse> {
+    try {
+      return await this.api
+        .get("common/v1/members", {
+          searchParams: {
+            ...(params.name && { name: params.name }),
+            ...(params.externalEmailAddresses && { externalEmailAddresses: params.externalEmailAddresses }),
+            ...(params.userCode && { userCode: params.userCode }),
+            ...(params.userCodeExact && { userCodeExact: params.userCodeExact }),
+            ...(params.idProviderUserId && { idProviderUserId: params.idProviderUserId }),
+            ...(params.page != null && { page: params.page }),
+            ...(params.size != null && { size: params.size }),
+          },
+        })
+        .json<MemberSearchResponse>();
     } catch (e) {
       return toDoorayCliError(e);
     }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -355,6 +355,12 @@ export interface MemberDetail {
 
 export type MemberDetailResponse = DoorayApiResponse<MemberDetail>;
 
+export interface MemberSearchResponse {
+  header: DoorayApiHeader;
+  result: MemberDetail[];
+  totalCount: number;
+}
+
 export interface MeDetail extends MemberDetail {
   defaultOrganization: { id: string };
   idProviderType?: string;

--- a/src/commands/member/index.ts
+++ b/src/commands/member/index.ts
@@ -1,8 +1,10 @@
 import { Command } from "commander";
 import { memberGetCommand } from "./get.js";
 import { memberListCommand } from "./list.js";
+import { memberSearchCommand } from "./search.js";
 
 export const memberCommand = new Command("member")
   .description("Dooray 멤버 조회");
 memberCommand.addCommand(memberGetCommand);
 memberCommand.addCommand(memberListCommand);
+memberCommand.addCommand(memberSearchCommand);

--- a/src/commands/member/search.ts
+++ b/src/commands/member/search.ts
@@ -1,0 +1,55 @@
+import { Command } from "commander";
+import { getConfigOrThrow } from "../../config/store.js";
+import { DoorayApiClient } from "../../api/client.js";
+import { formatMemberSearchResults } from "../../formatters/member.js";
+import { startSpinner, stopSpinner } from "../../utils/spinner.js";
+import { DoorayCliError } from "../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../utils/exit-codes.js";
+import type { OutputOptions } from "../../formatters/table.js";
+
+export const memberSearchCommand = new Command("search")
+  .description("organization 전체에서 멤버 검색")
+  .argument("[keyword]", "이름 검색어 (--email/--user-code 미지정 시 name으로 검색)")
+  .option("--email <email>", "외부 이메일 (콤마 구분 가능, exact match)")
+  .option("--user-code <code>", "사번 like 검색")
+  .option("--user-code-exact <code>", "사번 exact match")
+  .option("--page <n>", "페이지 (기본 0)", "0")
+  .option("--size <n>", "페이지 크기 (기본 20, max 100)", "20")
+  .action(async (keyword: string | undefined, opts) => {
+    const globalOpts = memberSearchCommand.optsWithGlobals() as OutputOptions;
+
+    // 옵션 검증 — 적어도 하나는 있어야 함
+    const filterCount = [keyword, opts.email, opts.userCode, opts.userCodeExact].filter(Boolean).length;
+    if (filterCount === 0) {
+      throw new DoorayCliError(
+        "검색 조건이 필요합니다. positional <keyword>(=name) 또는 --email/--user-code/--user-code-exact 중 하나 이상.",
+        EXIT_PARAM_ERROR,
+      );
+    }
+    // 보수적 상호배타: keyword(name) + 다른 필터 동시 사용 금지 (Dooray가 AND/OR 처리하는지 doc 불명확)
+    if (keyword && (opts.email || opts.userCode || opts.userCodeExact)) {
+      throw new DoorayCliError(
+        "positional <keyword>(name)와 --email/--user-code/--user-code-exact 옵션은 동시 사용 불가.",
+        EXIT_PARAM_ERROR,
+      );
+    }
+
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+
+    const size = Math.min(Math.max(1, Number(opts.size) || 20), 100);
+    const page = Math.max(0, Number(opts.page) || 0);
+
+    startSpinner("멤버 검색 중...");
+    const res = await client.searchMembers({
+      ...(keyword && { name: keyword }),
+      ...(opts.email && { externalEmailAddresses: opts.email }),
+      ...(opts.userCode && { userCode: opts.userCode }),
+      ...(opts.userCodeExact && { userCodeExact: opts.userCodeExact }),
+      page,
+      size,
+    });
+    stopSpinner(true, `${res.totalCount}건 (이 페이지 ${res.result.length})`);
+
+    formatMemberSearchResults(res.result, globalOpts);
+  });

--- a/src/formatters/member.ts
+++ b/src/formatters/member.ts
@@ -30,3 +30,18 @@ export function formatMemberList(rows: MemberListRow[], opts: OutputOptions): vo
     ids: rows.map((r) => r.id),
   });
 }
+
+export function formatMemberSearchResults(members: MemberDetail[], opts: OutputOptions): void {
+  output(opts, {
+    headers: ["ID", "Name", "UserCode", "Nickname", "Email"],
+    rows: members.map((m) => [
+      m.id,
+      m.name,
+      m.userCode ?? "",
+      m.nickname ?? "",
+      m.externalEmailAddress ?? "",
+    ]),
+    raw: members,
+    ids: members.map((m) => m.id),
+  });
+}

--- a/tasks/017-feat-member-search/index.json
+++ b/tasks/017-feat-member-search/index.json
@@ -2,8 +2,8 @@
   "name": "017-feat-member-search",
   "description": "Issue #26 — `dooray member search <keyword>` 신설. organization-wide 멤버 검색. positional 기본=name, --email/--user-code 옵션. --page/--size 페이지네이션. API 동작 실증 완료(name=keyword 단독 200 OK). 캐시 미도입(ad-hoc 검색).",
   "created_at": "2026-04-29T00:00:00Z",
-  "status": "pending",
-  "current_phase": 1,
+  "status": "completed",
+  "current_phase": 3,
   "total_phases": 3,
   "error_message": null,
   "blocked_reason": null,
@@ -12,23 +12,23 @@
       "number": 1,
       "title": "API client 메서드 + types",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 2,
       "title": "member search 명령 + formatter + 옵션 상호배타 검증",
       "file": "phase-02.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 3,
       "title": "README/SKILL.md + 빌드/시나리오 + task 완료",
       "file": "phase-03.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],
-  "updated_at": "2026-04-29T00:00:00Z"
+  "updated_at": "2026-04-29T09:47:00Z"
 }


### PR DESCRIPTION
## Summary

- `dooray member search` 신설 — organization 전체 멤버를 `/common/v1/members` 엔드포인트로 ad-hoc 검색
- positional `<keyword>` = name 검색, `--email` (이메일 exact), `--user-code` (사번 like), `--user-code-exact` (사번 exact), `--page`/`--size` 페이지네이션
- 옵션 상호배타 사전 검증 — fetch 전 throw로 API 호출 비용 회피
- 캐시 미사용 (ad-hoc 검색이라 ADR-021 캐시 전략 미적용)

Closes #26

## Test plan
- [x] `pnpm run build` 성공
- [x] `pnpm test` 38 passed
- [x] 시나리오 A — `--help`에 5개 옵션 노출
- [x] 시나리오 B — 인자 없음 / positional+옵션 동시 → exit 3
- [ ] 시나리오 C — 실호출 (수동, API 키 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)