### PR TITLE
fix(api): import PostCommentDetailResponse to restore type inference

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -16,6 +16,7 @@ import type {
   SetWorkflowRequest,
   SetParentPostRequest,
   PostCommentListResponse,
+  PostCommentDetailResponse,
   CreateCommentApiResponse,
   CreateCommentRequest,
   UpdateCommentRequest,


### PR DESCRIPTION
## Summary

PR #46 (post comment get) 머지 시 `client.ts:304,308` 에서 `PostCommentDetailResponse` 타입 사용처에 import 가 누락된 회귀를 복구.

`pnpm tsc --noEmit` 결과: 28건 → 24건 (**-4**).

## Context

이번 PR-A (#50) 머지 후 baseline 28건 중 4건이 `PostCommentDetailResponse` / `PostComment.files` 타입 추론 실패에서 비롯. import 한 줄 추가로 `getPostComment` 반환 타입이 정상 추론되며 `list.ts:52` 의 implicit any 까지 자동 해결.

PR #50 (tsconfig Bundler) 의 후속 시리즈 (PR-A → **PR-B (본 PR)** → PR-C → PR-D) 중 두 번째.

## Changes

- `src/api/client.ts` — `import type { PostCommentDetailResponse } from "./types.js"` 한 줄 추가

## Test plan

- [x] `pnpm tsc --noEmit` → 28건 → 24건 (-4)
- [x] `pnpm build` → exit 0 (183.92 KB)
- [x] `pnpm test` → 100 pass

## Follow-up

- PR-C: `editor/index.ts`, `setup.ts` 타입 (-2)
- PR-D: imapflow 가드 (-22) + CI tsc 게이트