### PR TITLE
feat(commands): add feedback --last mode (ADR-023)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ bash scripts/benchmark.sh [project] [post-number] [wiki-page-id]
 - `post create`는 `--tag` (반복) / `--parent` (`code/number` 또는 raw postId) / `--workflow` / `--milestone` 지원. mandatory-tag 그룹은 클라이언트가 사전 검증
 - post 하위 12개 명령(get/edit/done/workflow + comment 4개 + file 5개)은 `<project> <post-number>` 외에도 `--id <postId>` / `--url <url>` / 첫 positional에 Dooray URL 직접 입력 지원. `resolvePostInput` 단일 헬퍼에서 분기
 - `dooray member get/list` 명령으로 표시명 조회. `post comment list` table 출력은 Creator 컬럼을 project 멤버 캐시로 enrich (단 `--json`은 raw 유지)
-- `dooray feedback`은 GitHub issue를 `gh` CLI에 위임해서 생성. baseUrl/시크릿은 자동 메타에 미포함. `--last`(직전 명령 추적)는 후속 이슈로 분리
+- `dooray feedback`은 GitHub issue를 `gh` CLI에 위임해서 생성. baseUrl/시크릿은 자동 메타에 미포함. `--last`로 직전 명령의 sanitized argv + 에러를 본문 상단에 자동 첨부 (opt-in: `dooray config set track-last-run true`, ADR-023)
 - 제목 옵션 이름은 post·wiki 모두 `--title`로 통일 (Issue #8)
 - resolver(멤버·워크플로우·태그·마일스톤)는 정확일치 → 이름 부분일치, 모호하면 에러 + 후보 목록 출력
 - post 목록은 최신순 정렬 (`-createdAt`)

--- a/README.md
+++ b/README.md
@@ -283,6 +283,28 @@ dooray post list <project> --quiet | xargs -I{} dooray post done <project> {}
 cp -r skills/dooray-cli ~/.claude/skills/
 ```
 
+## 피드백 (GitHub Issue 등록)
+
+`dooray feedback` 명령으로 GitHub issue를 직접 등록할 수 있습니다 (`gh` CLI 위임).
+
+```bash
+# 인터랙티브 (제목/본문/라벨 대화형 입력)
+dooray feedback
+
+# 논인터랙티브
+dooray feedback --title "버그 제목" --body "재현 방법"
+
+# --last 모드 (직전 에러 자동 첨부)
+dooray config set track-last-run true   # 1회만, opt-in
+dooray feedback --last                  # 직전 명령 + 에러 자동 첨부 + $EDITOR로 의견 추가
+dooray feedback --last --title "재현" --body "추가 설명" --dry-run  # 미리보기
+
+# 미리보기 (gh 호출 없이 본문 확인)
+dooray feedback --dry-run
+```
+
+> **개인정보 보호 (ADR-023)**: `--last` 모드에서 argv는 `--api-key`/`--token`/`Authorization` 등 시크릿 패턴을 자동 마스킹 후 저장합니다. cwd/env는 미저장.
+
 ## 캐시
 
 프로젝트, 멤버, 워크플로우, 위키 정보는 `~/.dooray/cache/`에 캐시됩니다.

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -46,6 +46,7 @@ src/
     store.ts                # ~/.dooray/cache/ 디렉토리 기반 CRUD + TTL 체크
                             #   MEMBER_GROUPS_DIR = ~/.dooray/cache/member-groups/
     types.ts                # CacheEntry·Cached* 인터페이스
+    last-run.ts             # ~/.dooray/last-run.json 단일 read/write (ADR-023, cache 디렉토리 외부 — cache clear 영향 없음)
 
   config/
     store.ts                # ~/.dooray/config.json CRUD
@@ -68,6 +69,8 @@ src/
     dooray-url.ts           # https://*.dooray.com/task/to/<postId> URL parser (ADR-020)
     comment-enrich.ts       # PostComment[] Creator 이름 채우기 (ADR-021, immutable)
     mention.ts              # 멤버·그룹 멘션 마크업 빌더 + prependMentions (Issue #25)
+    feedback-meta.ts        # CLI 버전·환경 수집 + GitHub issue body 빌더 + buildLastRunBlock (ADR-022, ADR-023)
+    argv-sanitize.ts        # argv 시크릿 패턴 마스킹 (--api-key/--token/--password/Authorization, ADR-023)
 
   commands/
     setup.ts                # dooray setup — 대화형 초기 설정 마법사 (스킬 설치 포함)

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -316,6 +316,22 @@ dooray post comment add P 1 --mention 홍길동 --mention-group 개발 --body ".
 
 ---
 
+## 피드백 (GitHub Issue 등록)
+
+`dooray feedback` 명령으로 dooray-cli GitHub issue를 직접 등록한다 (`gh` CLI 위임).
+
+```bash
+# 논인터랙티브 (non-interactive — 에이전트 자동화용)
+dooray feedback --title "버그 제목" --body "재현 방법" --label "bug"
+
+# --last 모드 (직전 에러 자동 첨부 — track-last-run 활성화 필요)
+dooray config set track-last-run true
+dooray feedback --last --title "에러 제목" --body "추가 설명" --dry-run  # 미리보기
+dooray feedback --last --title "에러 제목" --body "추가 설명"            # 실제 등록
+```
+
+> **참고**: `--last` 모드는 `trackLastRun: true` (ADR-023 opt-in)가 설정된 경우에만 직전 실패 명령이 자동 기록됨. argv는 시크릿 패턴(`--api-key`/`--token`/`Authorization`) 마스킹 후 저장.
+
 ## 에러 핸들링
 
 CLI 에러 발생 시 복구 방법:

--- a/src/cache/last-run.ts
+++ b/src/cache/last-run.ts
@@ -1,0 +1,38 @@
+import { readFile, writeFile, mkdir, rename } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const LAST_RUN_PATH = join(homedir(), ".dooray", "last-run.json");
+
+export interface LastRun {
+  argv: string[];           // sanitized
+  exitCode: number;
+  errorMessage: string;
+  timestamp: string;        // ISO 8601
+}
+
+export async function readLastRun(): Promise<LastRun | null> {
+  try {
+    const raw = await readFile(LAST_RUN_PATH, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (
+      Array.isArray(parsed?.argv) &&
+      parsed.argv.every((a: unknown) => typeof a === "string") &&
+      typeof parsed?.exitCode === "number" &&
+      typeof parsed?.errorMessage === "string" &&
+      typeof parsed?.timestamp === "string"
+    ) {
+      return parsed as LastRun;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeLastRun(data: LastRun): Promise<void> {
+  await mkdir(join(homedir(), ".dooray"), { recursive: true });
+  const tmp = LAST_RUN_PATH + ".tmp";
+  await writeFile(tmp, JSON.stringify(data, null, 2) + "\n");
+  await rename(tmp, LAST_RUN_PATH);
+}

--- a/src/cache/last-run.ts
+++ b/src/cache/last-run.ts
@@ -11,20 +11,23 @@ export interface LastRun {
   timestamp: string;        // ISO 8601
 }
 
+function isLastRun(obj: unknown): obj is LastRun {
+  if (typeof obj !== "object" || obj === null) return false;
+  const o = obj as Record<string, unknown>;
+  return (
+    Array.isArray(o.argv) &&
+    o.argv.every((a) => typeof a === "string") &&
+    typeof o.exitCode === "number" &&
+    typeof o.errorMessage === "string" &&
+    typeof o.timestamp === "string"
+  );
+}
+
 export async function readLastRun(): Promise<LastRun | null> {
   try {
     const raw = await readFile(LAST_RUN_PATH, "utf-8");
-    const parsed = JSON.parse(raw);
-    if (
-      Array.isArray(parsed?.argv) &&
-      parsed.argv.every((a: unknown) => typeof a === "string") &&
-      typeof parsed?.exitCode === "number" &&
-      typeof parsed?.errorMessage === "string" &&
-      typeof parsed?.timestamp === "string"
-    ) {
-      return parsed as LastRun;
-    }
-    return null;
+    const parsed: unknown = JSON.parse(raw);
+    return isLastRun(parsed) ? parsed : null;
   } catch {
     return null;
   }
@@ -33,6 +36,6 @@ export async function readLastRun(): Promise<LastRun | null> {
 export async function writeLastRun(data: LastRun): Promise<void> {
   await mkdir(join(homedir(), ".dooray"), { recursive: true });
   const tmp = LAST_RUN_PATH + ".tmp";
-  await writeFile(tmp, JSON.stringify(data, null, 2) + "\n");
+  await writeFile(tmp, JSON.stringify(data, null, 2) + "\n", { mode: 0o600 });
   await rename(tmp, LAST_RUN_PATH);
 }

--- a/src/commands/feedback.ts
+++ b/src/commands/feedback.ts
@@ -10,7 +10,9 @@ import {
   readCliVersion,
   collectMeta,
   buildIssueBody,
+  buildLastRunBlock,
 } from "../utils/feedback-meta.js";
+import { readLastRun } from "../cache/last-run.js";
 import { DoorayCliError } from "../utils/errors.js";
 import { EXIT_PARAM_ERROR } from "../utils/exit-codes.js";
 
@@ -50,11 +52,31 @@ export const feedbackCommand = new Command("feedback")
     (value: string, prev: string[]) => [...prev, value],
     [] as string[],
   )
+  .option("--last", "직전 실행한 dooray 명령의 argv + 에러를 본문 상단에 자동 첨부")
   .option("--dry-run", "gh 호출 없이 본문만 미리보기")
   .action(async (opts) => {
     let title: string | undefined = opts.title;
     let userBody = await readBody(opts);
     let labels: string[] = [...(opts.label as string[])];
+
+    if (opts.last) {
+      const last = await readLastRun();
+      if (!last) {
+        throw new DoorayCliError(
+          "기록된 직전 실행이 없습니다. config.json에 trackLastRun: true 설정 후 dooray 명령 실행 시 자동 기록됩니다.\n  설정: dooray config set track-last-run true",
+          EXIT_PARAM_ERROR,
+        );
+      }
+      const lastBlock = buildLastRunBlock(last);
+      if (userBody == null) {
+        userBody = await editor({
+          message: "본문 작성 ($EDITOR가 열림)",
+          default: lastBlock + "\n\n",
+        });
+      } else {
+        userBody = lastBlock + "\n\n" + userBody;
+      }
+    }
 
     if (!title) {
       title = await input({ message: "이슈 제목" });

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -159,7 +159,14 @@ export const setupCommand = new Command("setup")
         }
       }
 
-      // 8. 저장 (all-or-nothing)
+      // 8. feedback --last 모드 (opt-in)
+      const trackLastRun = await confirm({
+        message: "feedback --last 모드 활성화 (직전 명령 에러를 GitHub issue에 자동 첨부)?",
+        default: false,
+        theme: { prefix: "📋" },
+      });
+
+      // 9. 저장 (all-or-nothing)
       const config: Config = {
         version: 1,
         apiKey,
@@ -172,6 +179,7 @@ export const setupCommand = new Command("setup")
         smtpHost: useMail ? DEFAULTS.smtpHost : existing?.smtpHost,
         smtpPort: useMail ? DEFAULTS.smtpPort : existing?.smtpPort,
       };
+      config.trackLastRun = trackLastRun;
 
       await saveConfig(config);
       console.log(

--- a/src/config/store.ts
+++ b/src/config/store.ts
@@ -73,9 +73,12 @@ export async function setConfigValue(
     case "smtp-port":
       config.smtpPort = parseInt(value, 10);
       break;
+    case "track-last-run":
+      config.trackLastRun = value === "true";
+      break;
     default:
       throw new DoorayCliError(
-        `알 수 없는 설정 키: ${key}\n사용 가능한 키: api-key, base-url, tenant-name, imap-host, imap-port, imap-username, imap-password, smtp-host, smtp-port`,
+        `알 수 없는 설정 키: ${key}\n사용 가능한 키: api-key, base-url, tenant-name, imap-host, imap-port, imap-username, imap-password, smtp-host, smtp-port, track-last-run`,
         EXIT_CONFIG_ERROR,
       );
   }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -9,6 +9,7 @@ export interface Config {
   imapPassword?: string;
   smtpHost?: string;
   smtpPort?: number;
+  trackLastRun?: boolean;
 }
 
 export const API_ENDPOINTS = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,9 @@ import { mailSendCommand } from "./commands/mail/send.js";
 import { mailReplyCommand } from "./commands/mail/reply.js";
 import { feedbackCommand } from "./commands/feedback.js";
 import { DoorayCliError } from "./utils/errors.js";
+import { sanitizeArgv } from "./utils/argv-sanitize.js";
+import { writeLastRun } from "./cache/last-run.js";
+import { getConfig } from "./config/store.js";
 
 const program = new Command();
 
@@ -123,11 +126,28 @@ program.addCommand(wikiCommand);
 program.addCommand(mailCommand);
 program.addCommand(feedbackCommand);
 
-program.parseAsync().catch((err) => {
-  if (err instanceof DoorayCliError) {
-    process.stderr.write(chalk.red(`오류: ${err.message}`) + "\n");
-    process.exit(err.exitCode);
+program.parseAsync().catch(async (err) => {
+  const errorMessage = err instanceof Error ? err.message : String(err);
+  const exitCode = err instanceof DoorayCliError ? err.exitCode : 1;
+
+  // last-run 기록 (best-effort, opt-in, feedback 명령은 제외)
+  try {
+    const config = await getConfig();
+    const sanitized = sanitizeArgv(process.argv.slice(2));
+    const firstNonFlag = sanitized.find((a) => !a.startsWith("-"));
+    const isFeedbackCommand = firstNonFlag === "feedback";
+    if (config?.trackLastRun && !isFeedbackCommand) {
+      await writeLastRun({
+        argv: ["dooray", ...sanitized],
+        exitCode,
+        errorMessage,
+        timestamp: new Date().toISOString(),
+      });
+    }
+  } catch {
+    // last-run 기록 실패는 무시 — 원래 에러 마스킹 금지
   }
-  process.stderr.write(chalk.red(`오류: ${err.message}`) + "\n");
-  process.exit(1);
+
+  process.stderr.write(chalk.red(`오류: ${errorMessage}`) + "\n");
+  process.exit(exitCode);
 });

--- a/src/utils/argv-sanitize.test.ts
+++ b/src/utils/argv-sanitize.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeArgv } from "./argv-sanitize.js";
+
+describe("sanitizeArgv", () => {
+  it("--api-key=value 마스킹", () => {
+    expect(sanitizeArgv(["dooray", "post", "--api-key=secret123"]))
+      .toEqual(["dooray", "post", "--api-key=***"]);
+  });
+  it("--api-key value 분리 형태 마스킹", () => {
+    expect(sanitizeArgv(["dooray", "--api-key", "secret123", "post"]))
+      .toEqual(["dooray", "--api-key", "***", "post"]);
+  });
+  it("--token / --password 동일 처리", () => {
+    expect(sanitizeArgv(["--token=t", "--password=p"]))
+      .toEqual(["--token=***", "--password=***"]);
+  });
+  it("Authorization 헤더 인자 마스킹", () => {
+    expect(sanitizeArgv(["--header", "Authorization: Bearer abc123"]))
+      .toEqual(["--header", "Authorization: ***"]);
+  });
+  it("일반 인자는 그대로", () => {
+    expect(sanitizeArgv(["dooray", "post", "create", "<project>", "--title", "X"]))
+      .toEqual(["dooray", "post", "create", "<project>", "--title", "X"]);
+  });
+  it("회귀 가드 — secret 단어가 결과에 0건", () => {
+    const out = sanitizeArgv(["--api-key", "MY_SECRET_TOKEN_XXX"]);
+    expect(out.join(" ")).not.toContain("MY_SECRET_TOKEN_XXX");
+  });
+});

--- a/src/utils/argv-sanitize.ts
+++ b/src/utils/argv-sanitize.ts
@@ -1,0 +1,46 @@
+/**
+ * argv에서 시크릿 패턴을 자동 마스킹.
+ * ADR-023 sanitization 룰 표 기준.
+ */
+
+const KEY_VALUE_PATTERNS = [
+  /^(--api-key|--token|--password)=(.+)$/,
+];
+const SEPARATED_KEYS = new Set(["--api-key", "--token", "--password"]);
+
+export function sanitizeArgv(argv: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+
+    // --key=value 형태
+    let kvMatch: RegExpMatchArray | null = null;
+    for (const re of KEY_VALUE_PATTERNS) {
+      const m = re.exec(a);
+      if (m) { kvMatch = m; break; }
+    }
+    if (kvMatch) {
+      out.push(`${kvMatch[1]}=***`);
+      continue;
+    }
+
+    // --key value 형태 — 다음 토큰을 마스킹
+    if (SEPARATED_KEYS.has(a)) {
+      out.push(a);
+      if (i + 1 < argv.length) {
+        out.push("***");
+        i++;
+      }
+      continue;
+    }
+
+    // Authorization: ... 형태 (단일 string에 들어있을 때)
+    if (/^Authorization\s*:/i.test(a) || /^Bearer\s+\S+/.test(a)) {
+      out.push(a.replace(/(Authorization\s*:\s*).+/i, "$1***").replace(/^(Bearer\s+).+/i, "$1***"));
+      continue;
+    }
+
+    out.push(a);
+  }
+  return out;
+}

--- a/src/utils/feedback-meta.test.ts
+++ b/src/utils/feedback-meta.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildIssueBody, collectMeta } from "./feedback-meta.js";
+import { buildIssueBody, buildLastRunBlock, collectMeta } from "./feedback-meta.js";
 
 const FAKE_META = {
   cliVersion: "0.5.2",
@@ -33,6 +33,30 @@ describe("buildIssueBody", () => {
     const out = buildIssueBody("\n\n  의견  \n\n", FAKE_META);
     expect(out).toContain("의견");
     expect(out).not.toMatch(/\n{4,}/);
+  });
+});
+
+describe("buildLastRunBlock", () => {
+  it("argv + 에러 + exit code + timestamp 모두 포함", () => {
+    const out = buildLastRunBlock({
+      argv: ["dooray", "post", "create", "<project>"],
+      exitCode: 2,
+      errorMessage: "API 호출 실패: USER_INVALID_TAG_MANDATORY_PREFIX",
+      timestamp: "2026-04-29T10:00:00Z",
+    });
+    expect(out).toContain("$ dooray post create <project>");
+    expect(out).toContain("USER_INVALID_TAG_MANDATORY_PREFIX");
+    expect(out).toContain("exit code: 2");
+    expect(out).toContain("2026-04-29T10:00:00Z");
+  });
+  it("baseUrl/apiKey/시크릿 없음 회귀 가드", () => {
+    const out = buildLastRunBlock({
+      argv: ["dooray"],
+      exitCode: 1,
+      errorMessage: "x",
+      timestamp: "2026-04-29T00:00:00Z",
+    });
+    expect(out).not.toMatch(/baseUrl|apiKey|api[_-]?key|password|token|Bearer/i);
   });
 });
 

--- a/src/utils/feedback-meta.ts
+++ b/src/utils/feedback-meta.ts
@@ -46,7 +46,7 @@ export function buildLastRunBlock(last: LastRun): string {
     "",
     "```",
     `$ ${last.argv.join(" ")}`,
-    last.errorMessage,
+    last.errorMessage.replace(/```/g, "'''"),
     "```",
     "",
     `- exit code: ${last.exitCode}`,

--- a/src/utils/feedback-meta.ts
+++ b/src/utils/feedback-meta.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import type { LastRun } from "../cache/last-run.js";
 
 export async function readCliVersion(): Promise<string> {
   const entry = process.argv[1];
@@ -37,6 +38,20 @@ export function collectMeta(version: string): FeedbackMeta {
     os: process.platform,
     arch: process.arch,
   };
+}
+
+export function buildLastRunBlock(last: LastRun): string {
+  return [
+    "## 직전 실행 (자동 첨부)",
+    "",
+    "```",
+    `$ ${last.argv.join(" ")}`,
+    last.errorMessage,
+    "```",
+    "",
+    `- exit code: ${last.exitCode}`,
+    `- 시각: ${last.timestamp}`,
+  ].join("\n");
 }
 
 export function buildIssueBody(userBody: string, meta: FeedbackMeta): string {

--- a/tasks/018-feat-feedback-last-mode/index.json
+++ b/tasks/018-feat-feedback-last-mode/index.json
@@ -2,8 +2,8 @@
   "name": "018-feat-feedback-last-mode",
   "description": "Issue #27 — `dooray feedback --last` 모드. 직전 dooray 명령의 argv(sanitized) + 에러를 본문 상단에 자동 첨부. opt-in (config.json `trackLastRun: true`), 에러시만 기록, 최소 세트(argv/exitCode/errorMessage/timestamp), argv 패턴 마스킹(--api-key/--token/Authorization 등). ADR-023.",
   "created_at": "2026-04-29T00:00:00Z",
-  "status": "pending",
-  "current_phase": 1,
+  "status": "completed",
+  "current_phase": 3,
   "total_phases": 3,
   "error_message": null,
   "blocked_reason": null,
@@ -12,23 +12,23 @@
       "number": 1,
       "title": "config schema + sanitization util + last-run store + 단위 테스트",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 2,
       "title": "src/index.ts catch hook + feedback --last 로직",
       "file": "phase-02.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 3,
       "title": "README/SKILL.md + setup wizard 통합 + 빌드/시나리오 + task 완료",
       "file": "phase-03.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],
-  "updated_at": "2026-04-29T00:00:00Z"
+  "updated_at": "2026-05-07T07:44:00Z"
 }

--- a/tasks/018-feat-feedback-last-mode/phase-01.md
+++ b/tasks/018-feat-feedback-last-mode/phase-01.md
@@ -13,9 +13,9 @@ Issue #27 — last-run 추적 인프라. ADR-023 (opt-in + 에러시만 + 최소
 
 ## 작업 목록 (4개)
 
-### 1) `src/config/store.ts` — `trackLastRun?: boolean` 추가
+### 1a) `src/config/types.ts` — `Config` 인터페이스에 `trackLastRun?: boolean` 추가
 
-기존 `Config` 인터페이스에 optional 필드 추가:
+`Config` 인터페이스는 `src/config/types.ts:1-12`에 있다. (store.ts는 `import type { Config }`만 함.)
 
 ```ts
 export interface Config {
@@ -24,9 +24,10 @@ export interface Config {
 }
 ```
 
-**`set` 명령 핸들러**: `case "track-last-run":` 추가, value를 `"true"`/`"false"` 파싱해 boolean 저장. `dooray config set track-last-run true` 형태로 활성화.
+### 1b) `src/config/store.ts` — `set` switch에 `case "track-last-run":` 추가
 
-기존 `case "tenant-name":` 같은 패턴 답습. set 알 수 없는 키 에러 메시지의 사용 가능 키 목록에 `track-last-run` 추가.
+`case "tenant-name":` (현재 store.ts:70) 같은 패턴 답습. value를 `"true"`/`"false"` 파싱해 boolean 저장.
+`dooray config set track-last-run true` 형태로 활성화. set 알 수 없는 키 에러 메시지의 사용 가능 키 목록에도 `track-last-run` 추가.
 
 ### 2) `src/utils/argv-sanitize.ts` — 신규 + 단위 테스트
 
@@ -157,7 +158,8 @@ phase 1의 핵심 검증은 sanitize 단위 테스트. 시크릿 단어가 출�
 
 - [ ] `pnpm run build` 성공
 - [ ] `pnpm test` 통과 (sanitize 6+ 케이스 추가)
-- [ ] `grep -c "trackLastRun" src/config/store.ts` → 2 이상 (interface + set case)
+- [ ] `grep -c "trackLastRun" src/config/types.ts` → 1 이상 (Config 인터페이스 필드)
+- [ ] `grep -c "trackLastRun" src/config/store.ts` → 1 이상 (set case 내부 boolean 할당)
 - [ ] `grep -c "track-last-run" src/config/store.ts` → 2 이상 (set case + 사용가능 키 목록)
 - [ ] `ls src/utils/argv-sanitize.ts src/utils/argv-sanitize.test.ts src/cache/last-run.ts` → 3 파일
 - [ ] `grep -c "readLastRun\|writeLastRun" src/cache/last-run.ts` → 2 이상

--- a/tasks/018-feat-feedback-last-mode/phase-02.md
+++ b/tasks/018-feat-feedback-last-mode/phase-02.md
@@ -32,7 +32,7 @@ program.parseAsync().catch((err) => {
 ```ts
 import { sanitizeArgv } from "./utils/argv-sanitize.js";
 import { writeLastRun } from "./cache/last-run.js";
-import { getConfigOrThrow } from "./config/store.js";
+import { getConfig } from "./config/store.js";  // Throw 안 하는 변형 사용
 
 program.parseAsync().catch(async (err) => {
   const errorMessage = err instanceof Error ? err.message : String(err);
@@ -40,13 +40,14 @@ program.parseAsync().catch(async (err) => {
 
   // last-run 기록 (best-effort, opt-in, feedback 명령은 제외)
   try {
-    const config = await getConfigOrThrow();
-    const isFeedbackCommand =
-      process.argv.includes("feedback") &&
-      process.argv[2] === "feedback";
-    if (config.trackLastRun && !isFeedbackCommand) {
+    const config = await getConfig();  // null 가능 — setup 안 한 사용자
+    // 전역 옵션 우회 차단: argv 전체에서 "-" 로 시작 안 하는 첫 토큰을 서브명령으로 본다
+    const sanitized = sanitizeArgv(process.argv.slice(2));
+    const firstNonFlag = sanitized.find((a) => !a.startsWith("-"));
+    const isFeedbackCommand = firstNonFlag === "feedback";
+    if (config?.trackLastRun && !isFeedbackCommand) {
       await writeLastRun({
-        argv: sanitizeArgv(process.argv.slice(1)),  // node 경로 제외
+        argv: ["dooray", ...sanitized],  // 본문 출력 시 "$ dooray ..." 재현 의도
         exitCode,
         errorMessage,
         timestamp: new Date().toISOString(),
@@ -61,9 +62,11 @@ program.parseAsync().catch(async (err) => {
 });
 ```
 
-> **재귀 방지**: `process.argv[2] === "feedback"` 체크로 `dooray feedback ...` 자체 실행은 last-run에 안 남김. argv[0]=node, argv[1]=dist/index.js, argv[2]=서브명령.
+> **재귀 방지 (강화)**: 단순히 `argv[2] === "feedback"` 만 보면 `dooray --json feedback ...` 처럼 전역 옵션이 앞에 오는 경우 우회된다. 따라서 `argv.slice(2)` 에서 "-" 로 시작 안 하는 첫 토큰을 서브명령으로 판정. ADR-023 재귀 방지 정책 일치.
 >
-> **getConfigOrThrow 내부에서 throw 가능성**: config 자체 읽기 실패 → 그냥 try/catch로 swallow. last-run 기록만 못 할 뿐 원래 에러는 정상 출력.
+> **`getConfig` 사용**: `getConfigOrThrow` 는 setup 안 한 사용자에게 throw — catch 내부에서 호출하면 최초 사용자가 만난 원래 에러를 swallow 처리하느라 의도 어긋남. `getConfig` 가 `null` 반환하면 `config?.trackLastRun` 짧은 경로로 통과.
+>
+> **argv 출력**: `slice(2)` 후 `["dooray", ...]` 접두를 수동으로 붙여 본문에 `$ dooray post get X 1` 형태로 재현. argv[1]=dist/index.js 경로가 본문에 노출되지 않음.
 
 ### 2) `src/commands/feedback.ts` — `--last` 옵션 + 본문 조립
 
@@ -161,13 +164,14 @@ describe("buildLastRunBlock", () => {
 - [ ] `pnpm test` 통과 (buildLastRunBlock 2+ 케이스 추가)
 - [ ] `node dist/index.js feedback --help` → `--last` 옵션 노출
 - [ ] `grep -c "writeLastRun\|sanitizeArgv\|trackLastRun" src/index.ts` → 3 이상
-- [ ] `grep -c "isFeedbackCommand" src/index.ts` → 1 이상 (재귀 방지)
+- [ ] `grep -c "isFeedbackCommand\|firstNonFlag" src/index.ts` → 2 이상 (전역 옵션 우회 방지 가드)
+- [ ] `grep -c "getConfigOrThrow" src/index.ts` → 0 (catch hook은 `getConfig` 사용)
 - [ ] `grep -c "readLastRun\|buildLastRunBlock\|opts.last" src/commands/feedback.ts` → 3 이상
 
 ## 주의사항
 
 - **best-effort 기록**: catch 블록 내부 try/catch가 원래 에러 출력을 절대 마스킹하지 않도록. last-run 기록 실패는 silent
-- **재귀 방지 필수**: `process.argv[2] === "feedback"` 체크. feedback이 자기 자신 argv를 last-run에 남기면 다음 feedback에 fed back
+- **재귀 방지 필수 (전역 옵션 우회 케이스 포함)**: `argv.slice(2)` 의 첫 non-flag 토큰이 `feedback` 인지로 판정. 단순히 `argv[2] === "feedback"` 만 보면 `dooray --json feedback ...` 같이 전역 옵션이 앞에 올 때 가드가 풀려 feedback 자체 실패가 last-run에 기록 → 다음 `--last` 호출에서 fed back
 - **opt-in 게이트**: `config.trackLastRun !== true` 면 기록 X
 - **--last 사용 시 last-run 없음 → 명확한 에러 메시지** (단위 테스트로는 검증 어려움 — phase 3 시나리오)
 - **인터랙티브 모드 editor default**: lastBlock + "\n\n"로 사용자가 그 아래 의견 작성. 사용자 의견이 빈 줄이면 lastBlock만으로도 본문 충분

--- a/tasks/018-feat-feedback-last-mode/phase-03.md
+++ b/tasks/018-feat-feedback-last-mode/phase-03.md
@@ -6,7 +6,7 @@ phase 1·2의 last-run 인프라를 사용자 docs에 노출 + setup 마법사�
 
 ## 작업 목록 (4개)
 
-### 1) `setup` 마법사에 `trackLastRun` 안내 추가 (선택)
+### 1) `setup` 마법사에 `trackLastRun` 안내 추가 (필수 — 옵트인 신규 기능을 사용자가 인지할 유일한 surface)
 
 `src/commands/setup.ts` 흐름 끝부분에 confirm prompt 추가:
 ```ts
@@ -72,15 +72,24 @@ grep -E "SECRET_VALUE" ~/.dooray/last-run.json && echo "FAIL: 누출" || echo "O
 # 기대: OK: 마스킹
 ```
 
-**시나리오 E — feedback 자체 재귀 방지**:
+**시나리오 E — feedback 자체 재귀 방지 (실제 catch 진입 검증)** — 필수:
+
+`feedback --dry-run` 정상 종료는 catch 미진입이라 가드 검증이 안 된다. 따라서 **feedback 명령이 에러로 종료**하는 경로로 검증한다.
+
 ```bash
 dooray config set track-last-run true
-PREV=$(jq -r .timestamp ~/.dooray/last-run.json 2>/dev/null || echo "")
-node dist/index.js feedback --title T --body B --dry-run   # 에러 발생 안 함, 정상
-# 또는 일부러 에러 만들기:
-echo "feedback이 자기 argv 안 남기는지" 
-NEW=$(jq -r .timestamp ~/.dooray/last-run.json 2>/dev/null || echo "")
-[ "$PREV" = "$NEW" ] && echo "OK: feedback 자체는 last-run 안 남김" || echo "체크"
+rm -f ~/.dooray/last-run.json
+
+# (E-1) 일반 형태 — feedback --last 호출인데 last-run 없음 → DoorayCliError
+node dist/index.js feedback --last 2>/dev/null
+test -f ~/.dooray/last-run.json && echo "FAIL: feedback이 자기 에러를 last-run에 기록 (재귀)" || echo "OK: 재귀 방지 동작"
+# 기대: OK
+
+# (E-2) 전역 옵션 우회 케이스 — argv[2]가 "feedback" 아닌 경우도 가드해야 함
+rm -f ~/.dooray/last-run.json
+node dist/index.js --json feedback --last 2>/dev/null
+test -f ~/.dooray/last-run.json && echo "FAIL: 전역옵션 앞에 와도 가드 풀림" || echo "OK: 전역옵션 우회 방지"
+# 기대: OK
 ```
 
 **시나리오 F — 기록 없을 때 --last 호출**:
@@ -107,9 +116,10 @@ node dist/index.js feedback --last
 - [ ] **시나리오 B (opt-in 미설정 시 미기록) — 필수 회귀 가드**
 - [ ] **시나리오 D (sanitization 회귀 가드) — 필수**
 - [ ] (선택) 시나리오 C — 기록 + 자동 첨부 정상
-- [ ] (선택) 시나리오 E — 재귀 방지 동작
+- [ ] **시나리오 E (재귀 방지 — 일반 + 전역옵션 우회) — 필수 회귀 가드**
 - [ ] (선택) 시나리오 F — 기록 없을 때 안내 에러
 - [ ] `grep -c "track-last-run\|--last\|trackLastRun" README.md skills/dooray-cli/SKILL.md` → 각 2 이상
+- [ ] `grep -c "trackLastRun\|track-last-run" src/commands/setup.ts` → 1 이상 (마법사 통합)
 - [ ] index.json `status: "completed"`
 
 ## 주의사항
@@ -117,7 +127,7 @@ node dist/index.js feedback --last
 - **시나리오 B/D가 회귀 가드 핵심** — opt-in 정책 + sanitization은 보안 정책. 깨지면 프라이버시 사고
 - **이슈 #27 close**: 본 task 머지 후 release 시점에 close (release 스킬 Step 9)
 - **README PII gate 호환**: README/SKILL.md에 추가하는 예시도 `<project>`/`example.com` placeholder 유지
-- **setup 마법사 통합 (작업 1)**은 선택 — 빠지면 사용자가 `config set` 직접 호출. 둘 다 OK
+- **setup 마법사 통합 (작업 1)**: 옵트인 신규 기능을 사용자가 인지할 surface. confirm prompt + default false. `dooray config set track-last-run true`도 병행 가능
 
 ## Blocked 조건
 


### PR DESCRIPTION
## Summary

`dooray feedback --last` 모드 — 직전 dooray 명령이 에러로 종료한 경우 sanitized argv + 에러 메시지를 다음 GitHub issue 본문 상단에 자동 첨부. opt-in.

Closes #27.

## ADR-023 정책

- **opt-in**: `config.json` 의 `trackLastRun: true` 일 때만 기록. `dooray setup` 마법사 또는 `dooray config set track-last-run true` 로 활성화
- **에러시만 기록**: `src/index.ts` 의 `parseAsync().catch()` hook 에서 best-effort 처리. 기록 실패는 swallow (원래 에러 마스킹 금지)
- **최소 세트**: `argv` (sanitized) / `exitCode` / `errorMessage` / `timestamp` — cwd/env/시크릿 자체는 저장 안 함
- **argv 패턴 마스킹**: `--api-key`, `--token`, `--password`, `Authorization`/`Bearer` 헤더 — `src/utils/argv-sanitize.ts`
- **재귀 방지**: `argv.slice(2)` 의 첫 non-flag 토큰이 `feedback` 인지 가드 (`dooray --json feedback ...` 같은 전역 옵션 우회도 차단)
- **저장 위치**: `~/.dooray/last-run.json` (cache 디렉토리 외부 — `dooray cache clear` 영향 없음)
- **읽기 시 스키마 검증** + **atomic write** (tmp + rename)

## Files

- 신규: `src/cache/last-run.ts`, `src/utils/argv-sanitize.ts` + 단위 테스트
- 수정: `src/index.ts` (catch hook), `src/commands/feedback.ts` (`--last` 옵션), `src/commands/setup.ts` (마법사 통합), `src/config/types.ts` + `src/config/store.ts` (`trackLastRun` 필드 + `track-last-run` set 키), `src/utils/feedback-meta.ts` (`buildLastRunBlock`)
- 문서: `README.md`, `skills/dooray-cli/SKILL.md`, `docs/code-architecture.md`, `CLAUDE.md`

## Test plan

- [x] `pnpm run build` (151.02 KB)
- [x] `pnpm test` 46/46 pass (argv-sanitize 6 케이스 + buildLastRunBlock 2 케이스 추가)
- [x] 시나리오 B (opt-in 미설정 시 미기록) ✓
- [x] 시나리오 D (sanitization 회귀 가드 — `MY_SECRET_TOKEN_XXX` 마스킹) ✓
- [x] 시나리오 E-1 (feedback 자기 재귀 방지) ✓
- [x] 시나리오 E-2 (`--json feedback --last` 전역 옵션 우회 방지) ✓

## Review pipeline

build-with-teams 파이프라인:
- critic (opus): REVISE 1회 → APPROVE
- executor (sonnet): phase 1·2·3 순차 실행
- code-reviewer (sonnet): FIX_NEEDED 2건 (스키마 검증 + atomic write) → 픽스 후 PASS
- docs-verifier (sonnet): UPDATE_NEEDED 2건 (`code-architecture.md`, `CLAUDE.md` stale 문구) → 반영 후 PASS