### PR TITLE
fix(api,ci): guard imapflow types + add tsc gate to CI (PR-D, 22→0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Run type check
+        run: pnpm tsc --noEmit
+
       - name: Run tests
         run: pnpm test
 

--- a/src/api/imapClient.ts
+++ b/src/api/imapClient.ts
@@ -1,5 +1,5 @@
 import { ImapFlow } from "imapflow";
-import { simpleParser } from "mailparser";
+import { simpleParser, type ParsedMail } from "mailparser";
 import type { Config } from "../config/types.js";
 import { DEFAULTS } from "../config/types.js";
 import { DoorayCliError } from "../utils/errors.js";
@@ -62,10 +62,10 @@ export async function listMails(
       if (Object.keys(query).length === 0) query.all = true;
 
       const uids = await client.search(query, { uid: true });
-      if (uids.length === 0) return [];
+      if (!Array.isArray(uids) || uids.length === 0) return [];
 
       // Take latest N UIDs (highest UID = newest)
-      const sorted = uids.sort((a, b) => b - a).slice(0, limit);
+      const sorted = uids.sort((a: number, b: number) => b - a).slice(0, limit);
       const uidSet = sorted.join(",");
 
       const messages: MailMessage[] = [];
@@ -74,17 +74,19 @@ export async function listMails(
         flags: true,
         envelope: true,
       }, { uid: true })) {
+        const { envelope, flags } = msg;
+        if (!envelope || !flags) continue;
         messages.push({
           uid: msg.uid,
-          subject: msg.envelope.subject ?? "(제목 없음)",
-          from: msg.envelope.from?.[0]
-            ? `${msg.envelope.from[0].name || ""} <${msg.envelope.from[0].address || ""}>`
+          subject: envelope.subject ?? "(제목 없음)",
+          from: envelope.from?.[0]
+            ? `${envelope.from[0].name || ""} <${envelope.from[0].address || ""}>`
             : "(unknown)",
-          to: (msg.envelope.to ?? []).map(
+          to: (envelope.to ?? []).map(
             (t) => `${t.name || ""} <${t.address || ""}>`,
           ),
-          date: msg.envelope.date ?? null,
-          isRead: msg.flags.has("\\Seen"),
+          date: envelope.date ?? null,
+          isRead: flags.has("\\Seen"),
         });
       }
 
@@ -120,21 +122,28 @@ export async function getMail(
       if (!msg) {
         throw new DoorayCliError(`메일을 찾을 수 없습니다: UID ${uid}`, 1);
       }
+      const { envelope, flags, source } = msg;
+      if (!envelope || !flags || !source) {
+        throw new DoorayCliError(
+          `메일 메타데이터가 불완전합니다 (UID ${uid}): envelope/flags/source 누락`,
+          1,
+        );
+      }
 
-      const parsed = await simpleParser(msg.source);
-      const body = parsed.text ?? parsed.html ?? "(본문 없음)";
+      const parsed: ParsedMail = await simpleParser(source);
+      const body: string = parsed.text || (parsed.html || "") || "(본문 없음)";
 
       return {
         uid: msg.uid,
-        subject: msg.envelope.subject ?? "(제목 없음)",
-        from: msg.envelope.from?.[0]
-          ? `${msg.envelope.from[0].name || ""} <${msg.envelope.from[0].address || ""}>`
+        subject: envelope.subject ?? "(제목 없음)",
+        from: envelope.from?.[0]
+          ? `${envelope.from[0].name || ""} <${envelope.from[0].address || ""}>`
           : "(unknown)",
-        to: (msg.envelope.to ?? []).map(
+        to: (envelope.to ?? []).map(
           (t) => `${t.name || ""} <${t.address || ""}>`,
         ),
-        date: msg.envelope.date ?? null,
-        isRead: msg.flags.has("\\Seen"),
+        date: envelope.date ?? null,
+        isRead: flags.has("\\Seen"),
         body,
       };
     } finally {

--- a/src/api/imapClient.ts
+++ b/src/api/imapClient.ts
@@ -131,6 +131,7 @@ export async function getMail(
       }
 
       const parsed: ParsedMail = await simpleParser(source);
+      // parsed.html can be false (mailparser); || collapses false and empty string both → fallback
       const body: string = parsed.text || (parsed.html || "") || "(본문 없음)";
 
       return {

--- a/src/commands/mail/reply.ts
+++ b/src/commands/mail/reply.ts
@@ -28,7 +28,8 @@ async function getMessageId(config: Parameters<typeof getImapConfigOrThrow>[0], 
         uid: true,
         envelope: true,
       }, { uid: true });
-      return msg?.envelope.messageId ?? null;
+      if (!msg) return null;
+      return msg.envelope?.messageId ?? null;
     } finally {
       lock.release();
     }


### PR DESCRIPTION
## Summary

`pnpm tsc --noEmit` 결과: 22건 → **0건**. PR #50/#51/#52 후속 PR-D — tsc 회귀 시리즈 종결.

CI 에 `pnpm tsc --noEmit` 게이트 추가로 향후 type 회귀 자동 차단.

## Changes

### `src/api/imapClient.ts` (-21)

| 위치 | 패턴 |
|---|---|
| `listMails` | `client.search()` 의 `false \| number[]` 에 `Array.isArray` 가드. for-await-loop 의 `msg.envelope`/`flags` 를 destructure 후 falsy continue (누락 메시지 skip — 서버가 envelope 누락된 응답을 줄 수 있다는 imapflow 타입 contract 존중) |
| `getMail` | `envelope`/`flags`/`source` 누락 시 `DoorayCliError` throw — 단건 조회는 fail-fast 가 사용자 예측에 부합 |
| `simpleParser` | `ParsedMail` 반환 타입 명시. mailparser 의 callback/promise 오버로드 동시 매칭 (`void & Promise<ParsedMail>`) 회피 |
| `body` fallback | `parsed.html` 의 `string \| false` 를 `string` 으로 강제 (`parsed.text \|\| (parsed.html \|\| "")` 우선순위 + 최종 한국어 fallback) |

### `src/commands/mail/reply.ts` (-1)

- `msg?.envelope.messageId`: `msg` 가 `false \| FetchMessageObject` 인데 `?.` 만으로 `false` 분기 못 잡음 → 명시적 `if (!msg) return null;` 후 `envelope?.messageId` 접근

### `.github/workflows/ci.yml` (+3 lines)

- `Run type check` step 을 `Run tests` 직전에 추가. 향후 모든 PR 에서 `pnpm tsc --noEmit` 자동 검증 → 1-10 (common-pitfalls) 의 type 회귀 함정 자동 차단

## Test plan

- [x] `pnpm tsc --noEmit` → 22 → 0
- [x] `pnpm build` → exit 0 (184.29 KB)
- [x] `pnpm test` → 100 pass

## After merge

- 시리즈 종결: PR-A (-10) + PR-B (-4) + PR-C (-2) + **PR-D (-22)** = 38 → 0
- v0.7.0 npm publish 재진행 가능 (이전 세션에서 tag/Release 만 삭제했고 version commit `23d4d04` 은 main 유지)