### PR TITLE
fix(commands,editor): resolve TS2322/TS2339 in setup + editor

### DIFF
--- a/src/commands/post/edit.ts
+++ b/src/commands/post/edit.ts
@@ -22,11 +22,11 @@ import type { CreatePostUser } from "../../api/types.js";
 async function resolveUsers(
   client: DoorayApiClient,
   projectId: string,
-  emails: string[],
+  names: string[],
 ): Promise<CreatePostUser[]> {
   const users: CreatePostUser[] = [];
-  for (const email of emails) {
-    const memberId = await resolveMember(client, projectId, email);
+  for (const name of names) {
+    const memberId = await resolveMember(client, projectId, name);
     users.push({ type: "member", member: { organizationMemberId: memberId } });
   }
   return users;

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -40,7 +40,7 @@ export const setupCommand = new Command("setup")
       const defaultEndpoint =
         existing?.baseUrl ?? API_ENDPOINTS["민간 클라우드"];
 
-      const baseUrl = await select({
+      const baseUrl = await select<string>({
         message: "API Endpoint를 선택하세요",
         choices: endpointChoices,
         default: defaultEndpoint,

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -73,7 +73,7 @@ function memberIdToEmail(
   const member = members.find(
     (m) => m.organizationMemberId === memberId,
   );
-  return member?.emailAddress ?? memberId;
+  return member?.name ?? memberId;
 }
 
 export function serializePostFrontmatter(

--- a/src/editor/index.ts
+++ b/src/editor/index.ts
@@ -66,7 +66,7 @@ export interface ParsedPost extends PostFrontmatter {
   body: string;
 }
 
-function memberIdToEmail(
+function memberIdToName(
   memberId: string,
   members: CachedMember[],
 ): string {
@@ -86,14 +86,14 @@ export function serializePostFrontmatter(
     due_date: post.dueDate ?? null,
     to: post.users.to
       .map((u) => {
-        if (u.member) return memberIdToEmail(u.member.organizationMemberId, members);
+        if (u.member) return memberIdToName(u.member.organizationMemberId, members);
         if (u.emailUser) return u.emailUser.emailAddress;
         return "";
       })
       .filter(Boolean),
     cc: post.users.cc
       .map((u) => {
-        if (u.member) return memberIdToEmail(u.member.organizationMemberId, members);
+        if (u.member) return memberIdToName(u.member.organizationMemberId, members);
         if (u.emailUser) return u.emailUser.emailAddress;
         return "";
       })


### PR DESCRIPTION
## Summary

`pnpm tsc --noEmit` 결과: 24건 → 22건 (**-2**). PR #50/#51 의 후속 PR-C.

## Changes

- **`src/commands/setup.ts:43`** — `select(...)` → `select<string>(...)`. `API_ENDPOINTS` 가 `as const` 로 좁혀진 literal union 과 `existing.baseUrl: string` 의 타입 mismatch 해소. 런타임 동작 변경 없음 (choices 는 그대로 4개 endpoint).
- **`src/editor/index.ts:76`** — `memberIdToEmail` 이 `CachedMember` 에 없는 `emailAddress` 를 접근하던 dead code 정정 (항상 fallback 으로 `memberId` 반환했음). `.name` 으로 교체 — 함수 의도(human-readable identifier) 에 맞춤. 편집기 frontmatter 의 `to:`/`cc:` 표시가 19자리 memberId 대신 이름으로 노출 → UX 개선.

## Test plan

- [x] `pnpm tsc --noEmit` → 24 → 22 (-2)
- [x] `pnpm build` → exit 0 (183.91 KB)
- [x] `pnpm test` → 100 pass

## Follow-up

- PR-D: `imapflow` 가드 (-21) + `list.ts:52` (-1) + CI tsc 게이트 추가 — 누적 22 → 0