### PR TITLE
fix(tsconfig): switch moduleResolution to Bundler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,12 @@ NHN Dooray REST API CLI 도구. TypeScript + Commander.js 기반.
 ```bash
 pnpm install          # 의존성 설치
 pnpm run build        # tsup 빌드 (dist/index.js 단일 번들)
+pnpm tsc --noEmit     # 타입 체크 전용 (런타임 번들에는 미사용)
 node dist/index.js    # 직접 실행
 dooray                # 글로벌 링크 시
 ```
+
+**역할 분리 (`tsconfig.json` `moduleResolution: "Bundler"`)**: `tsup`(esbuild) 이 ESM-only 패키지 (`chalk`/`ora`/`ky`/`@inquirer/prompts`)를 inline transform 으로 처리해 단일 CJS 번들 생성. `tsc` 는 타입 체크 전용이며 런타임 번들에는 관여하지 않음. 새 의존성 추가 시 `package.json` `exports` 맵 진입점이 의도와 맞는지 한 번 확인 (Bundler 모드는 Node16 대비 exports 검증이 완화됨).
 
 ## 디렉토리 구조
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "Node16",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

- \`tsconfig.json\` 의 \`module\` / \`moduleResolution\` 을 \`Node16\` → \`ESNext\` / \`Bundler\` 로 변경.
- \`pnpm tsc --noEmit\` 의 TS1479 (CJS import of ESM-only) 10 건 해결 — chalk / ora / ky / @inquirer/prompts 등이 ESM-only 인데 \`Node16\` 가 CJS 번들로의 import 를 차단했음. tsup (esbuild) 은 이미 inline transform 으로 이 패턴을 처리하므로 Bundler 가 정확한 매핑.

## Why this is a no-op at runtime

- \`pnpm build\` (tsup CJS 단일 번들) — PASS, 동일 183.92 KB
- \`pnpm test\` (vitest) — PASS, 13 files / 100 tests
- \`dist/index.js\` 는 esbuild 가 chalk/ora/ky 를 inline 처리하므로 ESM-only 패키지를 동적으로 require 하지 않음. tsc 검증만 정확히 맞춰주는 변경.

## Remaining tsc errors

이 PR 머지 후 \`pnpm tsc --noEmit\` 28 건 남음 — 다음 follow-up PR 들로 분리 처리:
- PR-B: \`PostCommentDetailResponse\` import 누락 (PR #46 회귀, TS2552 2건) + \`comment/file/list.ts\` files implicit any (TS7006 2건)
- PR-C: \`CachedMember.emailAddress\` schema (TS2339 1건) + \`setup.ts\` URL union narrowing (TS2322 1건)
- PR-D: \`api/imapClient.ts\` + \`mail/reply.ts\` imapflow null guards (TS18048 14 / TS2339 5 / TS2345 1 / TS7006 2 = 22건) + CI \`pnpm tsc --noEmit\` gate 추가

## Test plan

- [x] \`pnpm tsc --noEmit | grep TS1479\` → 0건
- [x] \`pnpm build\` → exit 0, dist/index.js 183.92 KB
- [x] \`pnpm test\` → 13 files / 100 tests PASS
- [x] \`node dist/index.js --version\` → 0.7.0 (변경 없음)