### PR TITLE
fix(ci): prevent runaway DELETE polling in dummy comment cleanup

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -408,32 +408,28 @@ jobs:
           REPO="${{ github.repository }}"
           PR_NUMBER="${{ env.PR_NUMBER }}"
 
-          # claude[bot] 가 작성한 인라인 댓글만 검사
-          gh api "repos/$REPO/pulls/$PR_NUMBER/comments" \
-            --jq '.[] | select(.user.login == "claude[bot]") | "\(.id)\t\(.body)"' \
-            | while IFS=$'\t' read -r comment_id body; do
-              [ -z "$comment_id" ] && continue
+          # 필터링은 jq 안에서 수행하고 ID 만 출력 — multi-line body 가 bash
+          # `while read` 를 깨뜨리는 사고 방지 (이전 구현은 body 의 개행이 새
+          # entry 로 오인되어 garbage id 로 DELETE 폭주, run 시간 9분+ 폭증).
+          # 정리 조건 (하나라도 만족하면 삭제):
+          #   1) 본문 길이 12자 미만
+          #   2) /^test\s*\d*$/i 같은 단순 placeholder (test, test1, sample, foo 등)
+          #   3) 🔴 / 🟡 severity 마커 부재 (정상 review 형식 미준수)
+          ids=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments" --jq '
+            .[]
+            | select(.user.login == "claude[bot]")
+            | select(
+                (.body | length < 12) or
+                (.body | test("^(test|sample|placeholder|foo|bar|example)\\s*[0-9]*$"; "i")) or
+                ((.body | test("🔴|🟡")) | not)
+              )
+            | .id
+          ')
 
-              # 정리 조건 (하나라도 만족하면 삭제):
-              # 1) 본문 길이 12자 미만
-              # 2) /^test\s*\d*$/i 같은 단순 placeholder (test, test1, test 2, sample, foo 등)
-              # 3) 🔴 / 🟡 severity 마커 부재 (정상 review 형식 미준수)
-              len=${#body}
-              should_delete=0
-
-              if [ "$len" -lt 12 ]; then
-                should_delete=1
-              elif printf '%s' "$body" | grep -qiE '^(test|sample|placeholder|foo|bar|example)[[:space:]]*[0-9]*$'; then
-                should_delete=1
-              elif ! printf '%s' "$body" | grep -qE '🔴|🟡'; then
-                should_delete=1
-              fi
-
-              if [ "$should_delete" = "1" ]; then
-                echo "dummy 인라인 댓글 자동 삭제: id=$comment_id body=\"$body\""
-                gh api "repos/$REPO/pulls/comments/$comment_id" --method DELETE || true
-              fi
-            done
+          for id in $ids; do
+            echo "dummy 인라인 댓글 자동 삭제: id=$id"
+            gh api "repos/$REPO/pulls/comments/$id" --method DELETE || true
+          done
 
       # 작업 결과를 /review 댓글에 ✅/❌ reaction 으로 표시 (success/failure 분기, always 실행)
       - name: /review 댓글에 종료 reaction 추가


### PR DESCRIPTION
## Summary

`.github/workflows/claude-code-review.yml` 의 "dummy 인라인 댓글 자동 삭제" step 에서 multi-line body 파싱 버그로 인한 runaway DELETE polling 수정.

## Background

PR #38 의 cleanup step 이 **9분 8초** 걸린 사고 발생. 정상적으론 수 초.

## Root cause

`gh api ... --jq '"\(.id)\t\(.body)"'` 출력을 bash `while IFS=$'\t' read -r comment_id body` 로 파싱:

- claude bot 리뷰 댓글의 body 는 거의 항상 **여러 줄** (개행 포함)
- `while read` 는 한 줄만 읽음 → body 의 두 번째 줄 이후가 **새 entry 로 오인**
- 그 줄 전체가 `comment_id` 로 들어감 (예: `**수정**:`)
- garbage id 로 `gh api .../comments/**수정**: DELETE` → 매번 404 + 네트워크 round-trip

PR #38 로그에 `id=**수정**: body=""` 가 명확한 증거.

## Fix

**필터링을 jq 안으로 이동, ID 만 출력**:

```bash
ids=$(gh api "..." --jq '
  .[]
  | select(.user.login == "claude[bot]")
  | select(
      (.body | length < 12) or
      (.body | test("^(test|sample|placeholder|foo|bar|example)\\s*[0-9]*$"; "i")) or
      ((.body | test("🔴|🟡")) | not)
    )
  | .id
')

for id in $ids; do
  gh api "repos/$REPO/pulls/comments/$id" --method DELETE || true
done
```

핵심:
1. **JSON parser (jq) 가 multi-line body 안전 처리** — bash `while read` 로 새는 일 없음
2. **ID 만 출력** (한 줄당 숫자 하나) — bash `for` loop 으로 순회
3. **이모지 매칭도 jq `test()` (PCRE)** — bash `grep` 의 locale 의존성 제거

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` 통과
- [ ] 다음 PR review run 에서 cleanup step 실행 시간이 정상 (수 초) 인지 확인 — 머지 후 자연 검증