### PR TITLE
feat(utils,resolvers,commands): CLI automation quick-wins (Issue #35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ dooray post get <project> 42 --json           # JSON 출력
 | 방식 | 예시 |
 |---|---|
 | `<project> <number>` | `dooray post get <project> 42` |
-| Dooray URL positional | `dooray post get https://x.dooray.com/task/to/<postId>` |
+| Dooray URL positional (`/task/to/<postId>`) | `dooray post get https://x.dooray.com/task/to/<postId>` |
+| Dooray URL positional (브라우저 주소창 복사본) | `dooray post get https://x.dooray.com/task/<projectId>/<postId>` |
 | `--id <postId>` | `dooray post get --id <postId>` |
 | `--url <url>` | `dooray post get --url https://x.dooray.com/task/to/...` |
 

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -322,7 +322,10 @@
 - comment/file 명령의 sub-id(`<comment-id>`, `<file-id>`)는 **옵션화** (`--comment-id`, `--file-id`). 기존 positional도 호환 — agent 친화
 - 입력 검증은 `resolvePostInput` 단일 헬퍼에 집중. `--id`/`--url`/positional 동시 사용 시 명시적 에러
 - standalone API `GET /project/v1/posts/{postId}` 활용 — 응답에 `project.{id,code}`, `taskNumber`, `number` 포함되어 한 번의 lookup으로 기존 코드 경로 재사용
-- URL 매칭은 strict 정규식 `^https?://[\w.-]+\.dooray\.com/task/to/(\d+)(?:[/?#].*)?$`. 매칭 실패 시 명확한 에러
+- URL 매칭은 두 형태 모두 지원 (Issue #35 item 4):
+  - 공식 short form: `^https?://[\w.-]+\.dooray\.com/task/to/(\d+)(?:[/?#].*)?$` → 캡처 1 = postId
+  - 브라우저 주소창 복사본 alt form: `^https?://[\w.-]+\.dooray\.com/task/(\d+)/(\d+)(?:[/?#].*)?$` → 캡처 2 = postId. 캡처 1 은 projectId 이지만 `parseDoorayTaskUrl` 의 `string | null` 시그니처 유지를 위해 미반환 — `resolvePostInput` 이 postId 로 standalone API 재호출하면서 project 정보 획득
+- 매칭 실패 시 명확한 에러
 - **테스트 인프라로 vitest 도입** — dooray-cli 첫 테스트 환경. URL parser와 resolvePostInput 단위 테스트로 분기 안전성 확보
 
 **이유**:

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -63,10 +63,10 @@ src/
 
   utils/
     errors.ts               # DoorayCliError (message + exitCode)
-    spinner.ts              # ora 래퍼
+    spinner.ts              # ora 래퍼 + setQuiet (--json/--quiet 시 noop proxy 반환, Issue #35 item 1)
     exit-codes.ts           # 0 성공 / 1 API오류 / 2 인증실패 / 3 파라미터오류 / 4 설정오류
     body-input.ts           # --body / --body-file → string (stdin "-" + 충돌 가드)
-    dooray-url.ts           # https://*.dooray.com/task/to/<postId> URL parser (ADR-020)
+    dooray-url.ts           # /task/to/<postId> 및 /task/<projectId>/<postId> URL parser (ADR-020)
     comment-enrich.ts       # PostComment[] Creator 이름 채우기 (ADR-021, immutable)
     mention.ts              # 멤버·그룹 멘션 마크업 빌더 + prependMentions (Issue #25)
     feedback-meta.ts        # CLI 버전·환경 수집 + GitHub issue body 빌더 + buildLastRunBlock (ADR-022, ADR-023)
@@ -187,6 +187,7 @@ class DoorayApiClient {
 - `--quiet`: ID만 출력 (스크립팅용)
 - `--no-color`: 컬러 제거 (CI 환경, `NO_COLOR` env 자동 감지)
 - 스피너·에러: stderr / 데이터: stdout (파이프 시 stderr 오염 방지)
+- `--json` / `--quiet` 모드: spinner 완전 억제 (`setQuiet(true)` → `startSpinner` 가 no-op `Proxy<Ora>` 반환). jq 같은 파이프에서 stdout 청결 보장 (Issue #35 item 1)
 
 ## 테스트
 

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -45,7 +45,7 @@ dooray doctor                                 # 설정 검증
 
 자연어 요청을 커맨드로 변환할 때 아래 표를 참고한다.
 
-> **공통 (post 하위 12개 명령)**: `post get`/`edit`/`done`/`workflow`, `post comment list`/`add`/`edit`/`delete`, `post file list`/`upload`/`download`/`download-all`/`delete`는 `<project> <number>` 외에도 `--id <postId>`, `--url <url>`, 또는 첫 인자에 Dooray URL(`https://*.dooray.com/task/to/<postId>`)을 직접 받는다. **사용자가 URL을 줬으면 그대로 첫 인자로 전달**하는 것이 가장 빠른 경로 (resolve 단계 단축, ADR-020).
+> **공통 (post 하위 12개 명령)**: `post get`/`edit`/`done`/`workflow`, `post comment list`/`add`/`edit`/`delete`, `post file list`/`upload`/`download`/`download-all`/`delete`는 `<project> <number>` 외에도 `--id <postId>`, `--url <url>`, 또는 첫 인자에 Dooray URL(`https://*.dooray.com/task/to/<postId>` 또는 브라우저 주소창 복사본 `https://*.dooray.com/task/<projectId>/<postId>`)을 직접 받는다. **사용자가 URL을 줬으면 그대로 첫 인자로 전달**하는 것이 가장 빠른 경로 (resolve 단계 단축, ADR-020).
 
 | 의도 | 커맨드 |
 |------|--------|

--- a/src/commands/post/create.ts
+++ b/src/commands/post/create.ts
@@ -3,7 +3,7 @@ import { getConfigOrThrow } from "../../config/store.js";
 import { DoorayApiClient } from "../../api/client.js";
 import { resolveProject } from "../../resolvers/project.js";
 import { resolveMember } from "../../resolvers/member.js";
-import { resolveTags } from "../../resolvers/tag.js";
+import { resolveTags, validateMandatoryTags } from "../../resolvers/tag.js";
 import { resolveMilestone } from "../../resolvers/milestone.js";
 import { resolvePostRef } from "../../resolvers/postRef.js";
 import { resolveWorkflow } from "../../resolvers/workflow.js";
@@ -74,7 +74,7 @@ export const postCreateCommand = new Command("create")
     const [tagIds, parentPostId, milestoneId] = await Promise.all([
       tagInputs.length > 0
         ? resolveTags(client, projectId, tagInputs)
-        : Promise.resolve<string[] | undefined>(undefined),
+        : validateMandatoryTags(client, projectId).then(() => undefined),
       opts.parent
         ? resolvePostRef(client, opts.parent)
         : Promise.resolve<string | undefined>(undefined),

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import { mailReplyCommand } from "./commands/mail/reply.js";
 import { feedbackCommand } from "./commands/feedback.js";
 import { DoorayCliError } from "./utils/errors.js";
 import { sanitizeArgv } from "./utils/argv-sanitize.js";
+import { setQuiet } from "./utils/spinner.js";
 import { writeLastRun } from "./cache/last-run.js";
 import { getConfig } from "./config/store.js";
 
@@ -52,11 +53,14 @@ program
   .option("--quiet", "ID만 출력")
   .option("--no-color", "색상 비활성화");
 
-// --no-color 처리: chalk 비활성화
+// --no-color 처리: chalk 비활성화. --json / --quiet 모드에서 spinner 비활성화
 program.hook("preAction", () => {
   const opts = program.opts();
   if (opts.color === false || process.env.NO_COLOR) {
     chalk.level = 0;
+  }
+  if (opts.json || opts.quiet) {
+    setQuiet(true);
   }
 });
 

--- a/src/resolvers/tag.test.ts
+++ b/src/resolvers/tag.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// cache/store 모킹 — ensureTags 가 항상 fetchAllTags 를 거치도록
+vi.mock("../cache/store.js", () => ({
+  getTags: vi.fn().mockResolvedValue(null),
+  setTags: vi.fn().mockResolvedValue(undefined),
+  isExpired: vi.fn().mockReturnValue(true),
+}));
+
+import { validateMandatoryTags } from "./tag.js";
+import { DoorayCliError } from "../utils/errors.js";
+import type { DoorayApiClient } from "../api/client.js";
+
+type RawTag = {
+  id: string;
+  name: string;
+  color?: string;
+  tagGroup?: { id: string; name: string; mandatory: boolean; selectOne: boolean };
+};
+
+function mockClient(tags: RawTag[]): DoorayApiClient {
+  return {
+    getProjectTags: vi.fn().mockResolvedValue({ result: tags, totalCount: tags.length }),
+  } as unknown as DoorayApiClient;
+}
+
+describe("validateMandatoryTags", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("mandatory 그룹 0개면 throw 없이 통과", async () => {
+    const client = mockClient([{ id: "1", name: "bug" }]);
+    await expect(validateMandatoryTags(client, "<project>")).resolves.toBeUndefined();
+  });
+
+  it("mandatory 그룹 다중 — 메시지에 그룹별 후보 포함", async () => {
+    const client = mockClient([
+      { id: "1", name: "p0", tagGroup: { id: "g1", name: "priority", mandatory: true, selectOne: false } },
+      { id: "2", name: "p1", tagGroup: { id: "g1", name: "priority", mandatory: true, selectOne: false } },
+      { id: "3", name: "fix", tagGroup: { id: "g2", name: "type", mandatory: true, selectOne: false } },
+    ]);
+    await expect(validateMandatoryTags(client, "<project>")).rejects.toThrow(/p0|p1|fix/);
+  });
+
+  it("mandatory 그룹 에러는 DoorayCliError", async () => {
+    const client = mockClient([
+      { id: "1", name: "p0", tagGroup: { id: "g1", name: "priority", mandatory: true, selectOne: false } },
+    ]);
+    await expect(validateMandatoryTags(client, "<project>")).rejects.toBeInstanceOf(DoorayCliError);
+  });
+
+  it("groupId 없는 mandatory 태그는 무시 (false-positive 방지)", async () => {
+    const client = mockClient([{ id: "1", name: "x" }]);
+    // tagGroup 없으므로 groupId = null, groupMandatory = false → 무시
+    await expect(validateMandatoryTags(client, "<project>")).resolves.toBeUndefined();
+  });
+});

--- a/src/resolvers/tag.ts
+++ b/src/resolvers/tag.ts
@@ -38,6 +38,44 @@ export async function ensureTags(client: DoorayApiClient, projectId: string): Pr
   return items;
 }
 
+/** 누락 그룹별 후보 태그 추출 헬퍼 */
+function buildMandatoryHint(allTags: CachedTag[], missingGroupIds: string[]): string {
+  const lines: string[] = [];
+  for (const gid of missingGroupIds) {
+    const groupTags = allTags.filter((t) => t.groupId === gid);
+    const gname = groupTags[0]?.groupName ?? gid;
+    const candidates = groupTags.map((t) => t.name).join(", ");
+    lines.push(`  - "${gname}": ${candidates || "(태그 없음)"}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * 태그 입력 없이 post create 시 mandatory 그룹 존재 여부를 사전 검증.
+ * mandatory 그룹이 있으면 후보 태그를 포함한 에러를 throw.
+ */
+export async function validateMandatoryTags(
+  client: DoorayApiClient,
+  projectId: string,
+): Promise<void> {
+  const allTags = await ensureTags(client, projectId);
+  const missingGroupIds: string[] = [];
+  const seen = new Set<string>();
+  for (const t of allTags) {
+    if (t.groupMandatory && t.groupId && !seen.has(t.groupId)) {
+      seen.add(t.groupId);
+      missingGroupIds.push(t.groupId);
+    }
+  }
+  if (missingGroupIds.length === 0) return;
+  throw new DoorayCliError(
+    `필수 태그 그룹이 누락되었습니다 (그룹당 1개 이상 필요):\n` +
+      buildMandatoryHint(allTags, missingGroupIds) +
+      `\n\n다시 시도: --tag "<그룹>: <후보>" 형식으로 추가`,
+    EXIT_PARAM_ERROR,
+  );
+}
+
 /**
  * 입력된 태그 이름들을 CachedTag로 lookup하고 mandatory/selectOne 정책을 검증.
  * 반환값은 tagIds (post create body용).
@@ -65,14 +103,14 @@ export async function resolveTags(
     if (t.groupMandatory && t.groupId) mandatoryGroups.set(t.groupId, t.groupName ?? t.groupId);
   }
   const coveredGroups = new Set(selected.map((t) => t.groupId).filter((g): g is string => !!g));
-  const missing: string[] = [];
-  for (const [gid, gname] of mandatoryGroups) {
-    if (!coveredGroups.has(gid)) missing.push(gname);
+  const missingIds: string[] = [];
+  for (const [gid] of mandatoryGroups) {
+    if (!coveredGroups.has(gid)) missingIds.push(gid);
   }
-  if (missing.length > 0) {
+  if (missingIds.length > 0) {
     throw new DoorayCliError(
       `필수 태그 그룹이 누락되었습니다 (그룹당 1개 이상 필요):\n` +
-        missing.map((g) => `  - ${g}`).join("\n"),
+        buildMandatoryHint(allTags, missingIds),
       EXIT_PARAM_ERROR,
     );
   }

--- a/src/resolvers/tag.ts
+++ b/src/resolvers/tag.ts
@@ -41,11 +41,11 @@ export async function ensureTags(client: DoorayApiClient, projectId: string): Pr
 /** 누락 그룹별 후보 태그 추출 헬퍼 */
 function buildMandatoryHint(allTags: CachedTag[], missingGroupIds: string[]): string {
   const lines: string[] = [];
-  for (const gid of missingGroupIds) {
-    const groupTags = allTags.filter((t) => t.groupId === gid);
-    const gname = groupTags[0]?.groupName ?? gid;
+  for (const groupId of missingGroupIds) {
+    const groupTags = allTags.filter((t) => t.groupId === groupId);
+    const groupName = groupTags[0]?.groupName ?? groupId;
     const candidates = groupTags.map((t) => t.name).join(", ");
-    lines.push(`  - "${gname}": ${candidates || "(태그 없음)"}`);
+    lines.push(`  - "${groupName}": ${candidates || "(태그 없음)"}`);
   }
   return lines.join("\n");
 }

--- a/src/utils/dooray-url.test.ts
+++ b/src/utils/dooray-url.test.ts
@@ -27,6 +27,20 @@ describe("parseDoorayTaskUrl", () => {
     expect(parseDoorayTaskUrl("tc-ocr/337")).toBeNull();
     expect(parseDoorayTaskUrl("12345")).toBeNull();
   });
+  it("/task/<projectId>/<postId> 형 URL 에서 postId 추출", () => {
+    expect(parseDoorayTaskUrl("https://example.dooray.com/task/1234567890123456789/9876543210987654321"))
+      .toBe("9876543210987654321");
+  });
+  it("/task/<projectId>/<postId> 형도 query string 무시", () => {
+    expect(parseDoorayTaskUrl("https://x.dooray.com/task/123/456?ref=foo"))
+      .toBe("456");
+  });
+  it("/task/<projectId>/<postId> 형도 trailing slash 허용", () => {
+    expect(parseDoorayTaskUrl("https://x.dooray.com/task/123/456/")).toBe("456");
+  });
+  it("/task/<projectId>/<postId> 형도 dooray.com 도메인 외 reject", () => {
+    expect(parseDoorayTaskUrl("https://other.com/task/123/456")).toBeNull();
+  });
 });
 
 describe("isLikelyDoorayUrl", () => {

--- a/src/utils/dooray-url.ts
+++ b/src/utils/dooray-url.ts
@@ -1,8 +1,13 @@
 const TASK_URL_RE = /^https?:\/\/[\w.-]+\.dooray\.com\/task\/to\/(\d+)(?:[/?#].*)?$/;
+// alt: /task/<projectId>/<postId> form (자체 호스팅 / 브라우저 주소창 복사)
+const TASK_URL_ALT_RE = /^https?:\/\/[\w.-]+\.dooray\.com\/task\/(\d+)\/(\d+)(?:[/?#].*)?$/;
 
 export function parseDoorayTaskUrl(input: string): string | null {
-  const m = TASK_URL_RE.exec(input);
-  return m ? m[1] : null;
+  const m1 = TASK_URL_RE.exec(input);
+  if (m1) return m1[1];
+  const m2 = TASK_URL_ALT_RE.exec(input);
+  if (m2) return m2[2]; // postId 만 반환 (projectId 는 path[1])
+  return null;
 }
 
 export function isLikelyDoorayUrl(input: string): boolean {

--- a/src/utils/dooray-url.ts
+++ b/src/utils/dooray-url.ts
@@ -1,12 +1,14 @@
 const TASK_URL_RE = /^https?:\/\/[\w.-]+\.dooray\.com\/task\/to\/(\d+)(?:[/?#].*)?$/;
 // alt: /task/<projectId>/<postId> form (자체 호스팅 / 브라우저 주소창 복사)
-const TASK_URL_ALT_RE = /^https?:\/\/[\w.-]+\.dooray\.com\/task\/(\d+)\/(\d+)(?:[/?#].*)?$/;
+// projectId 는 비캡처 — `parseDoorayTaskUrl` 시그니처가 string|null 단일 반환이라 사용 안 함.
+// postId 가 캡처 1 이 되어 short form (`m1[1]`) 과 인덱스 일관.
+const TASK_URL_ALT_RE = /^https?:\/\/[\w.-]+\.dooray\.com\/task\/(?:\d+)\/(\d+)(?:[/?#].*)?$/;
 
 export function parseDoorayTaskUrl(input: string): string | null {
   const m1 = TASK_URL_RE.exec(input);
   if (m1) return m1[1];
   const m2 = TASK_URL_ALT_RE.exec(input);
-  if (m2) return m2[2]; // postId 만 반환 (projectId 는 path[1])
+  if (m2) return m2[1];
   return null;
 }
 

--- a/src/utils/spinner.test.ts
+++ b/src/utils/spinner.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { setQuiet, startSpinner, stopSpinner } from "./spinner.js";
+
+describe("spinner quiet mode", () => {
+  beforeEach(() => setQuiet(false));
+
+  it("setQuiet(true) suppresses stderr output from startSpinner", () => {
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    setQuiet(true);
+    const s = startSpinner("test");
+    expect(stderrWrite).not.toHaveBeenCalled();
+    s.stop();
+    stderrWrite.mockRestore();
+  });
+
+  it("noop proxy: text setter / stop() / succeed() / fail() 호출 안전", () => {
+    setQuiet(true);
+    const s = startSpinner("init");
+    expect(() => {
+      s.text = "updated";
+      s.stop();
+      s.succeed("ok");
+      s.fail("nope");
+    }).not.toThrow();
+  });
+
+  it("setQuiet(false) 복귀 후 정상 동작", () => {
+    setQuiet(false);
+    const s = startSpinner("normal");
+    expect(s).toBeDefined();
+    stopSpinner(true, "done");
+  });
+});

--- a/src/utils/spinner.ts
+++ b/src/utils/spinner.ts
@@ -1,18 +1,34 @@
 import ora, { type Ora } from "ora";
 
 let current: Ora | null = null;
+let quiet = false;
+
+const noopSpinner: Ora = new Proxy({} as Ora, {
+  get(_target, prop) {
+    if (prop === "text" || prop === "prefixText" || prop === "suffixText") return "";
+    if (prop === "isSpinning") return false;
+    // 모든 메서드는 self-chainable no-op
+    return () => noopSpinner;
+  },
+  set() {
+    // text / prefixText / suffixText 등 setter 는 silent ignore
+    return true;
+  },
+});
+
+export function setQuiet(value: boolean): void {
+  quiet = value;
+}
 
 export function startSpinner(text: string): Ora {
+  if (quiet) return noopSpinner;
   current = ora({ text, stream: process.stderr }).start();
   return current;
 }
 
 export function stopSpinner(success?: boolean, text?: string): void {
-  if (!current) return;
-  if (success === false) {
-    current.fail(text);
-  } else {
-    current.succeed(text);
-  }
+  if (!current) return; // quiet 모드에서는 current 가 절대 set 안 되므로 no-op
+  if (success === false) current.fail(text);
+  else current.succeed(text);
   current = null;
 }

--- a/tasks/019-feat-cli-automation-quickwins/index.json
+++ b/tasks/019-feat-cli-automation-quickwins/index.json
@@ -2,8 +2,8 @@
   "name": "019-feat-cli-automation-quickwins",
   "description": "GitHub Issue #35 의 항목 1, 3, 4 를 묶어 자동화 사용성 quick-wins 처리. (1) --json/--quiet 시 spinner 비활성화로 stdout 청결 확보, (2) /task/<projectId>/<postId> 형 Dooray URL 파싱 추가, (3) post create 시 mandatory tag group 사전 검증으로 후보 태그 안내",
   "created_at": "2026-05-07T00:00:00Z",
-  "status": "pending",
-  "current_phase": 1,
+  "status": "completed",
+  "current_phase": 3,
   "total_phases": 3,
   "error_message": null,
   "blocked_reason": null,
@@ -12,23 +12,23 @@
       "number": 1,
       "title": "spinner suppression in --json / --quiet modes",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 2,
       "title": "Dooray URL parser supports /task/<projectId>/<postId>",
       "file": "phase-02.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 3,
       "title": "mandatory tag group pre-validation + completion marking",
       "file": "phase-03.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],
-  "updated_at": "2026-05-07T00:00:00Z"
+  "updated_at": "2026-05-07T08:47:30Z"
 }

--- a/tasks/019-feat-cli-automation-quickwins/phase-01.md
+++ b/tasks/019-feat-cli-automation-quickwins/phase-01.md
@@ -31,11 +31,13 @@ src/index.ts
 
 ## 작업 항목
 
-### 1. `src/utils/spinner.ts` — quiet 모드 추가
+### 1. `src/utils/spinner.ts` — quiet 모드 추가 (no-op proxy 반환)
 
-모듈에 `setQuiet(quiet: boolean)` 함수 추가. quiet=true 이면 `startSpinner` 가 ora 를 시작하지 않고 no-op `Ora` 호환 객체 반환 (또는 null 반환 + 호출자 가드). `stopSpinner` 도 quiet 시 즉시 return.
+모듈에 `setQuiet(quiet: boolean)` 함수 추가. quiet=true 이면 `startSpinner` 가 ora 를 시작하지 않고 **`Ora` 타입을 만족하는 no-op proxy** 반환. 반환 타입은 `Ora` 그대로 유지 → 호출처(`spinner.text = ...`, `spinner.stop()` 등) 무수정.
 
-구현 패턴 (예시):
+> 왜 `Ora | null` 이 아니라 proxy 인가? `obj?.prop = v` 는 ECMAScript 사양상 **SyntaxError** (optional chaining 은 assignment LHS 에 못 씀). 호출처를 모두 `if (spinner) spinner.text = ...` 로 가드하느니 spinner 모듈 안에서 흡수.
+
+구현 패턴 (정확히 이 패턴 사용):
 
 ```ts
 import ora, { type Ora } from "ora";
@@ -43,32 +45,38 @@ import ora, { type Ora } from "ora";
 let current: Ora | null = null;
 let quiet = false;
 
+const noopSpinner: Ora = new Proxy({} as Ora, {
+  get(_target, prop) {
+    if (prop === "text" || prop === "prefixText" || prop === "suffixText") return "";
+    if (prop === "isSpinning") return false;
+    // 모든 메서드는 self-chainable no-op
+    return () => noopSpinner;
+  },
+  set() {
+    // text / prefixText / suffixText 등 setter 는 silent ignore
+    return true;
+  },
+});
+
 export function setQuiet(value: boolean): void {
   quiet = value;
 }
 
-export function startSpinner(text: string): Ora | null {
-  if (quiet) return null;
+export function startSpinner(text: string): Ora {
+  if (quiet) return noopSpinner;
   current = ora({ text, stream: process.stderr }).start();
   return current;
 }
 
 export function stopSpinner(success?: boolean, text?: string): void {
-  if (!current) return;
+  if (!current) return;  // quiet 모드에서는 current 가 절대 set 안 되므로 no-op
   if (success === false) current.fail(text);
   else current.succeed(text);
   current = null;
 }
 ```
 
-`startSpinner` 의 반환 타입 변경 (`Ora` → `Ora | null`) 으로 호출자 영향 점검. 현재 반환값을 변수에 받아 사용하는 곳이 있는지 확인:
-
-```bash
-# cwd: /Users/nhn/personal/dooray-cli
-grep -rn "= startSpinner\|const spinner = startSpinner\|let spinner = startSpinner" src/
-```
-
-기대: `src/commands/post/file/download-all.ts:20` 등 일부. 해당 파일들은 spinner 변수를 사용하면 `spinner?.text = ...` 같은 optional chaining 으로 변경.
+**핵심 약속**: `startSpinner` 반환 타입은 `Ora` 그대로. 따라서 `download-all.ts:39` 의 `spinner.text = ...` 같은 호출처는 **수정 불필요** — proxy 의 set trap 이 silent 흡수.
 
 ### 2. `src/index.ts` — preAction hook 에서 quiet 모드 활성화
 
@@ -88,16 +96,56 @@ program.hook("preAction", () => {
 });
 ```
 
-### 3. spinner 변수 사용처 호환
+### 3. spinner 호출처 영향 검증 (수정 불필요)
 
-`startSpinner` 가 null 반환 가능하므로 변수에 담아 쓰는 곳은 모두 optional chaining. 다음 명령으로 사후 검증:
+작업 1 의 no-op proxy 패턴 덕분에 호출처 코드 변경은 **불필요**. 다음 명령으로 호출처를 확인하고, proxy 가 `spinner.text = ...` / `spinner.stop()` 등을 silent 흡수하는지 빌드/타입체크로 확인:
 
 ```bash
 # cwd: /Users/nhn/personal/dooray-cli
 grep -rnE "(const|let)\s+\w+\s*=\s*startSpinner" src/
+# 기대: download-all.ts:20 같은 1~2건. 본 phase 에서 이 파일들은 수정 안 함.
+
+# Ora setter 호출 패턴 (.text = ...) 파악
+grep -rnE "spinner\.(text|prefixText|suffixText)\s*=" src/
+# 기대: download-all.ts:39 의 1줄. 그대로 유지 — proxy 가 흡수.
+
+pnpm build  # tsup 가 타입 통과 확인
 ```
 
-각 사용처에서 `spinner.text = ...` → `spinner?.text = ...`, `spinner.stop()` → `spinner?.stop()` 등으로 변경. 단순 `startSpinner("...")` (반환값 미사용) 호출은 변경 불필요.
+### 4. `src/utils/spinner.test.ts` — 단위 테스트 (신규)
+
+quiet 모드 회귀 가드.
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { setQuiet, startSpinner, stopSpinner } from "./spinner.js";
+
+describe("spinner quiet mode", () => {
+  beforeEach(() => setQuiet(false));
+
+  it("setQuiet(true) suppresses stderr output from startSpinner", () => {
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    setQuiet(true);
+    const s = startSpinner("test");
+    expect(stderrWrite).not.toHaveBeenCalled();
+    s.stop();
+    stderrWrite.mockRestore();
+  });
+
+  it("noop proxy: text setter / stop() / succeed() / fail() 호출 안전", () => {
+    setQuiet(true);
+    const s = startSpinner("init");
+    expect(() => { s.text = "updated"; s.stop(); s.succeed("ok"); s.fail("nope"); }).not.toThrow();
+  });
+
+  it("setQuiet(false) 복귀 후 정상 동작", () => {
+    setQuiet(false);
+    const s = startSpinner("normal");
+    expect(s).toBeDefined();
+    stopSpinner(true, "done");
+  });
+});
+```
 
 ## 성공 기준
 
@@ -116,9 +164,10 @@ grep -n "export function setQuiet" src/utils/spinner.ts
 grep -n "setQuiet" src/index.ts
 # 기대: 2줄 (import + 호출)
 
-# 4. dist 번들에 setQuiet 포함
-grep -c "setQuiet" dist/index.js
-# 기대: 0 이상 (tsup 이 inline 했으면 다른 형태로 들어가도 OK — 빌드 통과로 갈음)
+# 4. quiet 모드 단위 테스트 — `src/utils/spinner.test.ts` (신규 또는 기존 확장)
+#    setQuiet(true) 후 startSpinner 호출 시 stderr 무출력 + 반환 객체에 .text=... / .stop() 호출 안전
+grep -nE "setQuiet\(true\)" src/utils/spinner.test.ts 2>/dev/null
+# 기대: 1줄 이상
 
 # 5. 수동 검증: --json 파이프 청결성 (executor 가 빌드 후 직접 실행)
 node dist/index.js --help >/dev/null 2>&1

--- a/tasks/019-feat-cli-automation-quickwins/phase-02.md
+++ b/tasks/019-feat-cli-automation-quickwins/phase-02.md
@@ -2,7 +2,7 @@
 
 ## 컨텍스트
 
-GitHub Issue #35 의 4번 항목. `dooray post get "https://<tenant>.dooray.com/task/3052841357365230129/4301717914215750193"` 가 reject 됨. 현재 regex 는 `/task/to/<id>` 만 허용.
+GitHub Issue #35 의 4번 항목. `dooray post get "https://<tenant>.dooray.com/task/1234567890123456789/9876543210987654321"` 가 reject 됨. 현재 regex 는 `/task/to/<id>` 만 허용.
 
 코드 현황:
 - `src/utils/dooray-url.ts` — `TASK_URL_RE = /^https?:\/\/[\w.-]+\.dooray\.com\/task\/to\/(\d+)(?:[/?#].*)?$/` (단일 패턴)
@@ -88,7 +88,7 @@ grep -nE "TASK_URL_ALT_RE|/task/\\\\d\\+/\\\\d\\+" src/utils/dooray-url.ts
 # 기대: 1줄 이상 매칭
 
 # 3. 신규 테스트 케이스 추가 확인
-grep -cE "/task/<projectId>/<postId> 형|task/3052841357365230129/4301717914215750193" src/utils/dooray-url.test.ts
+grep -cE "/task/<projectId>/<postId> 형|task/1234567890123456789/9876543210987654321" src/utils/dooray-url.test.ts
 # 기대: 1 이상
 
 # 4. 기존 케이스 회귀 없음 — 기존 7 케이스 + 신규 4 = 총 11 케이스

--- a/tasks/019-feat-cli-automation-quickwins/phase-02.md
+++ b/tasks/019-feat-cli-automation-quickwins/phase-02.md
@@ -58,8 +58,9 @@ export function parseDoorayTaskUrl(input: string): string | null {
 
 ```ts
 it("/task/<projectId>/<postId> 형 URL 에서 postId 추출", () => {
-  expect(parseDoorayTaskUrl("https://nhnent.dooray.com/task/3052841357365230129/4301717914215750193"))
-    .toBe("4301717914215750193");
+  // PII 게이트 — 사내 도메인 / 실제 19자리 ID 사용 금지. 승인된 dummy 만 사용.
+  expect(parseDoorayTaskUrl("https://example.dooray.com/task/1234567890123456789/9876543210987654321"))
+    .toBe("9876543210987654321");
 });
 it("/task/<projectId>/<postId> 형도 query string 무시", () => {
   expect(parseDoorayTaskUrl("https://x.dooray.com/task/123/456?ref=foo"))

--- a/tasks/019-feat-cli-automation-quickwins/phase-03.md
+++ b/tasks/019-feat-cli-automation-quickwins/phase-03.md
@@ -119,13 +119,52 @@ const [tagIds, parentPostId, milestoneId] = await Promise.all([
 
 `validateMandatoryTags` 는 통과 시 void 반환. throw 가 발생하지 않으면 `tagIds` 는 undefined 그대로 → 기존 `...(tagIds && tagIds.length > 0 && { tagIds })` 분기와 호환.
 
-### 3. 마지막 phase — index.json 완료 마킹
+### 3. `src/resolvers/tag.test.ts` — `validateMandatoryTags` 단위 테스트 (신규 또는 기존 확장)
+
+mocked client 로 mandatory 그룹 검증 분기를 회귀 가드. 최소 3 케이스:
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import { validateMandatoryTags } from "./tag.js";
+import type { DoorayApiClient } from "../api/client.js";
+
+function mockClient(tags: Array<{ id: string; name: string; tagGroupId?: string; groupMandatory?: boolean }>): DoorayApiClient {
+  return { listProjectTags: vi.fn().mockResolvedValue({ result: tags }) } as unknown as DoorayApiClient;
+}
+
+describe("validateMandatoryTags", () => {
+  it("mandatory 그룹 0개면 throw 없이 통과", async () => {
+    const client = mockClient([{ id: "1", name: "bug" }]);
+    await expect(validateMandatoryTags(client, "<project>")).resolves.toBeUndefined();
+  });
+
+  it("mandatory 그룹 다중 — 메시지에 그룹별 후보 포함", async () => {
+    const client = mockClient([
+      { id: "1", name: "p0", tagGroupId: "g1", groupMandatory: true },
+      { id: "2", name: "p1", tagGroupId: "g1", groupMandatory: true },
+      { id: "3", name: "fix", tagGroupId: "g2", groupMandatory: true },
+    ]);
+    await expect(validateMandatoryTags(client, "<project>")).rejects.toThrow(/p0|p1|fix/);
+  });
+
+  it("groupId 없는 mandatory 태그는 무시 (false-positive 방지)", async () => {
+    const client = mockClient([{ id: "1", name: "x", groupMandatory: true }]);
+    await expect(validateMandatoryTags(client, "<project>")).resolves.toBeUndefined();
+  });
+});
+```
+
+(정확한 함수 시그니처·throw 형태는 작업 1·2 의 구현에 맞춰 케이스 본문 조정.)
+
+### 4. 마지막 phase — index.json 완료 마킹
 
 phase-03 가 마지막이므로 본 phase commit 에 `tasks/019-feat-cli-automation-quickwins/index.json` 의 모든 status 를 `completed` 로 변경 포함.
 
+`sed -i ''` 는 BSD 전용이라 GNU sed (Linux) 에서 실패. **권장**: Edit 도구로 4개 위치 직접 치환. 또는 portable node 한 줄:
+
 ```bash
 # cwd: /Users/nhn/personal/dooray-cli
-sed -i '' 's/"status": "pending"/"status": "completed"/g' tasks/019-feat-cli-automation-quickwins/index.json
+node -e "const fs=require('fs');const f='tasks/019-feat-cli-automation-quickwins/index.json';const d=JSON.parse(fs.readFileSync(f,'utf8'));d.status='completed';d.current_phase=3;d.phases.forEach(p=>p.status='completed');d.updated_at=new Date().toISOString();fs.writeFileSync(f,JSON.stringify(d,null,2)+'\n');"
 
 # 검증: status: completed 가 4개 (index 1 + phases 3)
 grep -c '"status": "completed"' tasks/019-feat-cli-automation-quickwins/index.json
@@ -153,7 +192,11 @@ grep -n "validateMandatoryTags" src/commands/post/create.ts
 grep -n "buildMandatoryHint" src/resolvers/tag.ts
 # 기대: 3줄 이상 (정의 + resolveTags 호출 + validateMandatoryTags 호출)
 
-# 5. index.json 완료 마킹
+# 5. validateMandatoryTags 단위 테스트 추가
+grep -cE 'validateMandatoryTags.*resolves|validateMandatoryTags.*rejects' src/resolvers/tag.test.ts
+# 기대: 3 이상 (3 케이스)
+
+# 6. index.json 완료 마킹
 grep -c '"status": "completed"' tasks/019-feat-cli-automation-quickwins/index.json
 # 기대: 4
 ```


### PR DESCRIPTION
## Summary

Issue #35 의 항목 1, 3, 4 를 묶은 자동화 사용성 quick-wins.

### 1. `--json` / `--quiet` 시 spinner 억제 (item 1)

`dooray post get <project> <num> --json | jq '.id'` 같은 파이프에서 spinner 출력 (`- 업무 조회 중...` / `✔ 업무 조회 완료`) 이 stdout 에 섞여 jq 가 실패하던 문제 해결.

- `src/utils/spinner.ts`: `setQuiet(quiet: boolean)` 추가. quiet 모드면 `startSpinner` 가 ora 대신 **no-op `Proxy<Ora>`** 반환 → `spinner.text = "..."` / `spinner.stop()` 같은 호출처 코드 무수정.
- `src/index.ts` preAction hook 에서 `--json` 또는 `--quiet` 감지 시 `setQuiet(true)`.

### 2. 브라우저 주소창 복사본 URL 파싱 (item 4)

`https://<tenant>.dooray.com/task/<projectId>/<postId>` 형 URL 도 첫 인자로 받을 수 있게 확장.

- `src/utils/dooray-url.ts`: `TASK_URL_ALT_RE` 추가, `parseDoorayTaskUrl` 이 두 정규식 순차 매칭. 시그니처 (`string | null`) 유지 → `resolvePostInput` 호출처 무수정.

### 3. mandatory tag 사전 검증 (item 3)

`post create` 가 mandatory 그룹 누락을 API 호출 후에야 알게 되어 사용자 메시지가 불친절한 문제 해결.

- `src/resolvers/tag.ts`: `validateMandatoryTags` + `buildMandatoryHint` export. mandatory 그룹별 후보 태그를 에러 메시지에 포함.
- `src/commands/post/create.ts`: 태그 0-input 분기에서 `validateMandatoryTags` 호출 → 친화적 에러.
- ADR-019 정책 (mandatory 사전 검증 + 후보 목록 + ADR-008 모호 처리) 일관 유지.

## Files

- 신규: `src/utils/spinner.test.ts` (3 케이스), `src/resolvers/tag.test.ts` (4 케이스, vi.mock cache 우회)
- 수정: `src/utils/spinner.ts`, `src/index.ts`, `src/utils/dooray-url.ts`, `src/utils/dooray-url.test.ts` (4 케이스 추가, 총 13), `src/resolvers/tag.ts`, `src/commands/post/create.ts`
- 문서: `docs/adr.md` (ADR-020 alt form 정규식 명시), `docs/code-architecture.md` (spinner 억제 + alt URL form 반영), `README.md` (alt URL 예시), `skills/dooray-cli/SKILL.md` (두 형태 병기)

## Test plan

- [x] `pnpm run build` 통과 (152.87 KB)
- [x] `pnpm test` 57/57 pass (8 suites — spinner / tag / dooray-url / feedback-meta / argv-sanitize / config-store / post-input / build)
- [x] `setQuiet(true)` 후 `startSpinner` 호출 시 stderr 무출력 — 단위 테스트
- [x] proxy 의 `set` trap 이 `text=...` 흡수, `get` trap 이 chainable no-op 반환 — 단위 테스트
- [x] mandatory 0개 → no-throw / 다중 그룹 → 메시지에 후보 포함 / `groupId` 없는 mandatory 태그 false-positive 방지 — 단위 테스트

## Review pipeline

build-with-teams:
- critic (opus): REVISE 1회 (3건 fix — optional chain LHS / PII test data / 단위 테스트 누락) → APPROVE
- executor (sonnet): phase 1·2·3 순차 실행
- code-reviewer (sonnet): PASS (Pre-existing PII 2건 노트, 별도 처리 권장)
- docs-verifier (sonnet): UPDATE_NEEDED 4건 (ADR-020 alt form / code-architecture spinner / dooray-url 설명 / README+SKILL alt 형태) → 반영 후 PASS

### Pre-existing PII (별도 처리 — 본 PR scope 외)

- `src/utils/dooray-url.test.ts:6`: 기존 테스트의 `nhnent.dooray.com` + 비승인 19자리 ID
- `src/config/types.ts:24`: `DEFAULTS.tenantName = "nhnent"` 하드코딩

둘 다 cleanup 별도 PR 로 분리 권장.