### PR TITLE
refactor(api): throw await instead of return await on toDoorayCliError (Issue #49)

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -150,7 +150,7 @@ export class DoorayApiClient {
         .get("common/v1/members/me")
         .json<MeResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -171,7 +171,7 @@ export class DoorayApiClient {
         })
         .json<ProjectListResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -202,7 +202,7 @@ export class DoorayApiClient {
         })
         .json<PostListResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -212,7 +212,7 @@ export class DoorayApiClient {
         .get(`project/v1/projects/${projectId}/posts/${postId}`)
         .json<PostDetailResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -222,7 +222,7 @@ export class DoorayApiClient {
         .get(`project/v1/posts/${postId}`)
         .json<PostDetailResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -232,7 +232,7 @@ export class DoorayApiClient {
         .post(`project/v1/projects/${projectId}/posts`, { json: body })
         .json<CreatePostApiResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -242,7 +242,7 @@ export class DoorayApiClient {
         .put(`project/v1/projects/${projectId}/posts/${postId}`, { json: body })
         .json<UpdatePostResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -252,7 +252,7 @@ export class DoorayApiClient {
         .post(`project/v1/projects/${projectId}/posts/${postId}/set-done`)
         .json<DoorayApiUnitResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -264,7 +264,7 @@ export class DoorayApiClient {
         })
         .json<DoorayApiUnitResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -276,7 +276,7 @@ export class DoorayApiClient {
         })
         .json<DoorayApiUnitResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -294,7 +294,7 @@ export class DoorayApiClient {
         })
         .json<PostCommentListResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -308,7 +308,7 @@ export class DoorayApiClient {
         .get(`project/v1/projects/${projectId}/posts/${postId}/logs/${logId}`)
         .json<PostCommentDetailResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -318,7 +318,7 @@ export class DoorayApiClient {
         .post(`project/v1/projects/${projectId}/posts/${postId}/logs`, { json: body })
         .json<CreateCommentApiResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -328,7 +328,7 @@ export class DoorayApiClient {
         .put(`project/v1/projects/${projectId}/posts/${postId}/logs/${logId}`, { json: body })
         .json<UpdateCommentResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -338,7 +338,7 @@ export class DoorayApiClient {
         .delete(`project/v1/projects/${projectId}/posts/${postId}/logs/${logId}`)
         .json<DeleteCommentResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -356,7 +356,7 @@ export class DoorayApiClient {
         })
         .json<ProjectMemberListResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -366,7 +366,7 @@ export class DoorayApiClient {
         .get(`common/v1/members/${memberId}`)
         .json<MemberDetailResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -386,7 +386,7 @@ export class DoorayApiClient {
         })
         .json<MemberSearchResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -398,7 +398,7 @@ export class DoorayApiClient {
         .get(`project/v1/projects/${projectId}/workflows`)
         .json<ProjectWorkflowListResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -418,7 +418,7 @@ export class DoorayApiClient {
         })
         .json<TagListResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -438,7 +438,7 @@ export class DoorayApiClient {
         })
         .json<MemberGroupListResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -458,7 +458,7 @@ export class DoorayApiClient {
         })
         .json<MilestoneListResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -475,7 +475,7 @@ export class DoorayApiClient {
         })
         .json<WikiListResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -489,7 +489,7 @@ export class DoorayApiClient {
         })
         .json<WikiPagesResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -499,7 +499,7 @@ export class DoorayApiClient {
         .get(`wiki/v1/wikis/${wikiId}/pages/${pageId}`)
         .json<WikiPageResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -509,7 +509,7 @@ export class DoorayApiClient {
         .post(`wiki/v1/wikis/${wikiId}/pages`, { json: body })
         .json<CreateWikiPageResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -519,7 +519,7 @@ export class DoorayApiClient {
         .put(`wiki/v1/wikis/${wikiId}/pages/${pageId}`, { json: body })
         .json<DoorayApiUnitResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -533,7 +533,7 @@ export class DoorayApiClient {
         .put(`wiki/v1/wikis/${wikiId}/pages/${pageId}/title`, { json: body })
         .json<DoorayApiUnitResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -547,7 +547,7 @@ export class DoorayApiClient {
         .put(`wiki/v1/wikis/${wikiId}/pages/${pageId}/content`, { json: body })
         .json<DoorayApiUnitResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -559,7 +559,7 @@ export class DoorayApiClient {
         .get(`project/v1/projects/${projectId}/posts/${postId}/files`)
         .json<PostFileListResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -571,7 +571,7 @@ export class DoorayApiClient {
         })
         .json<PostFileMetaResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -608,7 +608,7 @@ export class DoorayApiClient {
       return { buffer, fileName };
     } catch (e) {
       if (e instanceof DoorayCliError) throw e;
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -654,7 +654,7 @@ export class DoorayApiClient {
       return await res.json() as UploadFileResponse;
     } catch (e) {
       if (e instanceof DoorayCliError) throw e;
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 
@@ -664,7 +664,7 @@ export class DoorayApiClient {
         .delete(`project/v1/projects/${projectId}/posts/${postId}/files/${fileId}`)
         .json<DoorayApiUnitResponse>();
     } catch (e) {
-      return await toDoorayCliError(e);
+      throw await toDoorayCliError(e);
     }
   }
 }

--- a/tasks/028-refactor-client-throw-await/index.json
+++ b/tasks/028-refactor-client-throw-await/index.json
@@ -2,7 +2,7 @@
   "name": "028-refactor-client-throw-await",
   "description": "GitHub Issue #49 — toDoorayCliError 호출 패턴을 'return await' 에서 'throw await' 로 통일. 34곳 mechanical 치환. 시그니처 (async function ...: Promise<never>) 본문 (line 105-127) 그대로 — response body parsing 이 진짜 async I/O 라 sync 변환 옵션 C 부적합. 사용자 가시 동작 0 변경. ADR 불요 (자명성 게이트 통과 — TypeScript 일반 패턴).",
   "created_at": "2026-05-11T00:00:00Z",
-  "status": "pending",
+  "status": "completed",
   "current_phase": 1,
   "total_phases": 1,
   "error_message": null,
@@ -12,7 +12,7 @@
       "number": 1,
       "title": "src/api/client.ts 34곳 return await → throw await + 완료 마킹",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],


### PR DESCRIPTION
## Summary

GitHub Issue #49 — `toDoorayCliError` 호출 패턴을 `return await` 에서 `throw await` 로 통일.

- `src/api/client.ts` 34곳 mechanical 치환
- 시그니처 변경 없음 (`async function toDoorayCliError(error: unknown): Promise<never>` — 본문 line 110 `await error.response.json()` 가 진짜 async I/O 라 sync 변환 불가)
- 사용자 가시 동작 0 변경

## Why

`return` 키워드는 메서드 반환값처럼 보여 future 메서드 추가 시 오류 분기를 잘못 작성해도 컴파일러가 못 잡을 위험. `throw` 키워드는 본문의 `Promise<never>` 의도를 호출자 측에 명시적으로 노출.

## Commits

- `e083270` refactor(api): throw await instead of return await on toDoorayCliError

## Test plan

- [x] `pnpm tsc --noEmit` (0 errors)
- [x] `pnpm build` (CJS 단일 번들)
- [x] `pnpm test` (107 tests passed)
- [x] critic APPROVE (1-shot)
- [x] code-reviewer PASS (1-shot)
- [x] docs-verifier PASS (1-shot)

🤖 Generated with [Claude Code](https://claude.com/claude-code) (build-with-teams)