### PR TITLE
feat(commands): mention/link-task/dry-run as first-class options for post commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ bash scripts/benchmark.sh [project] [post-number] [wiki-page-id]
 - resolver(멤버·워크플로우·태그·마일스톤)는 정확일치 → 이름 부분일치, 모호하면 에러 + 후보 목록 출력
 - post 목록은 최신순 정렬 (`-createdAt`)
 - `post edit` / `post comment edit` 는 본문 full-replace. 새 본문에 기존 attachment markdown(`![](/files/<id>)`) 누락 시 (y/N) confirm. non-TTY 는 abort, `--no-confirm` 으로 우회.
+- `post create` / `post edit` / `post comment add/edit` 4 명령 모두 `--mention` / `--mention-group` / `--link-task` / `--dry-run` 동일 옵션 지원. mention 은 prepend, link-task 는 append, 적용 순서는 mention → link-task. interactive ($EDITOR) 모드의 `post edit` 는 mention/link-task 무시 + 경고
 
 ## 상황별 ADR 필수 참조
 

--- a/README.md
+++ b/README.md
@@ -141,30 +141,26 @@ dooray post comment add <project> 42 --body-file ./comment.md
 
 > table 출력의 Creator 컬럼은 프로젝트 멤버 캐시로 자동 enrich되며, `--json`은 raw 응답을 유지한다 (ADR-021).
 
-#### 멘션 (comment add / comment edit)
-
-`--mention <name>` (반복), `--mention-group <code>` (반복)으로 본문 앞에 멘션 마크업을 자동 prepend한다.
+#### 멘션·내부 링크 자동 삽입
 
 ```bash
-# 멤버 멘션 1명
-dooray post comment add P 1 --mention 홍길동 --body "확인 부탁드립니다"
+# 댓글에 멤버·그룹 멘션
+dooray post comment add <project> <post-number> \
+  --body "주간 리포트 첨부" \
+  --mention "홍길동" \
+  --mention-group <project>/dev
 
-# 여러 명
-dooray post comment add P 1 --mention 홍길동 --mention 김철수 --body "..."
+# 본문에 다른 업무 링크 append
+dooray post create <project> \
+  --title "이번 주 작업" \
+  --body "관련 이슈" \
+  --link-task <project>/470
 
-# 그룹 멘션
-dooray post comment add P 1 --mention-group 개발 --body "검토 요청"
-
-# 멤버 + 그룹 혼합
-dooray post comment add P 1 \
-  --mention 홍길동 \
-  --mention-group 개발 \
-  --body "검토 부탁드립니다"
-
-# comment edit에도 동일 옵션 사용 가능
-dooray post comment edit P 1 <commentId> --mention 홍길동 --body "수정 내용"
+# 송신 전 합성 결과 미리보기
+dooray post comment add <project> <post-number> --body "..." --link-task <project>/470 --dry-run
 ```
 
+> `--mention` / `--mention-group` / `--link-task` / `--dry-run` 은 `post create`, `post edit`, `post comment add`, `post comment edit` 4 명령 모두 지원.
 > 이전 버전 캐시는 orgId가 없으므로 첫 호출 시 자동 갱신됩니다 (또는 `dooray cache clear`).
 
 #### comment list 필터 옵션

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -69,6 +69,7 @@ src/
     dooray-url.ts           # /task/to/<postId> 및 /task/<projectId>/<postId> URL parser (ADR-020)
     comment-enrich.ts       # PostComment[] Creator 이름 채우기 (ADR-021, immutable)
     mention.ts              # 멤버·그룹 멘션 마크업 빌더 + prependMentions (Issue #25)
+    task-link.ts            # 업무 링크 빌더 (escapeLinkText / buildTaskLink / appendTaskLinks / parseLinkRef, Issue #33)
     feedback-meta.ts        # CLI 버전·환경 수집 + GitHub issue body 빌더 + buildLastRunBlock (ADR-022, ADR-023)
     argv-sanitize.ts        # argv 시크릿 패턴 마스킹 (--api-key/--token/--password/Authorization, ADR-023)
     comment-files.ts        # appendFileReference / removeFileReference — 댓글 본문 markdown reference 조작 (ADR-024)

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -289,9 +289,14 @@ dooray post comment latest <project> <number>
 
 ---
 
-## 멘션 자동 작성 (post comment add/edit)
+## 멘션·링크 자동 삽입 (first-class)
 
-`--mention <name>` (반복) 또는 `--mention-group <code>` (반복)으로 본문 앞에 멘션 마크업을 자동 prepend한다. 아래 "Dooray 마크다운 링크 형식" 섹션의 URL 형식을 자동 출력한다.
+`post create`, `post edit`, `post comment add`, `post comment edit` 모두 지원:
+
+- `--mention <name>` (반복) — 이름으로 멤버 resolve 후 dooray:// markdown prepend
+- `--mention-group <code>` (반복) — 그룹 코드로 resolve
+- `--link-task <project>/<number>` (반복) — 다른 업무 link 를 본문 끝에 append. 19자리 postId 도 가능
+- `--dry-run` — API 호출 없이 합성 결과만 stdout. CI / 자동화 검증용
 
 ```bash
 dooray post comment add P 1 --mention 홍길동 --mention-group 개발 --body "..."
@@ -300,7 +305,7 @@ dooray post comment add P 1 --mention 홍길동 --mention-group 개발 --body ".
 
 - 이름 부분일치 지원 (모호하면 에러 + 후보 목록 출력)
 - 멤버 먼저, 그룹 다음 순서 고정
-- comment edit에도 동일 옵션 사용 (`$EDITOR` 모드에서는 EDITOR 진입 전에 prepend)
+- interactive (`$EDITOR`) 모드의 `post edit` 는 mention/link-task 무시 + stderr 경고
 
 ## Dooray 마크다운 링크 형식 (멤버·그룹·업무 멘션)
 

--- a/src/commands/post/comment/add.ts
+++ b/src/commands/post/comment/add.ts
@@ -11,9 +11,7 @@ import { resolveMember, buildMemberNameMap } from "../../../resolvers/member.js"
 import { resolveMemberGroup } from "../../../resolvers/member-group.js";
 import { ensureMe } from "../../../resolvers/me.js";
 import { prependMentions } from "../../../utils/mention.js";
-import { appendTaskLinks, type TaskLinkInput } from "../../../utils/task-link.js";
-import { DoorayCliError } from "../../../utils/errors.js";
-import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
+import { appendTaskLinks, parseLinkRef, type TaskLinkInput } from "../../../utils/task-link.js";
 
 export const commentAddCommand = new Command("add")
   .description("댓글 추가")
@@ -88,27 +86,7 @@ export const commentAddCommand = new Command("add")
       const me = await ensureMe(client);
       const links: TaskLinkInput[] = await Promise.all(
         linkInputs.map(async (ref) => {
-          let projectArg: string | undefined;
-          let postNumberArg: string | undefined;
-          let idOpt: string | undefined;
-          if (/^[0-9]{15,}$/.test(ref)) {
-            idOpt = ref;
-          } else if (ref.includes("/")) {
-            const [p, n] = ref.split("/");
-            if (!p || !n) {
-              throw new DoorayCliError(
-                `--link-task 형식이 올바르지 않습니다: "${ref}". <project>/<number> 또는 postId를 입력하세요.`,
-                EXIT_PARAM_ERROR,
-              );
-            }
-            projectArg = p;
-            postNumberArg = n;
-          } else {
-            throw new DoorayCliError(
-              `--link-task 형식이 올바르지 않습니다: "${ref}". <project>/<number> 또는 postId를 입력하세요.`,
-              EXIT_PARAM_ERROR,
-            );
-          }
+          const { projectArg, postNumberArg, idOpt } = parseLinkRef(ref);
           const { projectId: pid, postId: pidPost, projectCode: pCode, postNumber } =
             await resolvePostInput(client, { projectArg, postNumberArg, idOpt });
           const detail = await client.getPost(pid, pidPost);

--- a/src/commands/post/comment/add.ts
+++ b/src/commands/post/comment/add.ts
@@ -36,6 +36,7 @@ export const commentAddCommand = new Command("add")
     [] as string[],
   )
   .option("--link-task <ref>", "다른 업무 링크 추가 (<project>/<number> 또는 postId, 반복 가능)", (v, prev: string[]) => [...prev, v], [] as string[])
+  .option("--dry-run", "API 호출 없이 합성된 본문만 stdout 출력 (mention/link-task 적용 결과 미리보기)")
   .action(async (project, postNumberStr, opts) => {
     const globalOpts = commentAddCommand.optsWithGlobals() as OutputOptions;
     const config = await getConfigOrThrow();
@@ -121,6 +122,16 @@ export const commentAddCommand = new Command("add")
         }),
       );
       bodyContent = appendTaskLinks(bodyContent, links, me);
+    }
+
+    if (opts.dryRun) {
+      stopSpinner(false);
+      if (globalOpts.json) {
+        process.stdout.write(JSON.stringify({ body: bodyContent }) + "\n");
+      } else {
+        process.stdout.write(bodyContent + "\n");
+      }
+      return;
     }
 
     const res = await client.createPostComment(projectId, postId, {

--- a/src/commands/post/comment/add.ts
+++ b/src/commands/post/comment/add.ts
@@ -11,7 +11,8 @@ import { resolveMember, buildMemberNameMap } from "../../../resolvers/member.js"
 import { resolveMemberGroup } from "../../../resolvers/member-group.js";
 import { ensureMe } from "../../../resolvers/me.js";
 import { prependMentions } from "../../../utils/mention.js";
-import { appendTaskLinks, parseLinkRef, type TaskLinkInput } from "../../../utils/task-link.js";
+import { appendTaskLinks } from "../../../utils/task-link.js";
+import { resolveTaskLinks } from "../../../resolvers/task-link.js";
 
 export const commentAddCommand = new Command("add")
   .description("댓글 추가")
@@ -84,21 +85,7 @@ export const commentAddCommand = new Command("add")
 
     if (linkInputs.length > 0) {
       const me = await ensureMe(client);
-      const links: TaskLinkInput[] = await Promise.all(
-        linkInputs.map(async (ref) => {
-          const { projectArg, postNumberArg, idOpt } = parseLinkRef(ref);
-          const { projectId: pid, postId: pidPost, projectCode: pCode, postNumber } =
-            await resolvePostInput(client, { projectArg, postNumberArg, idOpt });
-          const detail = await client.getPost(pid, pidPost);
-          return {
-            projectCode: pCode,
-            number: postNumber,
-            postId: pidPost,
-            subject: detail.result.subject,
-            workflowClass: detail.result.workflowClass,
-          };
-        }),
-      );
+      const links = await resolveTaskLinks(client, linkInputs);
       bodyContent = appendTaskLinks(bodyContent, links, me);
     }
 

--- a/src/commands/post/comment/add.ts
+++ b/src/commands/post/comment/add.ts
@@ -11,6 +11,9 @@ import { resolveMember, buildMemberNameMap } from "../../../resolvers/member.js"
 import { resolveMemberGroup } from "../../../resolvers/member-group.js";
 import { ensureMe } from "../../../resolvers/me.js";
 import { prependMentions } from "../../../utils/mention.js";
+import { appendTaskLinks, type TaskLinkInput } from "../../../utils/task-link.js";
+import { DoorayCliError } from "../../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
 
 export const commentAddCommand = new Command("add")
   .description("댓글 추가")
@@ -32,6 +35,7 @@ export const commentAddCommand = new Command("add")
     (value: string, prev: string[]) => [...prev, value],
     [] as string[],
   )
+  .option("--link-task <ref>", "다른 업무 링크 추가 (<project>/<number> 또는 postId, 반복 가능)", (v, prev: string[]) => [...prev, v], [] as string[])
   .action(async (project, postNumberStr, opts) => {
     const globalOpts = commentAddCommand.optsWithGlobals() as OutputOptions;
     const config = await getConfigOrThrow();
@@ -57,6 +61,7 @@ export const commentAddCommand = new Command("add")
 
     const mentionInputs: string[] = (opts.mention ?? []).filter((s: string) => s.length > 0);
     const groupInputs: string[] = (opts.mentionGroup ?? []).filter((s: string) => s.length > 0);
+    const linkInputs: string[] = (opts.linkTask ?? []).filter((s: string) => s.length > 0);
 
     if (mentionInputs.length > 0 || groupInputs.length > 0) {
       const me = await ensureMe(client);
@@ -76,6 +81,46 @@ export const commentAddCommand = new Command("add")
         }),
       );
       bodyContent = prependMentions(bodyContent, members, groups, me);
+    }
+
+    if (linkInputs.length > 0) {
+      const me = await ensureMe(client);
+      const links: TaskLinkInput[] = await Promise.all(
+        linkInputs.map(async (ref) => {
+          let projectArg: string | undefined;
+          let postNumberArg: string | undefined;
+          let idOpt: string | undefined;
+          if (/^[0-9]{15,}$/.test(ref)) {
+            idOpt = ref;
+          } else if (ref.includes("/")) {
+            const [p, n] = ref.split("/");
+            if (!p || !n) {
+              throw new DoorayCliError(
+                `--link-task 형식이 올바르지 않습니다: "${ref}". <project>/<number> 또는 postId를 입력하세요.`,
+                EXIT_PARAM_ERROR,
+              );
+            }
+            projectArg = p;
+            postNumberArg = n;
+          } else {
+            throw new DoorayCliError(
+              `--link-task 형식이 올바르지 않습니다: "${ref}". <project>/<number> 또는 postId를 입력하세요.`,
+              EXIT_PARAM_ERROR,
+            );
+          }
+          const { projectId: pid, postId: pidPost, projectCode: pCode, postNumber } =
+            await resolvePostInput(client, { projectArg, postNumberArg, idOpt });
+          const detail = await client.getPost(pid, pidPost);
+          return {
+            projectCode: pCode,
+            number: postNumber,
+            postId: pidPost,
+            subject: detail.result.subject,
+            workflowClass: detail.result.workflowClass,
+          };
+        }),
+      );
+      bodyContent = appendTaskLinks(bodyContent, links, me);
     }
 
     const res = await client.createPostComment(projectId, postId, {

--- a/src/commands/post/comment/edit.ts
+++ b/src/commands/post/comment/edit.ts
@@ -11,7 +11,7 @@ import { resolveMember, buildMemberNameMap } from "../../../resolvers/member.js"
 import { resolveMemberGroup } from "../../../resolvers/member-group.js";
 import { ensureMe } from "../../../resolvers/me.js";
 import { prependMentions } from "../../../utils/mention.js";
-import { appendTaskLinks, type TaskLinkInput } from "../../../utils/task-link.js";
+import { appendTaskLinks, parseLinkRef, type TaskLinkInput } from "../../../utils/task-link.js";
 import { checkAndGuardDropped } from "../../../utils/attachment-check.js";
 
 export const commentEditCommand = new Command("edit")
@@ -151,27 +151,7 @@ export const commentEditCommand = new Command("edit")
       const me = await ensureMe(client);
       const links: TaskLinkInput[] = await Promise.all(
         linkInputs.map(async (ref) => {
-          let projectArg: string | undefined;
-          let postNumberArg: string | undefined;
-          let idOpt: string | undefined;
-          if (/^[0-9]{15,}$/.test(ref)) {
-            idOpt = ref;
-          } else if (ref.includes("/")) {
-            const [p, n] = ref.split("/");
-            if (!p || !n) {
-              throw new DoorayCliError(
-                `--link-task 형식이 올바르지 않습니다: "${ref}". <project>/<number> 또는 postId를 입력하세요.`,
-                EXIT_PARAM_ERROR,
-              );
-            }
-            projectArg = p;
-            postNumberArg = n;
-          } else {
-            throw new DoorayCliError(
-              `--link-task 형식이 올바르지 않습니다: "${ref}". <project>/<number> 또는 postId를 입력하세요.`,
-              EXIT_PARAM_ERROR,
-            );
-          }
+          const { projectArg, postNumberArg, idOpt } = parseLinkRef(ref);
           const { projectId: pid, postId: pidPost, projectCode: pCode, postNumber } =
             await resolvePostInput(client, { projectArg, postNumberArg, idOpt });
           const detail = await client.getPost(pid, pidPost);

--- a/src/commands/post/comment/edit.ts
+++ b/src/commands/post/comment/edit.ts
@@ -38,6 +38,7 @@ export const commentEditCommand = new Command("edit")
     [] as string[],
   )
   .option("--link-task <ref>", "다른 업무 링크 추가 (<project>/<number> 또는 postId, 반복 가능)", (v, prev: string[]) => [...prev, v], [] as string[])
+  .option("--dry-run", "API 호출 없이 합성된 본문만 stdout 출력 (mention/link-task 적용 결과 미리보기)")
   .action(async (arg1, arg2, arg3, opts) => {
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
@@ -184,6 +185,12 @@ export const commentEditCommand = new Command("edit")
         }),
       );
       edited = appendTaskLinks(edited, links, me);
+    }
+
+    if (opts.dryRun) {
+      stopSpinner(false);
+      process.stdout.write(edited + "\n");
+      return;
     }
 
     const attachments = (comment.files ?? []).map((f) => ({ id: f.id, name: f.name }));

--- a/src/commands/post/comment/edit.ts
+++ b/src/commands/post/comment/edit.ts
@@ -11,6 +11,7 @@ import { resolveMember, buildMemberNameMap } from "../../../resolvers/member.js"
 import { resolveMemberGroup } from "../../../resolvers/member-group.js";
 import { ensureMe } from "../../../resolvers/me.js";
 import { prependMentions } from "../../../utils/mention.js";
+import { appendTaskLinks, type TaskLinkInput } from "../../../utils/task-link.js";
 import { checkAndGuardDropped } from "../../../utils/attachment-check.js";
 
 export const commentEditCommand = new Command("edit")
@@ -36,6 +37,7 @@ export const commentEditCommand = new Command("edit")
     (value: string, prev: string[]) => [...prev, value],
     [] as string[],
   )
+  .option("--link-task <ref>", "다른 업무 링크 추가 (<project>/<number> 또는 postId, 반복 가능)", (v, prev: string[]) => [...prev, v], [] as string[])
   .action(async (arg1, arg2, arg3, opts) => {
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
@@ -105,6 +107,7 @@ export const commentEditCommand = new Command("edit")
     // 멘션 옵션 처리
     const mentionInputs: string[] = (opts.mention ?? []).filter((s: string) => s.length > 0);
     const groupInputs: string[] = (opts.mentionGroup ?? []).filter((s: string) => s.length > 0);
+    const linkInputs: string[] = (opts.linkTask ?? []).filter((s: string) => s.length > 0);
 
     let mentionPrefix = "";
     if (mentionInputs.length > 0 || groupInputs.length > 0) {
@@ -141,6 +144,46 @@ export const commentEditCommand = new Command("edit")
       }
     } else if (mentionPrefix) {
       edited = mentionPrefix + " " + edited;
+    }
+
+    if (linkInputs.length > 0) {
+      const me = await ensureMe(client);
+      const links: TaskLinkInput[] = await Promise.all(
+        linkInputs.map(async (ref) => {
+          let projectArg: string | undefined;
+          let postNumberArg: string | undefined;
+          let idOpt: string | undefined;
+          if (/^[0-9]{15,}$/.test(ref)) {
+            idOpt = ref;
+          } else if (ref.includes("/")) {
+            const [p, n] = ref.split("/");
+            if (!p || !n) {
+              throw new DoorayCliError(
+                `--link-task 형식이 올바르지 않습니다: "${ref}". <project>/<number> 또는 postId를 입력하세요.`,
+                EXIT_PARAM_ERROR,
+              );
+            }
+            projectArg = p;
+            postNumberArg = n;
+          } else {
+            throw new DoorayCliError(
+              `--link-task 형식이 올바르지 않습니다: "${ref}". <project>/<number> 또는 postId를 입력하세요.`,
+              EXIT_PARAM_ERROR,
+            );
+          }
+          const { projectId: pid, postId: pidPost, projectCode: pCode, postNumber } =
+            await resolvePostInput(client, { projectArg, postNumberArg, idOpt });
+          const detail = await client.getPost(pid, pidPost);
+          return {
+            projectCode: pCode,
+            number: postNumber,
+            postId: pidPost,
+            subject: detail.result.subject,
+            workflowClass: detail.result.workflowClass,
+          };
+        }),
+      );
+      edited = appendTaskLinks(edited, links, me);
     }
 
     const attachments = (comment.files ?? []).map((f) => ({ id: f.id, name: f.name }));

--- a/src/commands/post/comment/edit.ts
+++ b/src/commands/post/comment/edit.ts
@@ -7,11 +7,13 @@ import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
 import { readBodyInputOrNull } from "../../../utils/body-input.js";
 import { DoorayCliError } from "../../../utils/errors.js";
 import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
+import type { OutputOptions } from "../../../formatters/table.js";
 import { resolveMember, buildMemberNameMap } from "../../../resolvers/member.js";
 import { resolveMemberGroup } from "../../../resolvers/member-group.js";
 import { ensureMe } from "../../../resolvers/me.js";
 import { prependMentions } from "../../../utils/mention.js";
-import { appendTaskLinks, parseLinkRef, type TaskLinkInput } from "../../../utils/task-link.js";
+import { appendTaskLinks } from "../../../utils/task-link.js";
+import { resolveTaskLinks } from "../../../resolvers/task-link.js";
 import { checkAndGuardDropped } from "../../../utils/attachment-check.js";
 
 export const commentEditCommand = new Command("edit")
@@ -149,27 +151,18 @@ export const commentEditCommand = new Command("edit")
 
     if (linkInputs.length > 0) {
       const me = await ensureMe(client);
-      const links: TaskLinkInput[] = await Promise.all(
-        linkInputs.map(async (ref) => {
-          const { projectArg, postNumberArg, idOpt } = parseLinkRef(ref);
-          const { projectId: pid, postId: pidPost, projectCode: pCode, postNumber } =
-            await resolvePostInput(client, { projectArg, postNumberArg, idOpt });
-          const detail = await client.getPost(pid, pidPost);
-          return {
-            projectCode: pCode,
-            number: postNumber,
-            postId: pidPost,
-            subject: detail.result.subject,
-            workflowClass: detail.result.workflowClass,
-          };
-        }),
-      );
+      const links = await resolveTaskLinks(client, linkInputs);
       edited = appendTaskLinks(edited, links, me);
     }
 
     if (opts.dryRun) {
       stopSpinner(false);
-      process.stdout.write(edited + "\n");
+      const globalOpts = commentEditCommand.optsWithGlobals() as OutputOptions;
+      if (globalOpts.json) {
+        process.stdout.write(JSON.stringify({ body: edited }) + "\n");
+      } else {
+        process.stdout.write(edited + "\n");
+      }
       return;
     }
 

--- a/src/commands/post/create.ts
+++ b/src/commands/post/create.ts
@@ -51,6 +51,7 @@ export const postCreateCommand = new Command("create")
   .option("--parent <ref>", "부모 업무 (project/number 또는 postId)")
   .option("--workflow <name>", "초기 워크플로우 이름 또는 class")
   .option("--milestone <name>", "마일스톤 이름")
+  .option("--dry-run", "API 호출 없이 합성된 본문만 stdout 출력 (mention/link-task 적용 결과 미리보기)")
   .action(async (project, opts) => {
     const globalOpts = postCreateCommand.optsWithGlobals() as OutputOptions;
     const config = await getConfigOrThrow();
@@ -147,6 +148,16 @@ export const postCreateCommand = new Command("create")
         }),
       );
       bodyContent = appendTaskLinks(bodyContent, links, me);
+    }
+
+    if (opts.dryRun) {
+      stopSpinner(false);
+      if (globalOpts.json) {
+        process.stdout.write(JSON.stringify({ body: bodyContent }) + "\n");
+      } else {
+        process.stdout.write(bodyContent + "\n");
+      }
+      return;
     }
 
     const toUsers = opts.to ? await resolveUsers(client, projectId, opts.to) : [];

--- a/src/commands/post/create.ts
+++ b/src/commands/post/create.ts
@@ -15,7 +15,8 @@ import { DoorayCliError } from "../../utils/errors.js";
 import { EXIT_PARAM_ERROR } from "../../utils/exit-codes.js";
 import { readBodyInput } from "../../utils/body-input.js";
 import { prependMentions } from "../../utils/mention.js";
-import { appendTaskLinks, parseLinkRef, type TaskLinkInput } from "../../utils/task-link.js";
+import { appendTaskLinks } from "../../utils/task-link.js";
+import { resolveTaskLinks } from "../../resolvers/task-link.js";
 import type { CreatePostUser } from "../../api/types.js";
 import type { OutputOptions } from "../../formatters/table.js";
 import { printJson } from "../../formatters/table.js";
@@ -104,7 +105,7 @@ export const postCreateCommand = new Command("create")
       const groups = await Promise.all(
         groupInputs.map(async (code) => {
           const g = await resolveMemberGroup(client, projectId, code);
-          return { groupId: g.id, code: g.code, projectCode: projectCode! };
+          return { groupId: g.id, code: g.code, projectCode: projectCode ?? "" };
         }),
       );
       bodyContent = prependMentions(bodyContent, members, groups, me);
@@ -112,21 +113,7 @@ export const postCreateCommand = new Command("create")
 
     if (linkInputs.length > 0) {
       const me = await ensureMe(client);
-      const links: TaskLinkInput[] = await Promise.all(
-        linkInputs.map(async (ref) => {
-          const { projectArg, postNumberArg, idOpt } = parseLinkRef(ref);
-          const { projectId: pid, postId: pidPost, projectCode: pCode, postNumber } =
-            await resolvePostInput(client, { projectArg, postNumberArg, idOpt });
-          const detail = await client.getPost(pid, pidPost);
-          return {
-            projectCode: pCode,
-            number: postNumber,
-            postId: pidPost,
-            subject: detail.result.subject,
-            workflowClass: detail.result.workflowClass,
-          };
-        }),
-      );
+      const links = await resolveTaskLinks(client, linkInputs);
       bodyContent = appendTaskLinks(bodyContent, links, me);
     }
 

--- a/src/commands/post/create.ts
+++ b/src/commands/post/create.ts
@@ -1,16 +1,19 @@
 import { Command } from "commander";
 import { getConfigOrThrow } from "../../config/store.js";
 import { DoorayApiClient } from "../../api/client.js";
-import { resolveProject } from "../../resolvers/project.js";
-import { resolveMember } from "../../resolvers/member.js";
+import { resolveProject, ensureProjects } from "../../resolvers/project.js";
+import { resolveMember, buildMemberNameMap } from "../../resolvers/member.js";
+import { resolveMemberGroup } from "../../resolvers/member-group.js";
 import { resolveTags, validateMandatoryTags } from "../../resolvers/tag.js";
 import { resolveMilestone } from "../../resolvers/milestone.js";
 import { resolvePostRef } from "../../resolvers/postRef.js";
 import { resolveWorkflow } from "../../resolvers/workflow.js";
+import { ensureMe } from "../../resolvers/me.js";
 import { startSpinner, stopSpinner } from "../../utils/spinner.js";
 import { DoorayCliError } from "../../utils/errors.js";
 import { EXIT_PARAM_ERROR } from "../../utils/exit-codes.js";
 import { readBodyInput } from "../../utils/body-input.js";
+import { prependMentions } from "../../utils/mention.js";
 import type { CreatePostUser } from "../../api/types.js";
 import type { OutputOptions } from "../../formatters/table.js";
 import { printJson } from "../../formatters/table.js";
@@ -40,6 +43,8 @@ export const postCreateCommand = new Command("create")
   .option("--priority <level>", "우선순위 (highest, high, normal, low, lowest)", "normal")
   .option("--due-date <date>", "마감일 (ISO 8601 형식)")
   .option("--tag <name>", "태그 이름 (반복 가능)", (value, prev: string[]) => [...prev, value], [] as string[])
+  .option("--mention <name>", "멤버 멘션 (반복 가능, 이름 부분일치)", (v, prev: string[]) => [...prev, v], [] as string[])
+  .option("--mention-group <code>", "그룹 멘션 (반복 가능, code 부분일치)", (v, prev: string[]) => [...prev, v], [] as string[])
   .option("--parent <ref>", "부모 업무 (project/number 또는 postId)")
   .option("--workflow <name>", "초기 워크플로우 이름 또는 class")
   .option("--milestone <name>", "마일스톤 이름")
@@ -61,10 +66,44 @@ export const postCreateCommand = new Command("create")
       );
     }
 
-    const bodyContent = await readBodyInput(opts);
+    const mentionInputs: string[] = (opts.mention ?? []).filter((s: string) => s.length > 0);
+    const groupInputs: string[] = (opts.mentionGroup ?? []).filter((s: string) => s.length > 0);
+
+    let bodyContent = await readBodyInput(opts);
 
     startSpinner("업무 생성 중...");
     const projectId = await resolveProject(client, project);
+
+    let projectCode: string | undefined;
+    if (groupInputs.length > 0) {
+      const projects = await ensureProjects(client);
+      projectCode = projects.find((p) => p.id === projectId)?.code;
+      if (!projectCode) {
+        throw new DoorayCliError(
+          `--mention-group 은 공개 프로젝트에서만 지원됩니다. dooray project list 로 캐시 갱신 후 재시도하세요.`,
+          EXIT_PARAM_ERROR,
+        );
+      }
+    }
+
+    if (mentionInputs.length > 0 || groupInputs.length > 0) {
+      const me = await ensureMe(client);
+      const memberIds = await Promise.all(
+        mentionInputs.map((name) => resolveMember(client, projectId, name)),
+      );
+      const nameMap = await buildMemberNameMap(client, projectId);
+      const members = memberIds.map((memberId) => ({
+        memberId,
+        name: nameMap.get(memberId) ?? memberId,
+      }));
+      const groups = await Promise.all(
+        groupInputs.map(async (code) => {
+          const g = await resolveMemberGroup(client, projectId, code);
+          return { groupId: g.id, code: g.code, projectCode: projectCode! };
+        }),
+      );
+      bodyContent = prependMentions(bodyContent, members, groups, me);
+    }
 
     const toUsers = opts.to ? await resolveUsers(client, projectId, opts.to) : [];
     const ccUsers = opts.cc ? await resolveUsers(client, projectId, opts.cc) : [];

--- a/src/commands/post/create.ts
+++ b/src/commands/post/create.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { getConfigOrThrow } from "../../config/store.js";
 import { DoorayApiClient } from "../../api/client.js";
 import { resolveProject, ensureProjects } from "../../resolvers/project.js";
+import { resolvePostInput } from "../../resolvers/post-input.js";
 import { resolveMember, buildMemberNameMap } from "../../resolvers/member.js";
 import { resolveMemberGroup } from "../../resolvers/member-group.js";
 import { resolveTags, validateMandatoryTags } from "../../resolvers/tag.js";
@@ -14,6 +15,7 @@ import { DoorayCliError } from "../../utils/errors.js";
 import { EXIT_PARAM_ERROR } from "../../utils/exit-codes.js";
 import { readBodyInput } from "../../utils/body-input.js";
 import { prependMentions } from "../../utils/mention.js";
+import { appendTaskLinks, type TaskLinkInput } from "../../utils/task-link.js";
 import type { CreatePostUser } from "../../api/types.js";
 import type { OutputOptions } from "../../formatters/table.js";
 import { printJson } from "../../formatters/table.js";
@@ -45,6 +47,7 @@ export const postCreateCommand = new Command("create")
   .option("--tag <name>", "태그 이름 (반복 가능)", (value, prev: string[]) => [...prev, value], [] as string[])
   .option("--mention <name>", "멤버 멘션 (반복 가능, 이름 부분일치)", (v, prev: string[]) => [...prev, v], [] as string[])
   .option("--mention-group <code>", "그룹 멘션 (반복 가능, code 부분일치)", (v, prev: string[]) => [...prev, v], [] as string[])
+  .option("--link-task <ref>", "다른 업무 링크 추가 (<project>/<number> 또는 postId, 반복 가능)", (v, prev: string[]) => [...prev, v], [] as string[])
   .option("--parent <ref>", "부모 업무 (project/number 또는 postId)")
   .option("--workflow <name>", "초기 워크플로우 이름 또는 class")
   .option("--milestone <name>", "마일스톤 이름")
@@ -68,6 +71,7 @@ export const postCreateCommand = new Command("create")
 
     const mentionInputs: string[] = (opts.mention ?? []).filter((s: string) => s.length > 0);
     const groupInputs: string[] = (opts.mentionGroup ?? []).filter((s: string) => s.length > 0);
+    const linkInputs: string[] = (opts.linkTask ?? []).filter((s: string) => s.length > 0);
 
     let bodyContent = await readBodyInput(opts);
 
@@ -103,6 +107,46 @@ export const postCreateCommand = new Command("create")
         }),
       );
       bodyContent = prependMentions(bodyContent, members, groups, me);
+    }
+
+    if (linkInputs.length > 0) {
+      const me = await ensureMe(client);
+      const links: TaskLinkInput[] = await Promise.all(
+        linkInputs.map(async (ref) => {
+          let projectArg: string | undefined;
+          let postNumberArg: string | undefined;
+          let idOpt: string | undefined;
+          if (/^[0-9]{15,}$/.test(ref)) {
+            idOpt = ref;
+          } else if (ref.includes("/")) {
+            const [p, n] = ref.split("/");
+            if (!p || !n) {
+              throw new DoorayCliError(
+                `--link-task 형식이 올바르지 않습니다: "${ref}". <project>/<number> 또는 postId를 입력하세요.`,
+                EXIT_PARAM_ERROR,
+              );
+            }
+            projectArg = p;
+            postNumberArg = n;
+          } else {
+            throw new DoorayCliError(
+              `--link-task 형식이 올바르지 않습니다: "${ref}". <project>/<number> 또는 postId를 입력하세요.`,
+              EXIT_PARAM_ERROR,
+            );
+          }
+          const { projectId: pid, postId: pidPost, projectCode: pCode, postNumber } =
+            await resolvePostInput(client, { projectArg, postNumberArg, idOpt });
+          const detail = await client.getPost(pid, pidPost);
+          return {
+            projectCode: pCode,
+            number: postNumber,
+            postId: pidPost,
+            subject: detail.result.subject,
+            workflowClass: detail.result.workflowClass,
+          };
+        }),
+      );
+      bodyContent = appendTaskLinks(bodyContent, links, me);
     }
 
     const toUsers = opts.to ? await resolveUsers(client, projectId, opts.to) : [];

--- a/src/commands/post/create.ts
+++ b/src/commands/post/create.ts
@@ -15,7 +15,7 @@ import { DoorayCliError } from "../../utils/errors.js";
 import { EXIT_PARAM_ERROR } from "../../utils/exit-codes.js";
 import { readBodyInput } from "../../utils/body-input.js";
 import { prependMentions } from "../../utils/mention.js";
-import { appendTaskLinks, type TaskLinkInput } from "../../utils/task-link.js";
+import { appendTaskLinks, parseLinkRef, type TaskLinkInput } from "../../utils/task-link.js";
 import type { CreatePostUser } from "../../api/types.js";
 import type { OutputOptions } from "../../formatters/table.js";
 import { printJson } from "../../formatters/table.js";
@@ -114,27 +114,7 @@ export const postCreateCommand = new Command("create")
       const me = await ensureMe(client);
       const links: TaskLinkInput[] = await Promise.all(
         linkInputs.map(async (ref) => {
-          let projectArg: string | undefined;
-          let postNumberArg: string | undefined;
-          let idOpt: string | undefined;
-          if (/^[0-9]{15,}$/.test(ref)) {
-            idOpt = ref;
-          } else if (ref.includes("/")) {
-            const [p, n] = ref.split("/");
-            if (!p || !n) {
-              throw new DoorayCliError(
-                `--link-task 형식이 올바르지 않습니다: "${ref}". <project>/<number> 또는 postId를 입력하세요.`,
-                EXIT_PARAM_ERROR,
-              );
-            }
-            projectArg = p;
-            postNumberArg = n;
-          } else {
-            throw new DoorayCliError(
-              `--link-task 형식이 올바르지 않습니다: "${ref}". <project>/<number> 또는 postId를 입력하세요.`,
-              EXIT_PARAM_ERROR,
-            );
-          }
+          const { projectArg, postNumberArg, idOpt } = parseLinkRef(ref);
           const { projectId: pid, postId: pidPost, projectCode: pCode, postNumber } =
             await resolvePostInput(client, { projectArg, postNumberArg, idOpt });
           const detail = await client.getPost(pid, pidPost);

--- a/src/commands/post/edit.ts
+++ b/src/commands/post/edit.ts
@@ -6,7 +6,9 @@ import { resolveMember, ensureMembers, buildMemberNameMap } from "../../resolver
 import { resolveMemberGroup } from "../../resolvers/member-group.js";
 import { ensureMe } from "../../resolvers/me.js";
 import { prependMentions } from "../../utils/mention.js";
-import { appendTaskLinks, parseLinkRef, type TaskLinkInput } from "../../utils/task-link.js";
+import { appendTaskLinks } from "../../utils/task-link.js";
+import { resolveTaskLinks } from "../../resolvers/task-link.js";
+import type { OutputOptions } from "../../formatters/table.js";
 import {
   openInEditor,
   serializePostFrontmatter,
@@ -106,27 +108,19 @@ export const postEditCommand = new Command("edit")
       if (linkInputs.length > 0) {
         const effectiveBody = newBody ?? post.body.content;
         const me = await ensureMe(client);
-        const links: TaskLinkInput[] = await Promise.all(
-          linkInputs.map(async (ref) => {
-            const { projectArg, postNumberArg, idOpt } = parseLinkRef(ref);
-            const { projectId: pid, postId: pidPost, projectCode: pCode, postNumber } =
-              await resolvePostInput(client, { projectArg, postNumberArg, idOpt });
-            const detail = await client.getPost(pid, pidPost);
-            return {
-              projectCode: pCode,
-              number: postNumber,
-              postId: pidPost,
-              subject: detail.result.subject,
-              workflowClass: detail.result.workflowClass,
-            };
-          }),
-        );
+        const links = await resolveTaskLinks(client, linkInputs);
         newBody = appendTaskLinks(effectiveBody, links, me);
       }
 
       if (opts.dryRun) {
         stopSpinner(false);
-        process.stdout.write((newBody ?? post.body.content) + "\n");
+        const globalOpts = postEditCommand.optsWithGlobals() as OutputOptions;
+        const previewBody = newBody ?? post.body.content;
+        if (globalOpts.json) {
+          process.stdout.write(JSON.stringify({ body: previewBody }) + "\n");
+        } else {
+          process.stdout.write(previewBody + "\n");
+        }
         return;
       }
 

--- a/src/commands/post/edit.ts
+++ b/src/commands/post/edit.ts
@@ -45,6 +45,7 @@ export const postEditCommand = new Command("edit")
   .option("--mention <name>", "멤버 멘션 (반복 가능, 이름 부분일치)", (v, prev: string[]) => [...prev, v], [] as string[])
   .option("--mention-group <code>", "그룹 멘션 (반복 가능, code 부분일치)", (v, prev: string[]) => [...prev, v], [] as string[])
   .option("--link-task <ref>", "다른 업무 링크 추가 (<project>/<number> 또는 postId, 반복 가능)", (v, prev: string[]) => [...prev, v], [] as string[])
+  .option("--dry-run", "API 호출 없이 합성된 본문만 stdout 출력 (mention/link-task 적용 결과 미리보기)")
   .option("--no-confirm", "누락 attachment 경고 시 confirm 없이 진행 (자동화용)")
   .action(async (project, postNumberStr, opts) => {
     const config = await getConfigOrThrow();
@@ -79,7 +80,7 @@ export const postEditCommand = new Command("edit")
       // Non-interactive mode: apply only specified changes
       let newBody = await readBodyInputOrNull(opts);
 
-      if (newBody != null) {
+      if (newBody != null && !opts.dryRun) {
         const attachments = (post.files ?? []).map((f) => ({ id: f.id, name: f.name }));
         await checkAndGuardDropped(post.body.content, newBody, attachments, !opts.confirm);
       }
@@ -143,6 +144,12 @@ export const postEditCommand = new Command("edit")
           }),
         );
         newBody = appendTaskLinks(effectiveBody, links, me);
+      }
+
+      if (opts.dryRun) {
+        stopSpinner(false);
+        process.stdout.write((newBody ?? post.body.content) + "\n");
+        return;
       }
 
       startSpinner("업무 수정 중...");

--- a/src/commands/post/edit.ts
+++ b/src/commands/post/edit.ts
@@ -2,7 +2,10 @@ import { Command } from "commander";
 import { getConfigOrThrow } from "../../config/store.js";
 import { DoorayApiClient } from "../../api/client.js";
 import { resolvePostInput } from "../../resolvers/post-input.js";
-import { resolveMember, ensureMembers } from "../../resolvers/member.js";
+import { resolveMember, ensureMembers, buildMemberNameMap } from "../../resolvers/member.js";
+import { resolveMemberGroup } from "../../resolvers/member-group.js";
+import { ensureMe } from "../../resolvers/me.js";
+import { prependMentions } from "../../utils/mention.js";
 import {
   openInEditor,
   serializePostFrontmatter,
@@ -36,13 +39,18 @@ export const postEditCommand = new Command("edit")
   .option("--subject <subject>", "--title의 deprecated alias")
   .option("--body <text>", "본문 변경 (- 입력 시 stdin, non-interactive)")
   .option("--body-file <path>", "본문 파일 경로 (- 입력 시 stdin, non-interactive)")
+  .option("--mention <name>", "멤버 멘션 (반복 가능, 이름 부분일치)", (v, prev: string[]) => [...prev, v], [] as string[])
+  .option("--mention-group <code>", "그룹 멘션 (반복 가능, code 부분일치)", (v, prev: string[]) => [...prev, v], [] as string[])
   .option("--no-confirm", "누락 attachment 경고 시 confirm 없이 진행 (자동화용)")
   .action(async (project, postNumberStr, opts) => {
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
+    const mentionInputs: string[] = (opts.mention ?? []).filter((s: string) => s.length > 0);
+    const groupInputs: string[] = (opts.mentionGroup ?? []).filter((s: string) => s.length > 0);
+
     startSpinner("업무 조회 중...");
-    const { projectId, postId, postNumber } = await resolvePostInput(client, {
+    const { projectId, postId, postNumber, projectCode } = await resolvePostInput(client, {
       projectArg: project,
       postNumberArg: postNumberStr,
       idOpt: opts.id,
@@ -64,11 +72,31 @@ export const postEditCommand = new Command("edit")
 
     if (nonInteractive) {
       // Non-interactive mode: apply only specified changes
-      const newBody = await readBodyInputOrNull(opts);
+      let newBody = await readBodyInputOrNull(opts);
 
       if (newBody != null) {
         const attachments = (post.files ?? []).map((f) => ({ id: f.id, name: f.name }));
         await checkAndGuardDropped(post.body.content, newBody, attachments, !opts.confirm);
+      }
+
+      if (mentionInputs.length > 0 || groupInputs.length > 0) {
+        const effectiveBody = newBody ?? post.body.content;
+        const me = await ensureMe(client);
+        const memberIds = await Promise.all(
+          mentionInputs.map((name) => resolveMember(client, projectId, name)),
+        );
+        const nameMap = await buildMemberNameMap(client, projectId);
+        const members = memberIds.map((memberId) => ({
+          memberId,
+          name: nameMap.get(memberId) ?? memberId,
+        }));
+        const groups = await Promise.all(
+          groupInputs.map(async (code) => {
+            const g = await resolveMemberGroup(client, projectId, code);
+            return { groupId: g.id, code: g.code, projectCode };
+          }),
+        );
+        newBody = prependMentions(effectiveBody, members, groups, me);
       }
 
       startSpinner("업무 수정 중...");
@@ -99,6 +127,11 @@ export const postEditCommand = new Command("edit")
       stopSpinner(true, "업무 수정 완료");
     } else {
       // Interactive mode: $EDITOR
+      if (mentionInputs.length > 0 || groupInputs.length > 0) {
+        process.stderr.write(
+          "⚠  --mention/--mention-group 은 --title/--body 와 함께 사용 시에만 적용됩니다.\n",
+        );
+      }
       const original = serializePostFrontmatter(post, members);
       const edited = await openInEditor(original);
 

--- a/src/commands/post/edit.ts
+++ b/src/commands/post/edit.ts
@@ -6,12 +6,15 @@ import { resolveMember, ensureMembers, buildMemberNameMap } from "../../resolver
 import { resolveMemberGroup } from "../../resolvers/member-group.js";
 import { ensureMe } from "../../resolvers/me.js";
 import { prependMentions } from "../../utils/mention.js";
+import { appendTaskLinks, type TaskLinkInput } from "../../utils/task-link.js";
 import {
   openInEditor,
   serializePostFrontmatter,
   parsePostFrontmatter,
 } from "../../editor/index.js";
 import { startSpinner, stopSpinner } from "../../utils/spinner.js";
+import { DoorayCliError } from "../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../utils/exit-codes.js";
 import { readBodyInputOrNull } from "../../utils/body-input.js";
 import { checkAndGuardDropped } from "../../utils/attachment-check.js";
 import type { CreatePostUser } from "../../api/types.js";
@@ -41,6 +44,7 @@ export const postEditCommand = new Command("edit")
   .option("--body-file <path>", "본문 파일 경로 (- 입력 시 stdin, non-interactive)")
   .option("--mention <name>", "멤버 멘션 (반복 가능, 이름 부분일치)", (v, prev: string[]) => [...prev, v], [] as string[])
   .option("--mention-group <code>", "그룹 멘션 (반복 가능, code 부분일치)", (v, prev: string[]) => [...prev, v], [] as string[])
+  .option("--link-task <ref>", "다른 업무 링크 추가 (<project>/<number> 또는 postId, 반복 가능)", (v, prev: string[]) => [...prev, v], [] as string[])
   .option("--no-confirm", "누락 attachment 경고 시 confirm 없이 진행 (자동화용)")
   .action(async (project, postNumberStr, opts) => {
     const config = await getConfigOrThrow();
@@ -48,6 +52,7 @@ export const postEditCommand = new Command("edit")
 
     const mentionInputs: string[] = (opts.mention ?? []).filter((s: string) => s.length > 0);
     const groupInputs: string[] = (opts.mentionGroup ?? []).filter((s: string) => s.length > 0);
+    const linkInputs: string[] = (opts.linkTask ?? []).filter((s: string) => s.length > 0);
 
     startSpinner("업무 조회 중...");
     const { projectId, postId, postNumber, projectCode } = await resolvePostInput(client, {
@@ -97,6 +102,47 @@ export const postEditCommand = new Command("edit")
           }),
         );
         newBody = prependMentions(effectiveBody, members, groups, me);
+      }
+
+      if (linkInputs.length > 0) {
+        const effectiveBody = newBody ?? post.body.content;
+        const me = await ensureMe(client);
+        const links: TaskLinkInput[] = await Promise.all(
+          linkInputs.map(async (ref) => {
+            let projectArg: string | undefined;
+            let postNumberArg: string | undefined;
+            let idOpt: string | undefined;
+            if (/^[0-9]{15,}$/.test(ref)) {
+              idOpt = ref;
+            } else if (ref.includes("/")) {
+              const [p, n] = ref.split("/");
+              if (!p || !n) {
+                throw new DoorayCliError(
+                  `--link-task 형식이 올바르지 않습니다: "${ref}". <project>/<number> 또는 postId를 입력하세요.`,
+                  EXIT_PARAM_ERROR,
+                );
+              }
+              projectArg = p;
+              postNumberArg = n;
+            } else {
+              throw new DoorayCliError(
+                `--link-task 형식이 올바르지 않습니다: "${ref}". <project>/<number> 또는 postId를 입력하세요.`,
+                EXIT_PARAM_ERROR,
+              );
+            }
+            const { projectId: pid, postId: pidPost, projectCode: pCode, postNumber } =
+              await resolvePostInput(client, { projectArg, postNumberArg, idOpt });
+            const detail = await client.getPost(pid, pidPost);
+            return {
+              projectCode: pCode,
+              number: postNumber,
+              postId: pidPost,
+              subject: detail.result.subject,
+              workflowClass: detail.result.workflowClass,
+            };
+          }),
+        );
+        newBody = appendTaskLinks(effectiveBody, links, me);
       }
 
       startSpinner("업무 수정 중...");

--- a/src/commands/post/edit.ts
+++ b/src/commands/post/edit.ts
@@ -6,15 +6,13 @@ import { resolveMember, ensureMembers, buildMemberNameMap } from "../../resolver
 import { resolveMemberGroup } from "../../resolvers/member-group.js";
 import { ensureMe } from "../../resolvers/me.js";
 import { prependMentions } from "../../utils/mention.js";
-import { appendTaskLinks, type TaskLinkInput } from "../../utils/task-link.js";
+import { appendTaskLinks, parseLinkRef, type TaskLinkInput } from "../../utils/task-link.js";
 import {
   openInEditor,
   serializePostFrontmatter,
   parsePostFrontmatter,
 } from "../../editor/index.js";
 import { startSpinner, stopSpinner } from "../../utils/spinner.js";
-import { DoorayCliError } from "../../utils/errors.js";
-import { EXIT_PARAM_ERROR } from "../../utils/exit-codes.js";
 import { readBodyInputOrNull } from "../../utils/body-input.js";
 import { checkAndGuardDropped } from "../../utils/attachment-check.js";
 import type { CreatePostUser } from "../../api/types.js";
@@ -110,27 +108,7 @@ export const postEditCommand = new Command("edit")
         const me = await ensureMe(client);
         const links: TaskLinkInput[] = await Promise.all(
           linkInputs.map(async (ref) => {
-            let projectArg: string | undefined;
-            let postNumberArg: string | undefined;
-            let idOpt: string | undefined;
-            if (/^[0-9]{15,}$/.test(ref)) {
-              idOpt = ref;
-            } else if (ref.includes("/")) {
-              const [p, n] = ref.split("/");
-              if (!p || !n) {
-                throw new DoorayCliError(
-                  `--link-task 형식이 올바르지 않습니다: "${ref}". <project>/<number> 또는 postId를 입력하세요.`,
-                  EXIT_PARAM_ERROR,
-                );
-              }
-              projectArg = p;
-              postNumberArg = n;
-            } else {
-              throw new DoorayCliError(
-                `--link-task 형식이 올바르지 않습니다: "${ref}". <project>/<number> 또는 postId를 입력하세요.`,
-                EXIT_PARAM_ERROR,
-              );
-            }
+            const { projectArg, postNumberArg, idOpt } = parseLinkRef(ref);
             const { projectId: pid, postId: pidPost, projectCode: pCode, postNumber } =
               await resolvePostInput(client, { projectArg, postNumberArg, idOpt });
             const detail = await client.getPost(pid, pidPost);
@@ -183,6 +161,11 @@ export const postEditCommand = new Command("edit")
       if (mentionInputs.length > 0 || groupInputs.length > 0) {
         process.stderr.write(
           "⚠  --mention/--mention-group 은 --title/--body 와 함께 사용 시에만 적용됩니다.\n",
+        );
+      }
+      if (linkInputs.length > 0) {
+        process.stderr.write(
+          "⚠  --link-task 는 --title/--body 와 함께 사용 시에만 적용됩니다.\n",
         );
       }
       const original = serializePostFrontmatter(post, members);

--- a/src/resolvers/task-link.ts
+++ b/src/resolvers/task-link.ts
@@ -1,0 +1,26 @@
+import type { DoorayApiClient } from "../api/client.js";
+import { resolvePostInput } from "./post-input.js";
+import { parseLinkRef, type TaskLinkInput } from "../utils/task-link.js";
+
+export async function resolveTaskLinks(
+  client: DoorayApiClient,
+  linkInputs: string[],
+): Promise<TaskLinkInput[]> {
+  return Promise.all(
+    linkInputs.map(async (ref) => {
+      const { projectArg, postNumberArg, idOpt } = parseLinkRef(ref);
+      const { projectId, postId, projectCode, postNumber } = await resolvePostInput(
+        client,
+        { projectArg, postNumberArg, idOpt },
+      );
+      const detail = await client.getPost(projectId, postId);
+      return {
+        projectCode,
+        number: postNumber,
+        postId,
+        subject: detail.result.subject,
+        workflowClass: detail.result.workflowClass,
+      };
+    }),
+  );
+}

--- a/src/utils/task-link.test.ts
+++ b/src/utils/task-link.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { escapeLinkText, buildTaskLink, appendTaskLinks } from "./task-link.js";
+import type { CachedMe } from "../cache/types.js";
+
+const ME: CachedMe = { id: "user-1", orgId: "1234567890123456789", name: "tester" };
+
+describe("escapeLinkText", () => {
+  it("[ ] — & 이스케이프", () => {
+    expect(escapeLinkText("a [b] — c & d")).toBe("a &#91;b&#93; &mdash; c &amp; d");
+  });
+  it("이스케이프 대상 없으면 그대로", () => {
+    expect(escapeLinkText("plain text")).toBe("plain text");
+  });
+});
+
+describe("buildTaskLink", () => {
+  it("workflowClass 있으면 호버 title 포함", () => {
+    expect(buildTaskLink({
+      projectCode: "demo", number: 42, postId: "9876543210987654321",
+      subject: "feat: foo", workflowClass: "backlog",
+    }, ME)).toBe('[demo/42 feat: foo](dooray://1234567890123456789/tasks/9876543210987654321 "backlog")');
+  });
+  it("workflowClass 없으면 title 생략", () => {
+    expect(buildTaskLink({
+      projectCode: "demo", number: 42, postId: "9876543210987654321",
+      subject: "fix: bar",
+    }, ME)).toBe("[demo/42 fix: bar](dooray://1234567890123456789/tasks/9876543210987654321)");
+  });
+});
+
+describe("appendTaskLinks", () => {
+  it("links 가 비어있으면 body 그대로", () => {
+    expect(appendTaskLinks("hello", [], ME)).toBe("hello");
+  });
+  it("body 끝에 빈 줄 1개 + 링크 줄바꿈 append", () => {
+    const out = appendTaskLinks("hello", [{
+      projectCode: "demo", number: 1, postId: "9876543210987654321", subject: "x",
+    }], ME);
+    expect(out).toBe("hello\n\n[demo/1 x](dooray://1234567890123456789/tasks/9876543210987654321)");
+  });
+});

--- a/src/utils/task-link.ts
+++ b/src/utils/task-link.ts
@@ -1,4 +1,6 @@
 import type { CachedMe } from "../cache/types.js";
+import { DoorayCliError } from "./errors.js";
+import { EXIT_PARAM_ERROR } from "./exit-codes.js";
 
 // markdown link 텍스트 안의 특수문자 escape
 export function escapeLinkText(text: string): string {
@@ -25,6 +27,24 @@ export function buildTaskLink(t: TaskLinkInput, me: CachedMe): string {
     return `[${text}](${url} "${safeClass}")`;
   }
   return `[${text}](${url})`;
+}
+
+export function parseLinkRef(ref: string): { projectArg?: string; postNumberArg?: string; idOpt?: string } {
+  if (/^[0-9]{15,}$/.test(ref)) return { idOpt: ref };
+  if (ref.includes("/")) {
+    const [p, n] = ref.split("/");
+    if (!p || !n) {
+      throw new DoorayCliError(
+        `--link-task 형식이 올바르지 않습니다: "${ref}". <project>/<number> 또는 postId를 입력하세요.`,
+        EXIT_PARAM_ERROR,
+      );
+    }
+    return { projectArg: p, postNumberArg: n };
+  }
+  throw new DoorayCliError(
+    `--link-task 형식이 올바르지 않습니다: "${ref}". <project>/<number> 또는 postId를 입력하세요.`,
+    EXIT_PARAM_ERROR,
+  );
 }
 
 // body 끝에 task link 들을 줄바꿈 후 append. 본문이 비어있어도 형식 유지.

--- a/src/utils/task-link.ts
+++ b/src/utils/task-link.ts
@@ -1,0 +1,36 @@
+import type { CachedMe } from "../cache/types.js";
+
+// markdown link 텍스트 안의 특수문자 escape
+export function escapeLinkText(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/\[/g, "&#91;")
+    .replace(/\]/g, "&#93;")
+    .replace(/—/g, "&mdash;");
+}
+
+export interface TaskLinkInput {
+  projectCode: string;
+  number: number;
+  postId: string;
+  subject: string;
+  workflowClass?: string; // 호버 title 용 (옵션)
+}
+
+export function buildTaskLink(t: TaskLinkInput, me: CachedMe): string {
+  const text = `${t.projectCode}/${t.number} ${escapeLinkText(t.subject)}`;
+  const url = `dooray://${me.orgId}/tasks/${t.postId}`;
+  if (t.workflowClass) {
+    const safeClass = t.workflowClass.replace(/"/g, "&quot;");
+    return `[${text}](${url} "${safeClass}")`;
+  }
+  return `[${text}](${url})`;
+}
+
+// body 끝에 task link 들을 줄바꿈 후 append. 본문이 비어있어도 형식 유지.
+export function appendTaskLinks(body: string, links: TaskLinkInput[], me: CachedMe): string {
+  if (links.length === 0) return body;
+  const rendered = links.map((l) => buildTaskLink(l, me)).join("\n");
+  if (!body) return rendered;
+  return body.replace(/\n*$/, "") + "\n\n" + rendered;
+}

--- a/tasks/022-feat-mention-link-first-class/index.json
+++ b/tasks/022-feat-mention-link-first-class/index.json
@@ -2,7 +2,7 @@
   "name": "022-feat-mention-link-first-class",
   "description": "GitHub Issue #33 — 본문/댓글 작성 시 멘션·내부 링크를 first-class 옵션으로 지원. (1) `post create` / `post edit` 에 `--mention` / `--mention-group` 추가 (comment 와 동일 패턴), (2) 4 명령 (post create/edit + post comment add/edit) 에 `--link-task <project>/<number>` 옵션 + buildTaskLink util, (3) non-interactive 모드 4 명령에 `--dry-run` 미리보기.",
   "created_at": "2026-05-07T00:00:00Z",
-  "status": "pending",
+  "status": "completed",
   "current_phase": 1,
   "total_phases": 3,
   "error_message": null,
@@ -12,21 +12,21 @@
       "number": 1,
       "title": "post create / post edit 에 --mention / --mention-group 추가",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 2,
       "title": "4 명령에 --link-task 옵션 + buildTaskLink util + tests",
       "file": "phase-02.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 3,
       "title": "--dry-run 미리보기 + README / SKILL.md + 완료 마킹",
       "file": "phase-03.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],

--- a/tasks/022-feat-mention-link-first-class/phase-01.md
+++ b/tasks/022-feat-mention-link-first-class/phase-01.md
@@ -34,7 +34,7 @@ src/commands/post/edit.ts
 
 ## 작업 항목
 
-### 1. `src/commands/post/create.ts` — 옵션 추가 + body 합성
+### 1. `src/commands/post/create.ts` — 옵션 추가 + projectCode 획득 + body 합성
 
 옵션 정의 추가 (기존 `--tag` 옆):
 
@@ -43,14 +43,35 @@ src/commands/post/edit.ts
 .option("--mention-group <code>", "그룹 멘션 (반복 가능)", (v, prev: string[]) => [...prev, v], [] as string[])
 ```
 
+**projectCode 획득 (필수)** — `post create` 는 `resolveProject(client, input)` 만 사용하고 반환은 `string` (id만). `--mention-group` markdown 은 `[@<projectCode>/<groupCode>](...)` 포맷이라 정확한 projectCode 필요. positional 이 code 든 ID 든 projects cache 에서 reverse lookup:
+
+```ts
+import { ensureProjects } from "../../resolvers/project.js";
+import { DoorayCliError } from "../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../utils/exit-codes.js";
+// ...
+const projectId = await resolveProject(client, projectInput);
+let projectCode: string | undefined;
+if (groupInputs.length > 0) {
+  // mention-group 사용 시에만 reverse lookup (cache 히트면 추가 API 호출 없음)
+  const projects = await ensureProjects(client);
+  projectCode = projects.find((p) => p.id === projectId)?.code;
+  if (!projectCode) {
+    throw new DoorayCliError(
+      `--mention-group 은 공개 프로젝트에서만 지원됩니다. dooray project list 로 캐시 갱신 후 재시도하세요.`,
+      EXIT_PARAM_ERROR,
+    );
+  }
+}
+```
+
 action 안에서 (resolveTags 호출 근처):
 
 ```ts
 import { prependMentions } from "../../utils/mention.js";
 import { ensureMe } from "../../resolvers/me.js";
-import { resolveMember } from "../../resolvers/member.js";
+import { resolveMember, buildMemberNameMap } from "../../resolvers/member.js";
 import { resolveMemberGroup } from "../../resolvers/member-group.js";
-import { buildMemberNameMap } from "../../resolvers/member.js"; // 기존 export 가정
 
 // ...
 const mentionInputs: string[] = (opts.mention ?? []).filter((s: string) => s.length > 0);
@@ -67,7 +88,7 @@ if (mentionInputs.length > 0 || groupInputs.length > 0) {
   const groups = await Promise.all(
     groupInputs.map(async (code) => {
       const g = await resolveMemberGroup(client, projectId, code);
-      return { groupId: g.id, code: g.code, projectCode };
+      return { groupId: g.id, code: g.code, projectCode: projectCode! };
     }),
   );
   bodyContent = prependMentions(bodyContent, members, groups, me);
@@ -75,8 +96,6 @@ if (mentionInputs.length > 0 || groupInputs.length > 0) {
 
 // updatePost / createPost body 에 bodyContent 사용
 ```
-
-`projectCode` 는 `resolvePostInput` 결과 또는 입력 인자에서 획득 — comment add/edit 패턴 그대로.
 
 ### 2. `src/commands/post/edit.ts` — non-interactive 분기에만 적용
 

--- a/tasks/022-feat-mention-link-first-class/phase-03.md
+++ b/tasks/022-feat-mention-link-first-class/phase-03.md
@@ -23,7 +23,7 @@ CLAUDE.md
 tasks/022-feat-mention-link-first-class/index.json
 ```
 
-## 작업 항목
+## 작업 항목 (4개)
 
 ### 1. 4 명령에 `--dry-run` 옵션
 
@@ -45,7 +45,11 @@ if (opts.dryRun) {
 
 `--json` 과 함께 쓸 때: `process.stdout.write(JSON.stringify({ body: bodyContent }) + "\n")`. quiet 모드는 `bodyContent` 만.
 
-### 2. `README.md` — 사용 예 섹션 갱신
+**중요 — `post edit` non-interactive 분기**: `checkAndGuardDropped` 가 `--dry-run` 보다 먼저 실행되면 confirm prompt 가 떠서 미리보기 의도와 충돌. `--dry-run` 시 `checkAndGuardDropped` 도 skip.
+
+### 2. 사용자 가이드 docs 3 파일 갱신 (README + SKILL.md + CLAUDE.md)
+
+#### 2-1. `README.md` — 사용 예 섹션 갱신
 
 기존 mention 예시 옆에 task link + dry-run 예 추가:
 
@@ -70,7 +74,7 @@ dooray post comment add <project> <post-number> --body "..." --link-task <projec
 \`\`\`
 ```
 
-### 3. `skills/dooray-cli/SKILL.md` — AI 에이전트 가이드
+#### 2-2. `skills/dooray-cli/SKILL.md` — AI 에이전트 가이드
 
 ```markdown
 ## 멘션·링크 자동 삽입 (first-class)
@@ -83,20 +87,20 @@ dooray post comment add <project> <post-number> --body "..." --link-task <projec
 - `--dry-run` — API 호출 없이 합성 결과만 stdout. CI / 자동화 검증용
 ```
 
-### 4. `CLAUDE.md` 주의사항 표 — 한 줄 추가
+#### 2-3. `CLAUDE.md` 주의사항 표 — 한 줄 추가
 
 ```
 - `post create` / `post edit` / `post comment add/edit` 4 명령 모두 `--mention` / `--mention-group` / `--link-task` / `--dry-run` 동일 옵션 지원. mention 은 prepend, link-task 는 append, 적용 순서는 mention → link-task. interactive ($EDITOR) 모드의 `post edit` 는 mention/link-task 무시 + 경고
 ```
 
-### 5. 빌드 검증
+### 3. 빌드 검증
 
 ```bash
 # cwd: /Users/nhn/personal/dooray-cli
 pnpm build && pnpm test
 ```
 
-### 6. 마지막 phase — index.json 완료 마킹
+### 4. 마지막 phase — index.json 완료 마킹
 
 ```bash
 # cwd: /Users/nhn/personal/dooray-cli


### PR DESCRIPTION
## Summary

GitHub Issue #33 — 본문/댓글 작성 시 멘션·내부 링크를 first-class CLI 옵션으로 지원.

- `post create` / `post edit` 에 `--mention` / `--mention-group` 추가 (기존 comment 패턴 재사용)
- 4 명령 (post create/edit + post comment add/edit) 에 `--link-task <project>/<number>` 옵션 + `src/utils/task-link.ts` 신규 (escapeLinkText / buildTaskLink / appendTaskLinks / parseLinkRef + 6 vitest 케이스)
- 4 명령에 `--dry-run` 미리보기 (API 호출 없이 합성된 본문 stdout 출력)
- post edit interactive ($EDITOR) 모드에서 `--mention` / `--link-task` 사용 시 stderr 경고 + 무시
- README.md / skills/dooray-cli/SKILL.md / CLAUDE.md / docs/code-architecture.md 갱신

## Commits

- `feat(commands): add --mention/--mention-group to post create/edit` (phase 1/3)
- `feat(commands): add --link-task option for inline task references` (phase 2/3)
- `feat(commands): add --dry-run + document mention/link-task across post commands` (phase 3/3)
- `fix(commands): apply review #022 — extract parseLinkRef + warn link-task in editor mode`
- `docs(architecture): list task-link.ts in utils tree`

## Pipeline

build-with-teams 4-agent pipeline:
- critic APPROVE (REVISE 1회 후) — projectCode reverse lookup 명시 + phase-03 작업 항목 4개로 축소
- code-reviewer PASS (FIX_NEEDED 1회 후) — parseLinkRef DRY 헬퍼 추출 + interactive 경고 누락 수정
- docs-verifier PASS — code-architecture.md utils 트리에 task-link.ts 추가

## Test plan

- [x] `pnpm build` — 182.64 KB, CJS 단일 번들
- [x] `pnpm test` — 11 files, 84 tests all passed (신규 task-link 6 케이스 포함)
- [ ] `dooray post create <project> --title "..." --body "..." --mention "<name>" --dry-run` 실호출 검증
- [ ] `dooray post comment add <project> <post> --body "..." --link-task <project>/<number> --dry-run` 실호출 검증
- [ ] `dooray post edit <project> <post> --title "..." --body "..." --mention "..."` non-interactive
- [ ] post edit interactive ($EDITOR) 모드에서 `--mention/--link-task` 경고 출력 확인

Closes #33