### PR TITLE
feat(commands): add post comment file 4 commands (list/upload/download/delete)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ bash scripts/benchmark.sh [project] [post-number] [wiki-page-id]
 - `post edit`, `comment edit`은 `--title`/`--body` 옵션으로 non-interactive 사용 가능 (`--subject`는 deprecated alias, stderr 경고 후 동작)
 - `post create`는 `--title` 필수 (또는 `--subject` alias)
 - `post create`는 `--tag` (반복) / `--parent` (`code/number` 또는 raw postId) / `--workflow` / `--milestone` 지원. mandatory-tag 그룹은 클라이언트가 사전 검증
-- post 하위 12개 명령(get/edit/done/workflow + comment 4개 + file 5개)은 `<project> <post-number>` 외에도 `--id <postId>` / `--url <url>` / 첫 positional에 Dooray URL 직접 입력 지원. `resolvePostInput` 단일 헬퍼에서 분기
+- post 하위 16개 명령(get/edit/done/workflow + comment 4개 + file 5개 + comment file 4개)은 `<project> <post-number>` 외에도 `--id <postId>` / `--url <url>` / 첫 positional에 Dooray URL 직접 입력 지원. `resolvePostInput` 단일 헬퍼에서 분기
 - `dooray post comment file *` 4 명령(list/upload/download/delete) — 댓글에 첨부된 파일 관리. Dooray 가 댓글 전용 endpoint 미지원이라 내부적으로 post-level files API + 댓글 본문 PUT(`![filename](/files/<id>)` markdown) 합성으로 동작 (ADR-024). `delete` 는 markdown 제거 + 파일 삭제 둘 다 수행 (atomic 보장 없음 — 부분 성공 시 stderr 안내 + non-zero exit)
 - `dooray member get/list` 명령으로 표시명 조회. `post comment list` table 출력은 Creator 컬럼을 project 멤버 캐시로 enrich (단 `--json`은 raw 유지)
 - `dooray feedback`은 GitHub issue를 `gh` CLI에 위임해서 생성. baseUrl/시크릿은 자동 메타에 미포함. `--last`로 직전 명령의 sanitized argv + 에러를 본문 상단에 자동 첨부 (opt-in: `dooray config set track-last-run true`, ADR-023)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ dooray post get <project> 42                  # 업무 상세
 dooray post get <project> 42 --json           # JSON 출력
 ```
 
-#### 업무 식별 방식 (post 하위 12개 명령 공통)
+#### 업무 식별 방식 (post 하위 16개 명령 공통)
 
 | 방식 | 예시 |
 |---|---|
@@ -262,6 +262,28 @@ dooray post file upload   --url <url> --file ./report.pdf
 dooray post comment edit  --url <url> --comment-id <commentId> --body "..."
 dooray post comment delete --url <url> --comment-id <commentId>
 ```
+
+### 댓글 첨부 파일 (`post comment file *`)
+
+자동화로 댓글에 인라인 이미지 / 파일을 삽입할 때 사용. 4 명령 (list/upload/download/delete) 모두 `<project> <post-number> <comment-id>` 또는 `--id <postId> --comment-id <logId>` / `--url <url> --comment-id <logId>` 패턴 지원 (ADR-020).
+
+```bash
+# 첨부 목록
+dooray post comment file list <project> <post-num> <comment-id>
+
+# 업로드 (post-level files API 로 업로드 + 댓글 본문에 markdown reference append)
+dooray post comment file upload <project> <post-num> <comment-id> ./screenshot.png
+
+# 다운로드 (post-level 파일과 동일 — UX 일관성 wrapper)
+dooray post comment file download <project> <post-num> <comment-id> <file-id> --out ./out.png
+
+# 삭제 (댓글 본문 markdown 제거 + post-level 파일 삭제, --yes 로 confirm 생략)
+dooray post comment file delete <project> <post-num> <comment-id> <file-id> --yes
+```
+
+> Dooray REST API 가 댓글 전용 attachment endpoint 를 제공하지 않아 내부적으로
+> post-level files API 와 댓글 본문 PUT 의 합성으로 동작 (ADR-024). 단일 명령
+> = 단일 파일 — 다중 파일은 호출자가 반복 호출.
 
 ## 출력 모드
 

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -71,6 +71,7 @@ src/
     mention.ts              # 멤버·그룹 멘션 마크업 빌더 + prependMentions (Issue #25)
     feedback-meta.ts        # CLI 버전·환경 수집 + GitHub issue body 빌더 + buildLastRunBlock (ADR-022, ADR-023)
     argv-sanitize.ts        # argv 시크릿 패턴 마스킹 (--api-key/--token/--password/Authorization, ADR-023)
+    comment-files.ts        # appendFileReference / removeFileReference — 댓글 본문 markdown reference 조작 (ADR-024)
 
   commands/
     setup.ts                # dooray setup — 대화형 초기 설정 마법사 (스킬 설치 포함)
@@ -105,6 +106,12 @@ src/
         add.ts
         edit.ts
         delete.ts
+        file/
+          index.ts            # commentFileCommand 조립
+          list.ts             # 댓글 첨부 목록 (getPostComment → .files, ADR-024)
+          upload.ts           # 파일 업로드 + 댓글 reference append
+          download.ts         # post-level 다운로드 wrapper (UX 일관성, ADR-024)
+          delete.ts           # reference 제거 + 파일 삭제 (atomic 보장 X, ADR-024)
       file/
         list.ts               # 첨부파일 목록
         download.ts           # 단일 파일 다운로드

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -45,7 +45,7 @@ dooray doctor                                 # 설정 검증
 
 자연어 요청을 커맨드로 변환할 때 아래 표를 참고한다.
 
-> **공통 (post 하위 12개 명령)**: `post get`/`edit`/`done`/`workflow`, `post comment list`/`add`/`edit`/`delete`, `post file list`/`upload`/`download`/`download-all`/`delete`는 `<project> <number>` 외에도 `--id <postId>`, `--url <url>`, 또는 첫 인자에 Dooray URL(`https://*.dooray.com/task/to/<postId>` 또는 브라우저 주소창 복사본 `https://*.dooray.com/task/<projectId>/<postId>`)을 직접 받는다. **사용자가 URL을 줬으면 그대로 첫 인자로 전달**하는 것이 가장 빠른 경로 (resolve 단계 단축, ADR-020).
+> **공통 (post 하위 16개 명령)**: `post get`/`edit`/`done`/`workflow`, `post comment list`/`add`/`edit`/`delete`, `post file list`/`upload`/`download`/`download-all`/`delete`, `post comment file list`/`upload`/`download`/`delete`는 `<project> <number>` 외에도 `--id <postId>`, `--url <url>`, 또는 첫 인자에 Dooray URL(`https://*.dooray.com/task/to/<postId>` 또는 브라우저 주소창 복사본 `https://*.dooray.com/task/<projectId>/<postId>`)을 직접 받는다. **사용자가 URL을 줬으면 그대로 첫 인자로 전달**하는 것이 가장 빠른 경로 (resolve 단계 단축, ADR-020).
 
 | 의도 | 커맨드 |
 |------|--------|
@@ -87,6 +87,10 @@ dooray doctor                                 # 설정 검증
 | 전체 첨부파일 다운로드 | `dooray post file download-all <project> <number>` |
 | 첨부파일 업로드 | `dooray post file upload <project> <number> <file-path>` |
 | 첨부파일 삭제 | `dooray post file delete <project> <number> <file-id>` |
+| 댓글 첨부 목록 | `dooray post comment file list <project> <number> <comment-id>` |
+| 댓글 파일 업로드 | `dooray post comment file upload <project> <number> <comment-id> <path>` |
+| 댓글 파일 다운로드 | `dooray post comment file download <project> <number> <comment-id> <file-id>` |
+| 댓글 파일 삭제 | `dooray post comment file delete <project> <number> <comment-id> <file-id> --yes` |
 
 > **제목 옵션 네이밍**: `post` 와 `wiki page` 모두 `--title` 표준. `post`의 `--subject`는 deprecated alias로 당분간 동작하되, 새 코드에서는 `--title` 사용을 권장.
 
@@ -154,6 +158,18 @@ dooray post get <project> 42 --json
 dooray post comment add <project> 42 --body "진행 상황 업데이트: 80% 완료"
 ```
 
+### 시나리오 — 댓글에 스크린샷 자동 첨부
+
+스크립트가 스크린샷을 댓글에 삽입하거나, 에이전트가 결과 파일을 첨부 댓글로 보고할 때 사용. Dooray REST API 가 댓글 전용 attachment endpoint 를 미지원하므로 내부적으로 post-level files API + 댓글 본문 PUT 합성으로 동작 (ADR-024).
+
+```bash
+# 1. 댓글을 먼저 만든다 (텍스트만, --json 으로 commentId 획득)
+COMMENT_ID=$(dooray post comment add <project> <post-num> --body "스크린샷 보고:" --json | jq -r '.id')
+
+# 2. 그 댓글에 파일을 첨부 (post-level 업로드 + 댓글 본문 markdown 자동 추가)
+dooray post comment file upload <project> <post-num> "$COMMENT_ID" ./screenshot.png
+```
+
 ### 위키 페이지 조회
 
 ```bash
@@ -169,9 +185,9 @@ dooray wiki page get <project> <pageId> --json
 
 ## 커맨드 상세
 
-### 업무 식별 방식 (post 하위 12개 명령 공통, ADR-020)
+### 업무 식별 방식 (post 하위 16개 명령 공통, ADR-020)
 
-`post get`/`edit`/`done`/`workflow`, `post comment list`/`add`/`edit`/`delete`, `post file list`/`upload`/`download`/`download-all`/`delete`는 4가지 입력을 모두 받는다:
+`post get`/`edit`/`done`/`workflow`, `post comment list`/`add`/`edit`/`delete`, `post file list`/`upload`/`download`/`download-all`/`delete`, `post comment file list`/`upload`/`download`/`delete`는 4가지 입력을 모두 받는다:
 
 ```bash
 # (1) 기존 positional — 가장 익숙한 형태

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -297,6 +297,20 @@ export class DoorayApiClient {
     }
   }
 
+  async getPostComment(
+    projectId: string,
+    postId: string,
+    logId: string,
+  ): Promise<PostCommentDetailResponse> {
+    try {
+      return await this.api
+        .get(`project/v1/projects/${projectId}/posts/${postId}/logs/${logId}`)
+        .json<PostCommentDetailResponse>();
+    } catch (e) {
+      return toDoorayCliError(e);
+    }
+  }
+
   async createPostComment(projectId: string, postId: string, body: CreateCommentRequest): Promise<CreateCommentApiResponse> {
     try {
       return await this.api

--- a/src/commands/post/comment/file/delete.ts
+++ b/src/commands/post/comment/file/delete.ts
@@ -1,0 +1,118 @@
+import { Command } from "commander";
+import { getConfigOrThrow } from "../../../../config/store.js";
+import { DoorayApiClient } from "../../../../api/client.js";
+import { resolvePostInput } from "../../../../resolvers/post-input.js";
+import { startSpinner, stopSpinner } from "../../../../utils/spinner.js";
+import { DoorayCliError } from "../../../../utils/errors.js";
+import { EXIT_PARAM_ERROR, EXIT_API_ERROR } from "../../../../utils/exit-codes.js";
+import { removeFileReference } from "../../../../utils/comment-files.js";
+
+export const deleteCommentFileCommand = new Command("delete")
+  .description("댓글 첨부 파일 삭제 (댓글 본문 reference 제거 + 파일 삭제, ADR-024)")
+  .argument("[arg1]", "프로젝트 코드, Dooray URL, 또는 (`--id`/`--url` 모드일 때) 댓글 ID")
+  .argument("[arg2]", "업무 번호 또는 (`--id`/`--url` 모드일 때) 파일 ID")
+  .argument("[arg3]", "댓글 ID (positional 모드)")
+  .argument("[arg4]", "파일 ID (positional 모드)")
+  .option("--id <postId>", "Dooray post ID (project/post-number 대신)")
+  .option("--url <url>", "Dooray 업무 URL (project/post-number 대신)")
+  .option("--comment-id <logId>", "댓글 ID (positional 대체)")
+  .option("--file-id <fileId>", "파일 ID (positional 대체)")
+  .option("--yes", "확인 없이 삭제")
+  .action(async (arg1, arg2, arg3, arg4, opts) => {
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+
+    let projectArg: string | undefined;
+    let postNumberArg: string | undefined;
+    let logId: string | undefined = opts.commentId;
+    let fileId: string | undefined = opts.fileId;
+
+    if (opts.id || opts.url) {
+      if (arg3 || arg4) {
+        throw new DoorayCliError(
+          "--id/--url 모드에서는 댓글 ID 와 파일 ID 외 추가 positional 인자를 받지 않습니다.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+      logId = logId ?? arg1;
+      fileId = fileId ?? arg2;
+    } else if (arg4) {
+      projectArg = arg1;
+      postNumberArg = arg2;
+      logId = logId ?? arg3;
+      fileId = fileId ?? arg4;
+    } else if (arg3) {
+      projectArg = arg1;
+      postNumberArg = arg2;
+      logId = logId ?? arg3;
+    } else if (arg1 && !arg2) {
+      projectArg = arg1;
+    } else {
+      projectArg = arg1;
+      postNumberArg = arg2;
+    }
+
+    if (!logId) {
+      throw new DoorayCliError(
+        "<comment-id>가 필요합니다. positional 3번째 또는 --comment-id 옵션을 사용하세요.",
+        EXIT_PARAM_ERROR,
+      );
+    }
+    if (!fileId) {
+      throw new DoorayCliError(
+        "<file-id>가 필요합니다. positional 4번째 또는 --file-id 옵션을 사용하세요.",
+        EXIT_PARAM_ERROR,
+      );
+    }
+
+    if (!opts.yes) {
+      const { confirm } = await import("@inquirer/prompts");
+      const ok = await confirm({
+        message: `댓글 본문에서 reference 를 제거하고 파일(${fileId})을 삭제합니다. 같은 post 의 다른 댓글에서 같은 파일 ID 를 참조하는 경우 broken 됩니다. 계속하시겠습니까?`,
+      });
+      if (!ok) {
+        process.stdout.write("취소되었습니다.\n");
+        return;
+      }
+    }
+
+    const { projectId, postId } = await resolvePostInput(client, {
+      projectArg,
+      postNumberArg,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+    });
+
+    // Step 1: 댓글 본문에서 reference 제거
+    startSpinner("댓글 본문 reference 제거 중...");
+    try {
+      const commentRes = await client.getPostComment(projectId, postId, logId);
+      const currentBody = commentRes.result.body.content;
+      const newBody = removeFileReference(currentBody, fileId);
+      await client.updatePostComment(projectId, postId, logId, {
+        body: { mimeType: "text/x-markdown", content: newBody },
+      });
+      stopSpinner(true, "reference 제거 완료");
+    } catch {
+      stopSpinner(false, "");
+      throw new DoorayCliError(
+        `댓글 본문 reference 제거 실패. 파일 삭제를 진행하지 않습니다. fileId=${fileId}`,
+        EXIT_API_ERROR,
+      );
+    }
+
+    // Step 2: 파일 삭제
+    startSpinner("파일 삭제 중...");
+    try {
+      await client.deletePostFile(projectId, postId, fileId);
+      stopSpinner(true, "파일 삭제 완료");
+    } catch {
+      stopSpinner(false, "");
+      throw new DoorayCliError(
+        `댓글 본문 reference 제거 OK / 파일 삭제 실패. 'dooray post file delete' 로 후처리하세요. fileId=${fileId}`,
+        EXIT_API_ERROR,
+      );
+    }
+
+    process.stdout.write(`파일(${fileId})이 댓글(${logId})에서 삭제되었습니다.\n`);
+  });

--- a/src/commands/post/comment/file/download.ts
+++ b/src/commands/post/comment/file/download.ts
@@ -1,0 +1,80 @@
+import { Command } from "commander";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { getConfigOrThrow } from "../../../../config/store.js";
+import { DoorayApiClient } from "../../../../api/client.js";
+import { resolvePostInput } from "../../../../resolvers/post-input.js";
+import { startSpinner, stopSpinner } from "../../../../utils/spinner.js";
+import { DoorayCliError } from "../../../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../../../utils/exit-codes.js";
+
+export const downloadCommentFileCommand = new Command("download")
+  .description(
+    "댓글에 첨부된 파일 다운로드 (현재 comment-id 는 미사용 — 멘탈 모델 일관성, 미래 댓글 단위 권한 호환용)",
+  )
+  .argument("[arg1]", "프로젝트 코드, Dooray URL, 또는 (`--id`/`--url` 모드일 때) 댓글 ID")
+  .argument("[arg2]", "업무 번호 또는 (`--id`/`--url` 모드일 때) 파일 ID")
+  .argument("[arg3]", "댓글 ID (positional 모드)")
+  .argument("[arg4]", "파일 ID (positional 모드)")
+  .option("--id <postId>", "Dooray post ID (project/post-number 대신)")
+  .option("--url <url>", "Dooray 업무 URL (project/post-number 대신)")
+  .option("--comment-id <logId>", "댓글 ID (positional 대체)")
+  .option("--file-id <fileId>", "파일 ID (positional 대체)")
+  .option("--out <path>", "저장 경로 (미지정 시 현재 디렉토리에 원본 파일명으로 저장)", ".")
+  .action(async (arg1, arg2, arg3, arg4, opts) => {
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+
+    let projectArg: string | undefined;
+    let postNumberArg: string | undefined;
+    // commentId 는 UX 일관성 목적으로 받지만 download API 호출에는 사용 안 함
+    let _commentId: string | undefined = opts.commentId;
+    let fileId: string | undefined = opts.fileId;
+
+    if (opts.id || opts.url) {
+      if (arg3 || arg4) {
+        throw new DoorayCliError(
+          "--id/--url 모드에서는 댓글 ID 와 파일 ID 외 추가 positional 인자를 받지 않습니다.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+      _commentId = _commentId ?? arg1;
+      fileId = fileId ?? arg2;
+    } else if (arg4) {
+      projectArg = arg1;
+      postNumberArg = arg2;
+      _commentId = _commentId ?? arg3;
+      fileId = fileId ?? arg4;
+    } else if (arg3) {
+      projectArg = arg1;
+      postNumberArg = arg2;
+      _commentId = _commentId ?? arg3;
+    } else if (arg1 && !arg2) {
+      projectArg = arg1;
+    } else {
+      projectArg = arg1;
+      postNumberArg = arg2;
+    }
+
+    if (!fileId) {
+      throw new DoorayCliError(
+        "<file-id>가 필요합니다. positional 4번째 또는 --file-id 옵션을 사용하세요.",
+        EXIT_PARAM_ERROR,
+      );
+    }
+
+    startSpinner("파일 다운로드 중...");
+    const { projectId, postId } = await resolvePostInput(client, {
+      projectArg,
+      postNumberArg,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+    });
+    const { buffer, fileName } = await client.downloadPostFile(projectId, postId, fileId);
+
+    const outputPath = join(opts.out, fileName);
+    await writeFile(outputPath, Buffer.from(buffer));
+    stopSpinner(true, "다운로드 완료");
+
+    process.stdout.write(`${outputPath}\n`);
+  });

--- a/src/commands/post/comment/file/download.ts
+++ b/src/commands/post/comment/file/download.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import { writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { getConfigOrThrow } from "../../../../config/store.js";
 import { DoorayApiClient } from "../../../../api/client.js";
 import { resolvePostInput } from "../../../../resolvers/post-input.js";
@@ -72,7 +72,8 @@ export const downloadCommentFileCommand = new Command("download")
     });
     const { buffer, fileName } = await client.downloadPostFile(projectId, postId, fileId);
 
-    const outputPath = join(opts.out, fileName);
+    const safeName = basename(fileName);
+    const outputPath = join(opts.out, safeName);
     await writeFile(outputPath, Buffer.from(buffer));
     stopSpinner(true, "다운로드 완료");
 

--- a/src/commands/post/comment/file/index.ts
+++ b/src/commands/post/comment/file/index.ts
@@ -1,0 +1,12 @@
+import { Command } from "commander";
+import { listCommentFileCommand } from "./list.js";
+import { uploadCommentFileCommand } from "./upload.js";
+import { downloadCommentFileCommand } from "./download.js";
+import { deleteCommentFileCommand } from "./delete.js";
+
+export const commentFileCommand = new Command("file")
+  .description("댓글 첨부 파일 관리 (post-level files API + 댓글 PUT 합성, ADR-024)")
+  .addCommand(listCommentFileCommand)
+  .addCommand(uploadCommentFileCommand)
+  .addCommand(downloadCommentFileCommand)
+  .addCommand(deleteCommentFileCommand);

--- a/src/commands/post/comment/file/list.ts
+++ b/src/commands/post/comment/file/list.ts
@@ -1,0 +1,94 @@
+import { Command } from "commander";
+import { getConfigOrThrow } from "../../../../config/store.js";
+import { DoorayApiClient } from "../../../../api/client.js";
+import { resolvePostInput } from "../../../../resolvers/post-input.js";
+import { output, printJson, type OutputOptions } from "../../../../formatters/table.js";
+import { startSpinner, stopSpinner } from "../../../../utils/spinner.js";
+import { DoorayCliError } from "../../../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../../../utils/exit-codes.js";
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+export const listCommentFileCommand = new Command("list")
+  .description("댓글 첨부 파일 목록 조회")
+  .argument("[arg1]", "프로젝트 코드, Dooray URL, 또는 (`--id`/`--url` 모드일 때) 댓글 ID")
+  .argument("[arg2]", "업무 번호 (positional 모드)")
+  .argument("[arg3]", "댓글 ID (positional 3개 모드)")
+  .option("--id <postId>", "Dooray post ID (project/post-number 대신)")
+  .option("--url <url>", "Dooray 업무 URL (project/post-number 대신)")
+  .option("--comment-id <logId>", "댓글 ID (positional 대체)")
+  .action(async (arg1, arg2, arg3, opts) => {
+    const globalOpts = listCommentFileCommand.optsWithGlobals() as OutputOptions;
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+
+    let projectArg: string | undefined;
+    let postNumberArg: string | undefined;
+    let logId: string | undefined = opts.commentId;
+
+    if (opts.id || opts.url) {
+      if (arg2 || arg3) {
+        throw new DoorayCliError(
+          "--id/--url 모드에서는 댓글 ID 외 추가 positional 인자를 받지 않습니다. --comment-id 옵션 사용을 권장합니다.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+      logId = logId ?? arg1;
+    } else if (arg3) {
+      projectArg = arg1;
+      postNumberArg = arg2;
+      logId = logId ?? arg3;
+    } else if (arg1 && !arg2) {
+      projectArg = arg1;
+      if (!logId) {
+        throw new DoorayCliError(
+          "URL/--id 모드에서는 --comment-id 옵션이 필요합니다.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+    } else {
+      projectArg = arg1;
+      postNumberArg = arg2;
+      if (!logId) {
+        throw new DoorayCliError(
+          "<comment-id>가 필요합니다. positional 3번째 또는 --comment-id 옵션을 사용하세요.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+    }
+
+    if (!logId) {
+      throw new DoorayCliError("<comment-id>가 필요합니다.", EXIT_PARAM_ERROR);
+    }
+
+    startSpinner("댓글 첨부 파일 목록 조회 중...");
+    const { projectId, postId } = await resolvePostInput(client, {
+      projectArg,
+      postNumberArg,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+    });
+    const res = await client.getPostComment(projectId, postId, logId);
+    const files = res.result.files ?? [];
+    stopSpinner(true, `첨부 파일 ${files.length}개`);
+
+    if (files.length === 0) {
+      if (globalOpts.json) {
+        process.stdout.write("[]\n");
+      } else {
+        process.stderr.write("첨부 없음\n");
+      }
+      return;
+    }
+
+    output(globalOpts, {
+      headers: ["파일명", "크기", "ID"],
+      rows: files.map((f) => [f.name, formatSize(f.size), f.id]),
+      raw: files,
+      ids: files.map((f) => f.id),
+    });
+  });

--- a/src/commands/post/comment/file/list.ts
+++ b/src/commands/post/comment/file/list.ts
@@ -79,8 +79,8 @@ export const listCommentFileCommand = new Command("list")
     if (files.length === 0) {
       if (globalOpts.json) {
         process.stdout.write("[]\n");
-      } else {
-        process.stderr.write("첨부 없음\n");
+      } else if (!globalOpts.quiet) {
+        process.stdout.write("첨부 없음\n");
       }
       return;
     }

--- a/src/commands/post/comment/file/upload.ts
+++ b/src/commands/post/comment/file/upload.ts
@@ -1,0 +1,107 @@
+import { Command } from "commander";
+import { getConfigOrThrow } from "../../../../config/store.js";
+import { DoorayApiClient } from "../../../../api/client.js";
+import { resolvePostInput } from "../../../../resolvers/post-input.js";
+import { basename } from "node:path";
+import { printJson, type OutputOptions } from "../../../../formatters/table.js";
+import { startSpinner, stopSpinner } from "../../../../utils/spinner.js";
+import { DoorayCliError } from "../../../../utils/errors.js";
+import { EXIT_PARAM_ERROR, EXIT_API_ERROR } from "../../../../utils/exit-codes.js";
+import { appendFileReference } from "../../../../utils/comment-files.js";
+
+export const uploadCommentFileCommand = new Command("upload")
+  .description("댓글에 파일 업로드 (post-level 파일 업로드 + 댓글 reference 추가, ADR-024)")
+  .argument("[arg1]", "프로젝트 코드, Dooray URL, 또는 (`--id`/`--url` 모드일 때) 댓글 ID")
+  .argument("[arg2]", "업무 번호 또는 (`--id`/`--url` 모드일 때) 파일 경로")
+  .argument("[arg3]", "댓글 ID (positional 모드)")
+  .argument("[arg4]", "파일 경로 (positional 모드)")
+  .option("--id <postId>", "Dooray post ID (project/post-number 대신)")
+  .option("--url <url>", "Dooray 업무 URL (project/post-number 대신)")
+  .option("--comment-id <logId>", "댓글 ID (positional 대체)")
+  .option("--file <path>", "업로드할 파일 경로 (positional 대체)")
+  .action(async (arg1, arg2, arg3, arg4, opts) => {
+    const globalOpts = uploadCommentFileCommand.optsWithGlobals() as OutputOptions;
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+
+    let projectArg: string | undefined;
+    let postNumberArg: string | undefined;
+    let logId: string | undefined = opts.commentId;
+    let filePath: string | undefined = opts.file;
+
+    if (opts.id || opts.url) {
+      if (arg3 || arg4) {
+        throw new DoorayCliError(
+          "--id/--url 모드에서는 댓글 ID 와 파일 경로 외 추가 positional 인자를 받지 않습니다.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+      logId = logId ?? arg1;
+      filePath = filePath ?? arg2;
+    } else if (arg4) {
+      projectArg = arg1;
+      postNumberArg = arg2;
+      logId = logId ?? arg3;
+      filePath = filePath ?? arg4;
+    } else if (arg3) {
+      projectArg = arg1;
+      postNumberArg = arg2;
+      logId = logId ?? arg3;
+    } else if (arg1 && !arg2) {
+      projectArg = arg1;
+    } else {
+      projectArg = arg1;
+      postNumberArg = arg2;
+    }
+
+    if (!logId) {
+      throw new DoorayCliError(
+        "<comment-id>가 필요합니다. positional 3번째 또는 --comment-id 옵션을 사용하세요.",
+        EXIT_PARAM_ERROR,
+      );
+    }
+    if (!filePath) {
+      throw new DoorayCliError(
+        "<path>가 필요합니다. positional 4번째 또는 --file 옵션을 사용하세요.",
+        EXIT_PARAM_ERROR,
+      );
+    }
+
+    const { projectId, postId } = await resolvePostInput(client, {
+      projectArg,
+      postNumberArg,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+    });
+
+    // Step 1: 파일 업로드
+    startSpinner("파일 업로드 중...");
+    const uploadRes = await client.uploadPostFile(projectId, postId, filePath);
+    const fileId = uploadRes.result.id;
+    const fileName = basename(filePath);
+    stopSpinner(true, "업로드 완료");
+
+    // Step 2: 댓글 본문에 reference 추가
+    startSpinner("댓글 reference 추가 중...");
+    try {
+      const commentRes = await client.getPostComment(projectId, postId, logId);
+      const currentBody = commentRes.result.body.content;
+      const newBody = appendFileReference(currentBody, fileName, fileId);
+      await client.updatePostComment(projectId, postId, logId, {
+        body: { mimeType: "text/x-markdown", content: newBody },
+      });
+      stopSpinner(true, "reference 추가 완료");
+    } catch {
+      stopSpinner(false, "");
+      throw new DoorayCliError(
+        `업로드 OK / 댓글 reference 추가 실패. fileId=${fileId} — 'dooray post comment file delete' 또는 수동 PUT 으로 정리하세요.`,
+        EXIT_API_ERROR,
+      );
+    }
+
+    if (globalOpts.json) {
+      printJson({ fileId, fileName, commentId: logId });
+    } else if (!globalOpts.quiet) {
+      process.stdout.write(`업로드 + 댓글 reference 추가: fileId=${fileId}\n`);
+    }
+  });

--- a/src/commands/post/comment/file/upload.ts
+++ b/src/commands/post/comment/file/upload.ts
@@ -101,7 +101,9 @@ export const uploadCommentFileCommand = new Command("upload")
 
     if (globalOpts.json) {
       printJson({ fileId, fileName, commentId: logId });
-    } else if (!globalOpts.quiet) {
+    } else if (globalOpts.quiet) {
+      process.stdout.write(`${fileId}\n`);
+    } else {
       process.stdout.write(`업로드 + 댓글 reference 추가: fileId=${fileId}\n`);
     }
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { commentLatestCommand } from "./commands/post/comment/latest.js";
 import { commentAddCommand } from "./commands/post/comment/add.js";
 import { commentEditCommand } from "./commands/post/comment/edit.js";
 import { commentDeleteCommand } from "./commands/post/comment/delete.js";
+import { commentFileCommand } from "./commands/post/comment/file/index.js";
 import { fileListCommand } from "./commands/post/file/list.js";
 import { fileDownloadCommand } from "./commands/post/file/download.js";
 import { fileDownloadAllCommand } from "./commands/post/file/download-all.js";
@@ -89,6 +90,7 @@ commentCommand.addCommand(commentLatestCommand);
 commentCommand.addCommand(commentAddCommand);
 commentCommand.addCommand(commentEditCommand);
 commentCommand.addCommand(commentDeleteCommand);
+commentCommand.addCommand(commentFileCommand);
 postCommand.addCommand(commentCommand);
 
 // file 서브커맨드 그룹

--- a/src/utils/comment-files.test.ts
+++ b/src/utils/comment-files.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { appendFileReference, removeFileReference } from "./comment-files.js";
+
+describe("appendFileReference", () => {
+  it("빈 본문 → reference 만 반환", () => {
+    expect(appendFileReference("", "image.png", "1234567890123456789"))
+      .toBe("![image.png](/files/1234567890123456789)");
+  });
+
+  it("기존 본문 끝에 빈 줄로 분리해서 append", () => {
+    const result = appendFileReference("hello world", "x.png", "9876543210987654321");
+    expect(result).toBe("hello world\n\n![x.png](/files/9876543210987654321)");
+  });
+
+  it("기존 본문이 개행으로 끝나도 빈 줄 정확히 1 개", () => {
+    const result = appendFileReference("line1\n", "y.png", "1111");
+    expect(result).toBe("line1\n\n![y.png](/files/1111)");
+  });
+
+  it("filename 의 [] 는 이스케이프 (markdown 깨짐 방지)", () => {
+    expect(appendFileReference("", "[draft].png", "222"))
+      .toBe("![draft.png](/files/222)");
+  });
+});
+
+describe("removeFileReference", () => {
+  it("reference 만 있는 줄은 통째로 제거", () => {
+    const body = "hello\n![x.png](/files/123)\nworld";
+    expect(removeFileReference(body, "123")).toBe("hello\nworld");
+  });
+
+  it("줄 끝에 섞인 reference 는 빈 문자열로 치환 (텍스트 보존)", () => {
+    const body = "see ![x.png](/files/123) here";
+    expect(removeFileReference(body, "123")).toBe("see  here");
+  });
+
+  it("다른 fileId 는 안 건드림", () => {
+    const body = "![a.png](/files/111)\n![b.png](/files/222)";
+    expect(removeFileReference(body, "111")).toBe("![b.png](/files/222)");
+  });
+
+  it("같은 fileId 다중 출현 모두 제거", () => {
+    const body = "![a](/files/9)\nmid\n![a](/files/9)";
+    expect(removeFileReference(body, "9")).toBe("mid\n");
+  });
+
+  it("regex 특수문자 fileId 안전 (이스케이프)", () => {
+    expect(removeFileReference("![x](/files/abc.def)", "abc.def")).toBe("");
+    expect(removeFileReference("![x](/files/abcXdef)", "abc.def"))
+      .toBe("![x](/files/abcXdef)");
+  });
+});

--- a/src/utils/comment-files.ts
+++ b/src/utils/comment-files.ts
@@ -1,0 +1,30 @@
+/**
+ * Dooray 댓글/post 본문에 첨부 파일을 inline 으로 표시하는 markdown 형식.
+ * 형식: `![filename](/files/<fileId>)`
+ *
+ * Dooray 가 댓글 전용 attachment endpoint 를 제공하지 않으므로 (ADR-024)
+ * `dooray post comment file upload` 는 post-level 파일 업로드 후 이 헬퍼로
+ * 댓글 본문에 reference 를 append, `delete` 는 reference 를 제거하는 방식
+ * 으로 동작한다.
+ */
+
+export function appendFileReference(body: string, fileName: string, fileId: string): string {
+  const safeName = fileName.replace(/[\[\]]/g, "");
+  const ref = `![${safeName}](/files/${fileId})`;
+  if (body.length === 0) return ref;
+  const trailing = body.endsWith("\n") ? "" : "\n";
+  return `${body}${trailing}\n${ref}`;
+}
+
+/**
+ * 댓글 본문에서 특정 fileId 의 markdown reference 를 제거.
+ * `![*](/files/<fileId>)` 패턴을 줄 단위로 매치하여 그 줄 전체 제거.
+ * 같은 줄에 다른 텍스트가 있으면 reference 만 빈 문자열로 치환.
+ */
+export function removeFileReference(body: string, fileId: string): string {
+  const escaped = fileId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const refSource = `!\\[[^\\]]*\\]\\(/files/${escaped}\\)`;
+  const lineRe = new RegExp(`^[ \\t]*${refSource}[ \\t]*$\\n?`, "gm");
+  const inlineRe = new RegExp(refSource, "g");
+  return body.replace(lineRe, "").replace(inlineRe, "");
+}

--- a/tasks/020-feat-post-comment-file-commands/index.json
+++ b/tasks/020-feat-post-comment-file-commands/index.json
@@ -2,8 +2,8 @@
   "name": "020-feat-post-comment-file-commands",
   "description": "GitHub Issue #34 — `dooray post comment file *` 4 종 명령 신설 (list/upload/download/delete). Dooray 가 댓글 전용 attachment endpoint 미지원이라 내부적으론 post-level files API (`/posts/{postId}/files`) + 댓글 본문 PUT (`/logs/{logId}` 의 markdown reference 추가/제거) 합성으로 구현 (ADR-024). 자동화 스킬이 댓글에 인라인 이미지 삽입할 때 사용. 단일 명령 = 단일 파일 (다중 파일은 호출자가 반복).",
   "created_at": "2026-05-07T18:30:00Z",
-  "status": "pending",
-  "current_phase": 1,
+  "status": "completed",
+  "current_phase": 3,
   "total_phases": 3,
   "error_message": null,
   "blocked_reason": null,
@@ -12,23 +12,44 @@
       "number": 1,
       "title": "API client (getPostComment) + markdown helper + 단위 테스트",
       "file": "phase-01.md",
-      "status": "pending",
-      "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+      "status": "completed",
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash",
+        "Glob",
+        "Grep"
+      ]
     },
     {
       "number": 2,
       "title": "4 명령 구현 (list/upload/download/delete) + Commander 등록",
       "file": "phase-02.md",
-      "status": "pending",
-      "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+      "status": "completed",
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash",
+        "Glob",
+        "Grep"
+      ]
     },
     {
       "number": 3,
       "title": "README + SKILL.md + 빌드 검증 + task 완료",
       "file": "phase-03.md",
-      "status": "pending",
-      "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+      "status": "completed",
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash",
+        "Glob",
+        "Grep"
+      ]
     }
   ],
-  "updated_at": "2026-05-07T18:30:00Z"
+  "updated_at": "2026-05-07T10:39:40.701Z"
 }

--- a/tasks/020-feat-post-comment-file-commands/phase-01.md
+++ b/tasks/020-feat-post-comment-file-commands/phase-01.md
@@ -15,34 +15,22 @@ ADR-024 기반. Dooray 가 댓글 전용 attachment endpoint 를 미지원하므
 - `src/api/types.ts` `PostComment` / `PostCommentListResponse` — 단건 응답 타입 도출 base
 - `src/utils/feedback-meta.ts` — utils 단위 테스트 형식 참고
 
-## 작업 항목 (4개)
+## 작업 항목 (3개)
 
-### 1) `src/api/types.ts` — 단건 응답 타입 추가
+### 1) `src/api/client.ts` — `getPostComment` 단건 조회 메서드
 
-기존 `PostCommentListResponse` 를 보고 단건 변형 추가:
-
-```ts
-// 기존 PostCommentListResponse: DoorayApiResponse<PostComment[]>
-// 신규
-export type GetPostCommentResponse = DoorayApiResponse<PostComment>;
-```
-
-`PostComment` 타입에 `files: PostFileDetail[]` 필드가 이미 있는지 확인. 없으면 추가 (검증으로 확인됨 — 응답에 `files: []` 항상 존재).
-
-### 2) `src/api/client.ts` — `getPostComment` 단건 조회 메서드
-
-`getPostComments` (L284) 옆에 추가:
+`getPostComments` (L284) 옆에 추가. **반환 타입은 기존 `PostCommentDetailResponse`** (`src/api/types.ts:332` — `DoorayApiResponse<PostComment>`) 재사용. types.ts 수정 없음 (중복 alias 추가 금지). `PostComment.files?: PostCommentFile[]` (L311) 도 이미 존재 — optional 임에 유의 (다음 phase 에서 `?? []` 폴백).
 
 ```ts
 async getPostComment(
   projectId: string,
   postId: string,
   logId: string,
-): Promise<GetPostCommentResponse> {
+): Promise<PostCommentDetailResponse> {
   try {
     return await this.api
       .get(`project/v1/projects/${projectId}/posts/${postId}/logs/${logId}`)
-      .json<GetPostCommentResponse>();
+      .json<PostCommentDetailResponse>();
   } catch (e) {
     return toDoorayCliError(e);
   }
@@ -51,7 +39,7 @@ async getPostComment(
 
 `try { ... } catch (e) { return toDoorayCliError(e); }` 패턴 — 기존 모든 client 메서드 (예: `getPostFiles` L541) 와 일관. ky HTTPError 누설 방지.
 
-### 3) `src/utils/comment-files.ts` — markdown reference 헬퍼 (신규)
+### 2) `src/utils/comment-files.ts` — markdown reference 헬퍼 (신규)
 
 ```ts
 /**
@@ -86,7 +74,7 @@ export function removeFileReference(body: string, fileId: string): string {
 }
 ```
 
-### 4) `src/utils/comment-files.test.ts` — 단위 테스트 (신규)
+### 3) `src/utils/comment-files.test.ts` — 단위 테스트 (신규)
 
 ```ts
 import { describe, it, expect } from "vitest";
@@ -155,9 +143,9 @@ pnpm run build && pnpm test
 grep -nE "async getPostComment\b" src/api/client.ts
 # 기대: 1 줄
 
-# 3. 단건 응답 타입 export
-grep -nE "export type GetPostCommentResponse" src/api/types.ts
-# 기대: 1 줄
+# 3. 기존 PostCommentDetailResponse 재사용 — types.ts 변경 없음
+git diff --stat src/api/types.ts | tail -1
+# 기대: " 0 files changed" (또는 빈 출력)
 
 # 4. utils 신규 파일 + export 2 개
 grep -cE "export function (appendFileReference|removeFileReference)" src/utils/comment-files.ts
@@ -185,4 +173,4 @@ sed -n '/async getPostComment\b/,/^  }/p' src/api/client.ts | grep -c "toDoorayC
 
 ## Blocked 조건
 
-- `PostComment` 타입에 `files` 필드 부재 → types.ts 에 함께 추가
+- (없음) — `PostComment.files?: PostCommentFile[]` + `PostCommentDetailResponse` 모두 기존 코드에 존재 확인됨 (critic 검증 결과)

--- a/tasks/020-feat-post-comment-file-commands/phase-02.md
+++ b/tasks/020-feat-post-comment-file-commands/phase-02.md
@@ -11,7 +11,18 @@ phase-01 의 `getPostComment` + `appendFileReference`/`removeFileReference` 위�
 | `download <comment-id> <file-id>` | `downloadPostFile` (post file download 와 동일 — UX 일관성 wrapper) |
 | `delete <comment-id> <file-id>` | (1) `getPostComment` → `removeFileReference` → `updatePostComment`, (2) `deletePostFile` |
 
-전 명령은 ADR-020 의 `<project> <post-number>` / `--id <postId>` / `--url <url>` / 첫 positional URL 분기를 `resolvePostInput` 헬퍼로 통일. `<comment-id>` 는 4 번째 positional 또는 `--comment-id` 옵션. `<path>`/`<file-id>` 는 5 번째 positional 또는 `--file <path>` / `--file-id <id>` 옵션 (post/file 의 기존 패턴 답습).
+전 명령은 ADR-020 의 `<project> <post-number>` / `--id <postId>` / `--url <url>` / 첫 positional URL 분기를 `resolvePostInput` 헬퍼로 통일.
+
+**positional 시그니처 — `comment/edit.ts` (L17-80) 모드 의존 패턴 답습** (절대 4·5번째 positional 추가 금지):
+
+| 모드 | arg1 | arg2 | arg3 | arg4 |
+|---|---|---|---|---|
+| positional 모드 | `<project>` | `<post-number>` | `<comment-id>` | `<path>` 또는 `<file-id>` (해당 명령) |
+| `--id`/`--url` 모드 | `<comment-id>` | `<path>`/`<file-id>` | (금지) | (금지) |
+
+옵션 폴백 강제: `--comment-id <id>` / `--file <path>` (upload) / `--file-id <id>` (download/delete). list 는 4 번째 인자 없음 (3개까지).
+
+분기 검증 — `--id`/`--url` 모드에서 arg3·arg4 가 들어오면 `EXIT_PARAM_ERROR` 명시적 reject (edit.ts L48-54 그대로 답습).
 
 ### 먼저 읽을 파일
 
@@ -35,11 +46,17 @@ dooray post comment file list --url <url> --comment-id <logId>
 
 동작:
 1. `resolvePostInput` 으로 `{ projectId, postId }` 획득
-2. `<comment-id>` 는 positional 4 번째 또는 `--comment-id` 옵션
+2. `<comment-id>` 는 positional 3 번째 (positional 모드) / arg1 (`--id`/`--url` 모드) / `--comment-id` 옵션
 3. `client.getPostComment(projectId, postId, logId)` 호출
-4. `res.result.files` 를 `formatTable` 또는 `printJson` 으로 출력 — `post file list` 와 동일 컬럼 (이름 / 크기 / id / 등록 시각)
+4. `const files = res.result.files ?? []` (optional 필드 — 폴백 필수)
 
-`post/file/list.ts` 의 컬럼 헬퍼 / `OutputOptions` 처리 / 빈 결과 메시지 패턴 답습.
+**출력 형식** (ADR-021 table-only enrich 정신 답습 — `--json` 은 raw 유지):
+- table (기본): 3 컬럼 `이름 | 크기(human, e.g. "12.4 KB") | id`. **"등록 시각" 컬럼은 데이터 없음 (`PostCommentFile = { id, name, size }` 뿐) → 추가 금지**
+- `--json`: `res.result.files ?? []` 그대로 출력 (raw)
+- `--quiet`: 출력 생략
+- 빈 배열: stderr `'첨부 없음'` 한 줄 + stdout 비움 (`--json` 은 `[]` 출력)
+
+`post/file/list.ts` 의 `OutputOptions` 처리 / human size 헬퍼 / 빈 결과 메시지 패턴 답습.
 
 ### 2) `src/commands/post/comment/file/upload.ts` (신규)
 
@@ -55,7 +72,7 @@ dooray post comment file upload --id <postId> --comment-id <logId> --file <path>
 4. **step 2**: `client.getPostComment(...)` → `currentBody = res.result.body.content` (mimeType=`text/x-markdown`)
 5. `newBody = appendFileReference(currentBody, fileName, fileId)`
 6. `client.updatePostComment(projectId, postId, logId, { body: { mimeType: "text/x-markdown", content: newBody }})`
-7. **step 1 성공 + step 2 실패** 처리: stderr 안내 + `process.exit(EXIT_API_ERROR)` 또는 `throw new DoorayCliError("...", EXIT_API_ERROR)` — 사용자가 부분 성공 인지하도록. 실패 메시지에 fileId 노출 (사용자가 수동 PUT 또는 `comment file delete` 로 정리 가능).
+7. **step 1 성공 + step 2 실패** 처리: `throw new DoorayCliError("업로드 OK / 댓글 reference 추가 실패. fileId=<id> — 'dooray post comment file delete' 또는 수동 PUT 으로 정리하세요.", EXIT_API_ERROR)`. 코드베이스는 `DoorayCliError` throw 단일 패턴 (`src/utils/errors.ts`) — `process.exit` 직접 호출 금지.
 
 성공 시 stdout (`--quiet` 아니면) 한 줄: `업로드 + 댓글 reference 추가: fileId=...`. `--json` 이면 `{ fileId, fileName, commentId }` JSON.
 
@@ -66,6 +83,8 @@ dooray post comment file download <project> <post-number> <comment-id> <file-id>
 ```
 
 동작: `client.downloadPostFile(projectId, postId, fileId)` 호출 후 `--out` 또는 cwd 에 저장. `post/file/download.ts` 의 file write 패턴 그대로 답습 — **comment-id 는 받지만 download API 호출에는 사용 안 함**. UX 일관성 목적이므로 positional 받지만 무시 (warning 없음). `--out` 미지정 시 cwd 에 fileName 그대로.
+
+`--help` description 에 한 줄 명시: `"댓글에 첨부된 파일 다운로드 (현재 comment-id 는 미사용 — 멘탈 모델 일관성, 미래 댓글 단위 권한 호환용)"`.
 
 > 왜 commentId 를 받기만 하고 안 쓰는가: 사용자 멘탈 모델 ("그 댓글의 그 파일") 일관성 + 미래에 Dooray 가 댓글 단위 권한 도입할 가능성 → 인자만 받아두면 호환. 현재는 단순 wrapper.
 
@@ -81,11 +100,13 @@ dooray post comment file delete <project> <post-number> <comment-id> <file-id> [
 3. `--yes` 미지정이면 confirm prompt (`@inquirer/prompts confirm`) — 본문 markdown 제거 + 파일 삭제 안내 (post 단의 다른 댓글에서 같은 fileId 참조 시 broken 됨을 명시)
 4. **step 1**: `getPostComment` → `removeFileReference(body, fileId)` → `updatePostComment` (본문 갱신)
 5. **step 2**: `deletePostFile(projectId, postId, fileId)`
-6. step 1 성공 + step 2 실패 → stderr 경고 + `EXIT_API_ERROR`. 본문에서는 reference 빠졌지만 파일 자체 잔존 → 사용자가 `post file delete` 로 후처리 가능 안내.
+6. step 1 성공 + step 2 실패 → `throw new DoorayCliError("댓글 본문 reference 제거 OK / 파일 삭제 실패. 'dooray post file delete' 로 후처리하세요. fileId=<id>", EXIT_API_ERROR)` (`process.exit` 직접 호출 금지 — `DoorayCliError` throw 단일 패턴).
 
 `post/file/delete.ts` 의 confirm 패턴 답습.
 
-### 5) `src/commands/post/comment/file/index.ts` + `src/commands/post/comment/index.ts` 등록
+### 5) `src/commands/post/comment/file/index.ts` + `src/index.ts` 등록
+
+**중요**: `src/commands/post/comment/index.ts` 는 **존재하지 않음**. `commentCommand` 는 `src/index.ts` (L86-92) 에서 직접 조립됨. 그러므로 등록은 `src/index.ts` 에서 한다.
 
 `src/commands/post/comment/file/index.ts` (신규):
 ```ts
@@ -103,7 +124,14 @@ export const commentFileCommand = new Command("file")
   .addCommand(deleteCommentFileCommand);
 ```
 
-`src/commands/post/comment/index.ts` 에 `commentCommand.addCommand(commentFileCommand)` 한 줄 추가.
+`src/index.ts` 수정:
+1. import 추가: `import { commentFileCommand } from "./commands/post/comment/file/index.js";`
+2. L91 (`commentCommand.addCommand(commentDeleteCommand);`) 다음, **L92 (`postCommand.addCommand(commentCommand);`) 직전** 에 한 줄 추가:
+   ```ts
+   commentCommand.addCommand(commentFileCommand);
+   ```
+
+기존 `fileCommand` 등록 패턴 (L95-101) 의 형태 답습 — `commentFileCommand` 는 `commentCommand` 의 자식이라는 점만 차이.
 
 ## 성공 기준
 


### PR DESCRIPTION
## Summary

- GitHub Issue #34 — 댓글 첨부 파일 관리 4 명령 신설 (`dooray post comment file *`)
- Dooray 가 댓글 전용 attachment endpoint 미지원 → post-level files API + 댓글 본문 PUT(`![filename](/files/<id>)` markdown) 합성으로 구현 (ADR-024)
- 자동화 스킬이 댓글에 인라인 이미지/파일 첨부할 때 사용

## Implementation

| 명령 | 내부 동작 |
|---|---|
| `list` | `getPostComment` → `.files ?? []` |
| `upload` | (1) `uploadPostFile` (2) `getPostComment` → `appendFileReference` → `updatePostComment` |
| `download` | `downloadPostFile` wrapper (UX 일관성 — comment-id 받지만 미사용) |
| `delete` | (1) `getPostComment` → `removeFileReference` → `updatePostComment` (2) `deletePostFile` |

전 명령은 ADR-020 의 `resolvePostInput` 분기 답습 (`<project> <post-number>` / `--id` / `--url` / 첫 positional URL). `comment-id` / `path` / `file-id` 는 ADR-020 모드 의존 positional 패턴 (`comment/edit.ts` 답습) + `--comment-id` / `--file` / `--file-id` 옵션 폴백.

부분 실패 처리 (atomic 보장 X — ADR-024 트레이드오프): `DoorayCliError` throw + `EXIT_API_ERROR` + 후처리 안내 메시지.

## Test plan

- [x] `pnpm run build` (169 KB CJS 단일 번들)
- [x] `pnpm test` — 66 passed (9 files), 신규 `comment-files.test.ts` 9 케이스 추가
- [x] `node dist/index.js post comment file --help` → list/upload/download/delete 4 명령
- [x] 각 서브명령 `--help` smoke test
- [x] critic APPROVE (5건 mismatch 사전 수정)
- [x] code-reviewer PASS (process.exit 0건, ky 외 HTTP 0건, exitCode 누락 0건)
- [x] docs-verifier PASS (ADR-024 정합 + docs/code-architecture.md 동기화)

## Files

**신규:**
- `src/commands/post/comment/file/{list,upload,download,delete,index}.ts`
- `src/utils/comment-files.ts` (markdown reference helper)
- `src/utils/comment-files.test.ts`

**변경:**
- `src/api/client.ts` — `getPostComment` 단건 조회 추가
- `src/index.ts` — `commentFileCommand` Commander 등록
- `README.md`, `skills/dooray-cli/SKILL.md`, `docs/code-architecture.md`, `CLAUDE.md` — 문서 동기화

🤖 Generated with [Claude Code](https://claude.com/claude-code) via /build-with-teams

Closes #34