### PR TITLE
refactor(api): use return await on toDoorayCliError (Issue #42)

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -149,7 +149,7 @@ export class DoorayApiClient {
         .get("common/v1/members/me")
         .json<MeResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -170,7 +170,7 @@ export class DoorayApiClient {
         })
         .json<ProjectListResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -201,7 +201,7 @@ export class DoorayApiClient {
         })
         .json<PostListResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -211,7 +211,7 @@ export class DoorayApiClient {
         .get(`project/v1/projects/${projectId}/posts/${postId}`)
         .json<PostDetailResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -221,7 +221,7 @@ export class DoorayApiClient {
         .get(`project/v1/posts/${postId}`)
         .json<PostDetailResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -231,7 +231,7 @@ export class DoorayApiClient {
         .post(`project/v1/projects/${projectId}/posts`, { json: body })
         .json<CreatePostApiResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -241,7 +241,7 @@ export class DoorayApiClient {
         .put(`project/v1/projects/${projectId}/posts/${postId}`, { json: body })
         .json<UpdatePostResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -251,7 +251,7 @@ export class DoorayApiClient {
         .post(`project/v1/projects/${projectId}/posts/${postId}/set-done`)
         .json<DoorayApiUnitResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -263,7 +263,7 @@ export class DoorayApiClient {
         })
         .json<DoorayApiUnitResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -275,7 +275,7 @@ export class DoorayApiClient {
         })
         .json<DoorayApiUnitResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -293,7 +293,7 @@ export class DoorayApiClient {
         })
         .json<PostCommentListResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -307,7 +307,7 @@ export class DoorayApiClient {
         .get(`project/v1/projects/${projectId}/posts/${postId}/logs/${logId}`)
         .json<PostCommentDetailResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -317,7 +317,7 @@ export class DoorayApiClient {
         .post(`project/v1/projects/${projectId}/posts/${postId}/logs`, { json: body })
         .json<CreateCommentApiResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -327,7 +327,7 @@ export class DoorayApiClient {
         .put(`project/v1/projects/${projectId}/posts/${postId}/logs/${logId}`, { json: body })
         .json<UpdateCommentResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -337,7 +337,7 @@ export class DoorayApiClient {
         .delete(`project/v1/projects/${projectId}/posts/${postId}/logs/${logId}`)
         .json<DeleteCommentResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -355,7 +355,7 @@ export class DoorayApiClient {
         })
         .json<ProjectMemberListResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -365,7 +365,7 @@ export class DoorayApiClient {
         .get(`common/v1/members/${memberId}`)
         .json<MemberDetailResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -385,7 +385,7 @@ export class DoorayApiClient {
         })
         .json<MemberSearchResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -397,7 +397,7 @@ export class DoorayApiClient {
         .get(`project/v1/projects/${projectId}/workflows`)
         .json<ProjectWorkflowListResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -417,7 +417,7 @@ export class DoorayApiClient {
         })
         .json<TagListResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -437,7 +437,7 @@ export class DoorayApiClient {
         })
         .json<MemberGroupListResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -457,7 +457,7 @@ export class DoorayApiClient {
         })
         .json<MilestoneListResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -474,7 +474,7 @@ export class DoorayApiClient {
         })
         .json<WikiListResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -488,7 +488,7 @@ export class DoorayApiClient {
         })
         .json<WikiPagesResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -498,7 +498,7 @@ export class DoorayApiClient {
         .get(`wiki/v1/wikis/${wikiId}/pages/${pageId}`)
         .json<WikiPageResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -508,7 +508,7 @@ export class DoorayApiClient {
         .post(`wiki/v1/wikis/${wikiId}/pages`, { json: body })
         .json<CreateWikiPageResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -518,7 +518,7 @@ export class DoorayApiClient {
         .put(`wiki/v1/wikis/${wikiId}/pages/${pageId}`, { json: body })
         .json<DoorayApiUnitResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -532,7 +532,7 @@ export class DoorayApiClient {
         .put(`wiki/v1/wikis/${wikiId}/pages/${pageId}/title`, { json: body })
         .json<DoorayApiUnitResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -546,7 +546,7 @@ export class DoorayApiClient {
         .put(`wiki/v1/wikis/${wikiId}/pages/${pageId}/content`, { json: body })
         .json<DoorayApiUnitResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -558,7 +558,7 @@ export class DoorayApiClient {
         .get(`project/v1/projects/${projectId}/posts/${postId}/files`)
         .json<PostFileListResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -570,7 +570,7 @@ export class DoorayApiClient {
         })
         .json<PostFileMetaResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -607,7 +607,7 @@ export class DoorayApiClient {
       return { buffer, fileName };
     } catch (e) {
       if (e instanceof DoorayCliError) throw e;
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -653,7 +653,7 @@ export class DoorayApiClient {
       return await res.json() as UploadFileResponse;
     } catch (e) {
       if (e instanceof DoorayCliError) throw e;
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 
@@ -663,7 +663,7 @@ export class DoorayApiClient {
         .delete(`project/v1/projects/${projectId}/posts/${postId}/files/${fileId}`)
         .json<DoorayApiUnitResponse>();
     } catch (e) {
-      return toDoorayCliError(e);
+      await toDoorayCliError(e);
     }
   }
 }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -149,7 +149,7 @@ export class DoorayApiClient {
         .get("common/v1/members/me")
         .json<MeResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -170,7 +170,7 @@ export class DoorayApiClient {
         })
         .json<ProjectListResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -201,7 +201,7 @@ export class DoorayApiClient {
         })
         .json<PostListResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -211,7 +211,7 @@ export class DoorayApiClient {
         .get(`project/v1/projects/${projectId}/posts/${postId}`)
         .json<PostDetailResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -221,7 +221,7 @@ export class DoorayApiClient {
         .get(`project/v1/posts/${postId}`)
         .json<PostDetailResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -231,7 +231,7 @@ export class DoorayApiClient {
         .post(`project/v1/projects/${projectId}/posts`, { json: body })
         .json<CreatePostApiResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -241,7 +241,7 @@ export class DoorayApiClient {
         .put(`project/v1/projects/${projectId}/posts/${postId}`, { json: body })
         .json<UpdatePostResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -251,7 +251,7 @@ export class DoorayApiClient {
         .post(`project/v1/projects/${projectId}/posts/${postId}/set-done`)
         .json<DoorayApiUnitResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -263,7 +263,7 @@ export class DoorayApiClient {
         })
         .json<DoorayApiUnitResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -275,7 +275,7 @@ export class DoorayApiClient {
         })
         .json<DoorayApiUnitResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -293,7 +293,7 @@ export class DoorayApiClient {
         })
         .json<PostCommentListResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -307,7 +307,7 @@ export class DoorayApiClient {
         .get(`project/v1/projects/${projectId}/posts/${postId}/logs/${logId}`)
         .json<PostCommentDetailResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -317,7 +317,7 @@ export class DoorayApiClient {
         .post(`project/v1/projects/${projectId}/posts/${postId}/logs`, { json: body })
         .json<CreateCommentApiResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -327,7 +327,7 @@ export class DoorayApiClient {
         .put(`project/v1/projects/${projectId}/posts/${postId}/logs/${logId}`, { json: body })
         .json<UpdateCommentResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -337,7 +337,7 @@ export class DoorayApiClient {
         .delete(`project/v1/projects/${projectId}/posts/${postId}/logs/${logId}`)
         .json<DeleteCommentResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -355,7 +355,7 @@ export class DoorayApiClient {
         })
         .json<ProjectMemberListResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -365,7 +365,7 @@ export class DoorayApiClient {
         .get(`common/v1/members/${memberId}`)
         .json<MemberDetailResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -385,7 +385,7 @@ export class DoorayApiClient {
         })
         .json<MemberSearchResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -397,7 +397,7 @@ export class DoorayApiClient {
         .get(`project/v1/projects/${projectId}/workflows`)
         .json<ProjectWorkflowListResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -417,7 +417,7 @@ export class DoorayApiClient {
         })
         .json<TagListResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -437,7 +437,7 @@ export class DoorayApiClient {
         })
         .json<MemberGroupListResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -457,7 +457,7 @@ export class DoorayApiClient {
         })
         .json<MilestoneListResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -474,7 +474,7 @@ export class DoorayApiClient {
         })
         .json<WikiListResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -488,7 +488,7 @@ export class DoorayApiClient {
         })
         .json<WikiPagesResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -498,7 +498,7 @@ export class DoorayApiClient {
         .get(`wiki/v1/wikis/${wikiId}/pages/${pageId}`)
         .json<WikiPageResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -508,7 +508,7 @@ export class DoorayApiClient {
         .post(`wiki/v1/wikis/${wikiId}/pages`, { json: body })
         .json<CreateWikiPageResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -518,7 +518,7 @@ export class DoorayApiClient {
         .put(`wiki/v1/wikis/${wikiId}/pages/${pageId}`, { json: body })
         .json<DoorayApiUnitResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -532,7 +532,7 @@ export class DoorayApiClient {
         .put(`wiki/v1/wikis/${wikiId}/pages/${pageId}/title`, { json: body })
         .json<DoorayApiUnitResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -546,7 +546,7 @@ export class DoorayApiClient {
         .put(`wiki/v1/wikis/${wikiId}/pages/${pageId}/content`, { json: body })
         .json<DoorayApiUnitResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -558,7 +558,7 @@ export class DoorayApiClient {
         .get(`project/v1/projects/${projectId}/posts/${postId}/files`)
         .json<PostFileListResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -570,7 +570,7 @@ export class DoorayApiClient {
         })
         .json<PostFileMetaResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -607,7 +607,7 @@ export class DoorayApiClient {
       return { buffer, fileName };
     } catch (e) {
       if (e instanceof DoorayCliError) throw e;
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -653,7 +653,7 @@ export class DoorayApiClient {
       return await res.json() as UploadFileResponse;
     } catch (e) {
       if (e instanceof DoorayCliError) throw e;
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 
@@ -663,7 +663,7 @@ export class DoorayApiClient {
         .delete(`project/v1/projects/${projectId}/posts/${postId}/files/${fileId}`)
         .json<DoorayApiUnitResponse>();
     } catch (e) {
-      await toDoorayCliError(e);
+      return await toDoorayCliError(e);
     }
   }
 }

--- a/tasks/026-refactor-client-never-return/index.json
+++ b/tasks/026-refactor-client-never-return/index.json
@@ -2,7 +2,7 @@
   "name": "026-refactor-client-never-return",
   "description": "GitHub Issue #42 — `toDoorayCliError` 의 반환 타입을 `Promise<never>` 그대로 유지하되, client.ts 의 모든 catch 절에서 `return toDoorayCliError(e)` 를 `await toDoorayCliError(e)` 로 통일하여 TypeScript 의 control flow 분석을 명확히 한다. `return` 키워드는 호출자 시그니처가 메서드 반환값으로 해석할 여지를 만들어 future 메서드 추가 시 silent 회귀 위험. 약 34 곳 mechanical 치환.",
   "created_at": "2026-05-08T00:00:00Z",
-  "status": "pending",
+  "status": "completed",
   "current_phase": 1,
   "total_phases": 1,
   "error_message": null,
@@ -12,7 +12,7 @@
       "number": 1,
       "title": "client.ts 전체 catch 절 패턴 통일 + 빌드 검증 + 완료 마킹",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],

--- a/tasks/026-refactor-client-never-return/phase-01.md
+++ b/tasks/026-refactor-client-never-return/phase-01.md
@@ -37,7 +37,7 @@ echo "before: $BEFORE"
 ```
 
 치환 패턴:
-- `return toDoorayCliError(e);` → `await toDoorayCliError(e);`
+- `return toDoorayCliError(e);` → `return await toDoorayCliError(e);`
 - `return toDoorayCliError(error);` 같은 변형도 동일 (인자명 무관)
 
 **구현 방법** (executor): Edit 도구의 `replace_all=true` 사용. macOS BSD `sed` 의 `\b` 함정은 본 케이스에서 사용 안 함 (단순 문자열 치환).
@@ -50,7 +50,7 @@ echo "before: $BEFORE"
 
 // TO-BE
 } catch (e) {
-  await toDoorayCliError(e);
+  return await toDoorayCliError(e);
 }
 ```
 
@@ -75,7 +75,7 @@ async function toDoorayCliError(error: unknown): Promise<never>
 
 # 변경 후 카운트
 AFTER_RETURN=$(grep -c "return toDoorayCliError" src/api/client.ts)
-AFTER_AWAIT=$(grep -c "await toDoorayCliError" src/api/client.ts)
+AFTER_AWAIT=$(grep -c "return await toDoorayCliError" src/api/client.ts)
 echo "after return: $AFTER_RETURN, after await: $AFTER_AWAIT"
 # 기대: return 0, await 34
 
@@ -106,7 +106,7 @@ grep -c "return toDoorayCliError" src/api/client.ts
 # 기대: 0
 
 # 3. await 패턴 34
-grep -c "await toDoorayCliError" src/api/client.ts
+grep -c "return await toDoorayCliError" src/api/client.ts
 # 기대: 34
 
 # 4. index.json 완료
@@ -128,7 +128,7 @@ grep -c '"status": "completed"' tasks/026-refactor-client-never-return/index.jso
 # cwd: /Users/nhn/personal/dooray-cli/.claude/worktrees/026-refactor-client-never-return
 # branch: feat/026-refactor-client-never-return
 git add src/api/client.ts tasks/026-refactor-client-never-return/index.json
-git commit -m "refactor(api): use await toDoorayCliError instead of return
+git commit -m "refactor(api): use return await toDoorayCliError instead of return
 
 Issue #42: toDoorayCliError returns Promise<never> — using 'return' on
 it makes the catch block look like a value-returning path, which can

--- a/tasks/026-refactor-client-never-return/phase-01.md
+++ b/tasks/026-refactor-client-never-return/phase-01.md
@@ -13,7 +13,7 @@ GitHub Issue #42 — PR #40 claude bot 리뷰에서 제기된 cross-cutting 기�
 ## 변경 파일 (정확)
 
 ```bash
-# cwd: /Users/nhn/personal/dooray-cli
+# cwd: /Users/nhn/personal/dooray-cli/.claude/worktrees/026-refactor-client-never-return
 git diff <base>..HEAD --name-only -- src/api/client.ts tasks/026-refactor-client-never-return/
 ```
 
@@ -28,7 +28,7 @@ tasks/026-refactor-client-never-return/index.json
 ### 1. `src/api/client.ts` — 34곳 mechanical 치환
 
 ```bash
-# cwd: /Users/nhn/personal/dooray-cli
+# cwd: /Users/nhn/personal/dooray-cli/.claude/worktrees/026-refactor-client-never-return
 
 # 변경 전 카운트
 BEFORE=$(grep -c "return toDoorayCliError" src/api/client.ts)
@@ -71,7 +71,7 @@ async function toDoorayCliError(error: unknown): Promise<never>
 ### 3. 검증
 
 ```bash
-# cwd: /Users/nhn/personal/dooray-cli
+# cwd: /Users/nhn/personal/dooray-cli/.claude/worktrees/026-refactor-client-never-return
 
 # 변경 후 카운트
 AFTER_RETURN=$(grep -c "return toDoorayCliError" src/api/client.ts)
@@ -87,7 +87,7 @@ pnpm build && pnpm test
 ### 4. 마지막 phase — index.json 완료 마킹
 
 ```bash
-# cwd: /Users/nhn/personal/dooray-cli
+# cwd: /Users/nhn/personal/dooray-cli/.claude/worktrees/026-refactor-client-never-return
 sed -i '' 's/"status": "pending"/"status": "completed"/g' tasks/026-refactor-client-never-return/index.json
 grep -c '"status": "completed"' tasks/026-refactor-client-never-return/index.json
 # 기대: 2 (root + phase 1)
@@ -96,7 +96,7 @@ grep -c '"status": "completed"' tasks/026-refactor-client-never-return/index.jso
 ## 성공 기준
 
 ```bash
-# cwd: /Users/nhn/personal/dooray-cli
+# cwd: /Users/nhn/personal/dooray-cli/.claude/worktrees/026-refactor-client-never-return
 
 # 1. 빌드 + 테스트 통과 (단순 키워드 치환이므로 회귀 가능성 매우 낮음 — 컴파일러가 잡아줌)
 pnpm build && pnpm test
@@ -120,11 +120,12 @@ grep -c '"status": "completed"' tasks/026-refactor-client-never-return/index.jso
 - 다른 파일 (`src/utils/errors.ts`, resolvers, commands) 변경 금지 — client.ts 만
 - catch 절의 다른 로직 변경 금지 (예: 추가 컨텍스트 로깅) — 본 task 는 mechanical 치환만
 - ADR 추가 금지 (자명성 게이트 — TypeScript 일반 패턴)
+- `client.ts:304` 의 `PostCommentDetailResponse` 미임포트는 pre-existing — 본 task scope 외, 자체 수정 금지. 발견 시 SendMessage 로 team-lead 보고.
 
 ## 커밋
 
 ```bash
-# cwd: /Users/nhn/personal/dooray-cli
+# cwd: /Users/nhn/personal/dooray-cli/.claude/worktrees/026-refactor-client-never-return
 # branch: feat/026-refactor-client-never-return
 git add src/api/client.ts tasks/026-refactor-client-never-return/index.json
 git commit -m "refactor(api): use await toDoorayCliError instead of return


### PR DESCRIPTION
## Summary

- `src/api/client.ts` 의 `return toDoorayCliError(e)` 패턴 34곳을 `return await toDoorayCliError(e)` 로 일괄 변경 (Issue #42)
- bare `await` 만 사용 시 `Promise<never>` 라도 TypeScript control-flow 분석이 catch 블록을 never-path 로 추론 못 해 TS2366 (Function lacks ending return statement) 발생 → `return await` 패턴으로 타입 안전성 + await 의도 동시 보존
- `toDoorayCliError` 시그니처 (`async function ...: Promise<never>`) 는 그대로 유지

## Commits

- `b37f9fe` refactor(api): use await toDoorayCliError instead of return
- `a7b18d7` fix(api): preserve return for type narrowing on toDoorayCliError
- `3c1c58d` docs(task): clarify worktree cwd + pre-existing import note in plan026 phase-01

## Test plan

- [x] `pnpm tsc --noEmit` (TS2366 0건)
- [x] `pnpm build` (185.77 KB CJS bundle)
- [x] `pnpm test` (12 files / 91 tests passed)
- [x] `grep -c "return toDoorayCliError" src/api/client.ts` → 0
- [x] `grep -c "return await toDoorayCliError" src/api/client.ts` → 34

Closes #42