### PR TITLE
feat(commands): add --parent option to post edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,20 @@ dooray post edit <project> <post-number> --cc-group dev-team --dry-run --json | 
 # 출력 예: [{ "type": "group", "group": { "projectMemberGroupId": "...", "members": [] } }, ...]
 ```
 
+#### 상위 업무 변경 (`--parent`)
+
+```bash
+# 자식 업무에 부모 지정
+dooray post edit <project> <child-number> --title "<원제목>" --parent <project>/<parent-number>
+
+# 다른 부모로 변경
+dooray post edit --id <postId> --title "<원제목>" --parent <other-parent-postId>
+```
+
+내부적으로 `client.updatePost` 호출 후 별도 `POST .../set-parent-post` endpoint 추가 호출. **parent 해제 (top-level 화)** 는 Dooray API 가 미지원이라 웹 UI 에서 수동 처리.
+
+interactive ($EDITOR) 모드에서 `--parent` 사용 시 무시 + stderr 경고. **parent 만 단독 변경하려면 `--title "<원제목>"` 동반 필요** — `post edit` 가 본문 변경(`--title`/`--body`) 동반 시에만 non-interactive 분기로 들어가며, parent 변경은 그 분기 안에서만 수행됨. (Issue #60)
+
 #### comment list 필터 옵션
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ dooray post edit --id <postId> --title "<원제목>" --parent <other-parent-post
 
 interactive ($EDITOR) 모드에서 `--parent` 사용 시 무시 + stderr 경고. **parent 만 단독 변경하려면 `--title "<원제목>"` 동반 필요** — `post edit` 가 본문 변경(`--title`/`--body`) 동반 시에만 non-interactive 분기로 들어가며, parent 변경은 그 분기 안에서만 수행됨. (Issue #60)
 
+`--dry-run --json` 출력의 `parentChange` 필드는 **사용자 입력 원문 그대로** (`<project>/<number>` 또는 raw postId) — resolver 처리 전 미리보기 값이며 실제 호출 대상 `postId` 가 아님. dry-run 은 API 미호출 원칙을 유지해 `resolvePostRef` 도 건너뜀.
+
 #### comment list 필터 옵션
 
 ```bash

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -35,7 +35,7 @@ src/
     workflow.ts             # name·class → workflowId
     post.ts                 # postNumber → postId (API 호출)
     wiki.ts                 # projectCode → wikiId / wikiId → homePageId (캐시)
-    postRef.ts              # "code/number" 또는 raw postId → postId (post create --parent 전용)
+    postRef.ts              # "code/number" 또는 raw postId → postId (post create / post edit --parent 공용)
     tag.ts                  # name[] → tagIds + mandatory/selectOne 검증
     milestone.ts            # name → milestoneId
     match.ts                # 공용: 정확일치 → 부분일치 → 모호 시 에러

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -95,7 +95,7 @@ dooray doctor                                 # 설정 검증
 | 참조자(cc) 멤버/그룹 추가 | `dooray post edit <project> <number> --cc-group <code>` — 기존 참조자 유지 + 그룹 추가 (dedupe, ADR-025) |
 | 참조자 전체 교체 | `dooray post edit <project> <number> --cc-clear --cc <name>` — 기존 참조자 비우고 신규 멤버만 |
 | 신규 업무 + 그룹 cc | `dooray post create <project> --title "..." --cc-group <code>` — 생성 시 그룹 참조자 포함 |
-| `dooray post edit <project> <number> --parent <ref>` | 상위 업무 설정/변경 (Issue #60) |
+| 상위 업무 설정/변경 | `dooray post edit <project> <number> --title "<원제목>" --parent <ref>` — `<ref>` 는 `<project>/<number>` 또는 raw postId. `--title` 미동반 시 interactive 모드로 진입해 무시. unset 미지원 (Issue #60) |
 
 > **제목 옵션 네이밍**: `post` 와 `wiki page` 모두 `--title` 표준. `post`의 `--subject`는 deprecated alias로 당분간 동작하되, 새 코드에서는 `--title` 사용을 권장.
 

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -95,6 +95,7 @@ dooray doctor                                 # 설정 검증
 | 참조자(cc) 멤버/그룹 추가 | `dooray post edit <project> <number> --cc-group <code>` — 기존 참조자 유지 + 그룹 추가 (dedupe, ADR-025) |
 | 참조자 전체 교체 | `dooray post edit <project> <number> --cc-clear --cc <name>` — 기존 참조자 비우고 신규 멤버만 |
 | 신규 업무 + 그룹 cc | `dooray post create <project> --title "..." --cc-group <code>` — 생성 시 그룹 참조자 포함 |
+| `dooray post edit <project> <number> --parent <ref>` | 상위 업무 설정/변경 (Issue #60) |
 
 > **제목 옵션 네이밍**: `post` 와 `wiki page` 모두 `--title` 표준. `post`의 `--subject`는 deprecated alias로 당분간 동작하되, 새 코드에서는 `--title` 사용을 권장.
 
@@ -319,6 +320,20 @@ POST_ID=$(dooray post create <project> \
 # 2. (필요 시) 후속으로 cc 추가
 dooray post edit --id "$POST_ID" --cc-group qa-team
 ```
+
+---
+
+## 자식 업무 먼저 → 후속 부모 지정 (Issue #60)
+
+```bash
+# 1. 자식 업무 생성 (parent 모르고)
+CHILD_ID=$(dooray post create <project> --title "subtask A" --json | jq -r '.id')
+
+# 2. 부모 결정 후 후속 지정
+dooray post edit --id "$CHILD_ID" --title "subtask A" --parent <project>/<parent-number>
+```
+
+**한계** (cmux-browser spike 결과): Dooray API 가 `unset-parent-post` 미제공 → CLI 로 parent 해제 불가. 필요 시 웹 UI 에서 처리.
 
 ---
 

--- a/src/commands/post/edit.ts
+++ b/src/commands/post/edit.ts
@@ -9,6 +9,7 @@ import { prependMentions } from "../../utils/mention.js";
 import { appendTaskLinks } from "../../utils/task-link.js";
 import { resolveTaskLinks } from "../../resolvers/task-link.js";
 import { resolveUserAdditions, mergeUsers } from "../../resolvers/post-users.js";
+import { resolvePostRef } from "../../resolvers/postRef.js";
 import type { OutputOptions } from "../../formatters/table.js";
 import {
   openInEditor,
@@ -52,6 +53,7 @@ export const postEditCommand = new Command("edit")
   .option("--to <name>", "담당자(to) 멤버 추가 (반복 가능, 이름 부분일치)", (v, prev: string[]) => [...prev, v], [] as string[])
   .option("--to-group <code>", "담당자(to) 그룹 추가 (반복 가능, 그룹 코드 부분일치)", (v, prev: string[]) => [...prev, v], [] as string[])
   .option("--to-clear", "기존 담당자 전부 제거 후 신규만 적용")
+  .option("--parent <ref>", "상위 업무 변경 — project/number 또는 raw postId (post create 와 동일 — unset 은 미지원, 웹 UI 에서 처리)")
   .option("--dry-run", "API 호출 없이 합성된 본문만 stdout 출력 (mention/link-task 적용 결과 미리보기)")
   .option("--no-confirm", "누락 attachment 경고 시 confirm 없이 진행 (자동화용)")
   .action(async (project, postNumberStr, opts) => {
@@ -150,7 +152,11 @@ export const postEditCommand = new Command("edit")
         const globalOpts = postEditCommand.optsWithGlobals() as OutputOptions;
         const previewBody = newBody ?? post.body.content;
         if (globalOpts.json) {
-          process.stdout.write(JSON.stringify({ body: previewBody, users: { to: toUsers, cc: ccUsers } }) + "\n");
+          process.stdout.write(JSON.stringify({
+            body: previewBody,
+            users: { to: toUsers, cc: ccUsers },
+            ...(opts.parent && { parentChange: opts.parent }),
+          }) + "\n");
         } else {
           process.stdout.write(previewBody + "\n");
         }
@@ -170,6 +176,21 @@ export const postEditCommand = new Command("edit")
         users: { to: toUsers, cc: ccUsers },
       });
       stopSpinner(true, "업무 수정 완료");
+
+      if (opts.parent) {
+        startSpinner("상위 업무 변경 중...");
+        try {
+          const newParentPostId = await resolvePostRef(client, opts.parent);
+          await client.setPostParent(projectId, postId, newParentPostId);
+          stopSpinner(true, "상위 업무 변경 완료");
+        } catch (err) {
+          stopSpinner(false, "상위 업무 변경 실패");
+          process.stderr.write(
+            "⚠  본문은 수정되었으나 상위 업무 변경에 실패했습니다. 본문 재실행 금지 — 웹 UI 또는 dooray post edit --parent 단독 재시도 권장.\n",
+          );
+          throw err;
+        }
+      }
     } else {
       // Interactive mode: $EDITOR
       if (mentionInputs.length > 0 || groupInputs.length > 0) {
@@ -186,6 +207,11 @@ export const postEditCommand = new Command("edit")
           toNames.length > 0 || toGroups.length > 0 || opts.toClear) {
         process.stderr.write(
           "⚠  --cc/--cc-group/--cc-clear/--to/--to-group/--to-clear 는 --title/--body 와 함께 사용 시에만 적용됩니다.\n",
+        );
+      }
+      if (opts.parent) {
+        process.stderr.write(
+          "⚠  --parent 는 --title/--body 와 함께 사용 시에만 적용됩니다.\n",
         );
       }
       const original = serializePostFrontmatter(post, members);

--- a/src/resolvers/postRef.ts
+++ b/src/resolvers/postRef.ts
@@ -15,7 +15,7 @@ export async function resolvePostRef(client: DoorayApiClient, ref: string): Prom
     const num = Number(numStr);
     if (!code || !Number.isFinite(num) || num <= 0) {
       throw new DoorayCliError(
-        `--parent 형식이 올바르지 않습니다: "${ref}" (예: "tc-ocr/337" 또는 raw postId)`,
+        `--parent 형식이 올바르지 않습니다: "${ref}" (예: "my-project/337" 또는 raw postId)`,
         EXIT_PARAM_ERROR,
       );
     }

--- a/tasks/030-feat-post-edit-parent/index.json
+++ b/tasks/030-feat-post-edit-parent/index.json
@@ -2,8 +2,8 @@
   "name": "030-feat-post-edit-parent",
   "description": "GitHub Issue #60 — dooray post edit 에 --parent <ref> 옵션 추가 (상위 업무 설정/변경). client.setPostParent (이미 존재, POST .../set-parent-post endpoint) 호출. resolvePostRef 재사용 — `project/number` 또는 raw postId. interactive ($EDITOR) 모드 무시 + 경고. cmux-browser spike 결과 unset-parent-post 부재 확인 → --parent-clear 옵션 제외 (웹 UI 에서 처리).",
   "created_at": "2026-05-11T00:00:00Z",
-  "status": "pending",
-  "current_phase": 1,
+  "status": "completed",
+  "current_phase": 2,
   "total_phases": 2,
   "error_message": null,
   "blocked_reason": null,
@@ -12,14 +12,14 @@
       "number": 1,
       "title": "post edit --parent 옵션 추가 + setPostParent 호출 + 실증",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 2,
       "title": "README + skills/dooray-cli/SKILL.md + 완료 마킹",
       "file": "phase-02.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],

--- a/tasks/030-feat-post-edit-parent/phase-01.md
+++ b/tasks/030-feat-post-edit-parent/phase-01.md
@@ -48,28 +48,40 @@ src/commands/post/edit.ts
 
 ### 2. action 안에서 처리
 
-post create 의 `--workflow` 후속 호출 패턴 답습. `client.updatePost` 호출 후 `--parent` 가 있으면 `setPostParent` 추가 호출.
+post create 의 `--workflow` 후속 호출 패턴 답습. **위치**: non-interactive 블록 내, `client.updatePost` 후 `stopSpinner(true, "업무 수정 완료")` 직후 (dry-run early-return 은 이미 위에서 처리됨).
 
 ```ts
 import { resolvePostRef } from "../../resolvers/postRef.js";
 
-// non-interactive 분기 — client.updatePost 직후, dry-run 체크 이후
-if (opts.parent && !opts.dryRun) {
+// non-interactive 블록 안, updatePost 의 stopSpinner 직후
+if (opts.parent) {
   startSpinner("상위 업무 변경 중...");
-  const newParentPostId = await resolvePostRef(client, opts.parent);
-  await client.setPostParent(projectId, postId, newParentPostId);
-  stopSpinner(true, "상위 업무 변경 완료");
+  try {
+    const newParentPostId = await resolvePostRef(client, opts.parent);
+    await client.setPostParent(projectId, postId, newParentPostId);
+    stopSpinner(true, "상위 업무 변경 완료");
+  } catch (err) {
+    stopSpinner(false, "상위 업무 변경 실패");
+    process.stderr.write(
+      "⚠  본문은 수정되었으나 상위 업무 변경에 실패했습니다. 본문 재실행 금지 — 웹 UI 또는 dooray post edit --parent 단독 재시도 권장.\n",
+    );
+    throw err;
+  }
 }
 ```
 
-**호출 순서**: `client.updatePost` (subject/body/users) → `client.setPostParent` (parent). 둘 다 무관 endpoint 라 atomic 보장 없음 — `updatePost` 가 성공하고 `setPostParent` 가 실패해도 body 변경은 유지됨. partial 실패 stderr 안내는 setPostParent 의 catch 가 자동 처리 (toDoorayCliError → DoorayCliError throw + non-zero exit).
+**호출 순서**: `client.updatePost` (subject/body/users) → `client.setPostParent` (parent). 두 endpoint atomic 보장 없음 — `updatePost` 성공 후 `setPostParent` 실패 시 본문은 이미 저장된 상태. partial-failure 사용자 오해 방지 위해 stderr 안내 필수 (재실행 시 본문 재저장으로 mention prepend 중복 등 부작용 가능).
+
+**손자 구조 시도 (400)**: Dooray 서버가 "상위업무를 가진 하위업무를 상위로 설정" 거부. `toDoorayCliError` 가 서버 메시지를 wrap → DoorayCliError throw → non-zero exit. 실증 시 stderr 에 Dooray 원본 에러 메시지 노출되면 통과.
 
 ### 3. interactive ($EDITOR) 모드 경고
 
-`opts.parent` 가 있고 interactive 분기로 들어가면 stderr 경고 + 옵션 무시 (mention/link-task/cc 패턴 답습):
+`opts.parent` 가 있고 interactive 분기 (`else` 블록) 로 들어가면 stderr 경고 + 옵션 무시 (mention/link-task/cc 패턴 답습).
+
+**위치**: interactive `else { ... }` 블록 첫머리, 기존 mention/cc 경고 바로 다음 줄에 추가. non-interactive 블록 진입 *전* if(opts.parent) 검사 금지 (non-interactive 일 때 잘못 경고 출력됨).
 
 ```ts
-// interactive 분기 진입 직전 또는 안:
+// interactive else 블록 첫머리 (cc 경고 옆):
 if (opts.parent) {
   process.stderr.write(
     "⚠  --parent 는 --title/--body 와 함께 사용 시에만 적용됩니다.\n",
@@ -98,28 +110,31 @@ if (opts.dryRun) {
 }
 ```
 
+**주의**: `parentChange: opts.parent` 는 사용자 입력 그대로 (`<project>/<number>` 또는 raw postId). 실제 호출될 postId 로 변환 전 — 미리보기 목적이라 의도적. resolvePostRef 는 dry-run 에서 호출하지 않음 (API 미호출 원칙 유지).
+
 ### 5. 동작 실증 (필수)
 
 ```bash
 # cwd: /Users/nhn/personal/dooray-cli
 pnpm build
 
-# 1) 자식 업무 1개 + 부모 후보 1개 준비 (없으면 사용자에게 요청)
-# 2) parent 설정
-node dist/index.js post edit <project> <child-number> --parent <project>/<parent-number>
+# 1) 자식 업무 + 부모 후보 (사용자 제공: child=<project>/<child>, parent=<project>/<parent>)
+# 2) parent 설정 — non-interactive 진입 위해 --title 또는 --body 동반 필수
+node dist/index.js post edit <project> <child-number> --title "<원제목 그대로>" --parent <project>/<parent-number>
 # 기대: '업무 수정 완료' + '상위 업무 변경 완료' 200 OK
 
-# 3) parent 변경 (다른 부모로)
-node dist/index.js post edit --id <child-postId> --parent <other-parent-postId>
+# 3) parent 재설정 (동일 또는 다른 부모로 — parent2 없으면 동일 ref 로 idempotent 확인)
+node dist/index.js post edit --id <child-postId> --title "<원제목 그대로>" --parent <other-parent-postId>
 
-# 4) Dooray 제약 케이스: 손자 구조 시도 (상위업무를 가진 하위업무를 상위로) → 400 에러 기대
-# 5) dry-run JSON
-node dist/index.js post edit <project> <child-number> --parent <project>/<other-parent> --dry-run --json
+# 4) Dooray 제약 케이스: 손자 구조 시도 → 400 에러 + stderr 에 Dooray 서버 메시지 노출 + non-zero exit
+
+# 5) dry-run JSON — non-interactive 진입 위해 --title 동반 필수
+node dist/index.js post edit <project> <child-number> --title "<원제목>" --parent <project>/<other-parent> --dry-run --json
 # 기대: { body, users, parentChange: '<project>/<other-parent>' }. API 미호출
 
-# 6) interactive 경고
-node dist/index.js post edit <project> <child-number> --parent <project>/<parent-number>   # --title/--body 없음
-# 기대: stderr 경고 + frontmatter 편집 후 parent 미적용
+# 6) interactive 경고 — --title/--body 미동반
+node dist/index.js post edit <project> <child-number> --parent <project>/<parent-number>
+# 기대: stderr "⚠  --parent 는 --title/--body 와 함께 사용 시에만 적용됩니다." + $EDITOR 진입. parent 미적용
 ```
 
 ## 성공 기준

--- a/tasks/030-feat-post-edit-parent/phase-02.md
+++ b/tasks/030-feat-post-edit-parent/phase-02.md
@@ -33,7 +33,7 @@ dooray post edit --id <postId> --parent <other-parent-postId>
 
 내부적으로 `client.updatePost` 호출 후 별도 `POST .../set-parent-post` endpoint 추가 호출. **parent 해제 (top-level 화)** 는 Dooray API 가 미지원이라 웹 UI 에서 수동 처리.
 
-interactive ($EDITOR) 모드에서 `--parent` 사용 시 무시 + stderr 경고.
+interactive ($EDITOR) 모드에서 `--parent` 사용 시 무시 + stderr 경고. **parent 만 단독 변경하려면 `--title "<원제목>"` 동반 필요** — `post edit` 가 본문 변경(`--title`/`--body`) 동반 시에만 non-interactive 분기로 들어가며, parent 변경은 그 분기 안에서만 수행됨.
 ```
 
 ### 2. `skills/dooray-cli/SKILL.md` — AI 자동화 시나리오
@@ -65,8 +65,11 @@ dooray post edit --id "$CHILD_ID" --parent <project>/<parent-number>
 ```bash
 # cwd: /Users/nhn/personal/dooray-cli
 sed -i '' 's/"status": "pending"/"status": "completed"/g' tasks/030-feat-post-edit-parent/index.json
+sed -i '' 's/"current_phase": 1/"current_phase": 2/' tasks/030-feat-post-edit-parent/index.json
 grep -c '"status": "completed"' tasks/030-feat-post-edit-parent/index.json
 # 기대: 3 (index 1 + phases 2)
+grep -nE "\"current_phase\": 2" tasks/030-feat-post-edit-parent/index.json
+# 기대: 1줄
 ```
 
 ## 성공 기준
@@ -91,6 +94,8 @@ grep -nE "Issue #60" README.md skills/dooray-cli/SKILL.md
 # 4. index.json 완료 마킹
 grep -c '"status": "completed"' tasks/030-feat-post-edit-parent/index.json
 # 기대: 3
+grep -cE "\"current_phase\": 2" tasks/030-feat-post-edit-parent/index.json
+# 기대: 1
 
 # 5. PII grep 0건
 grep -rnE "tc-ocr|nhnent|nhn-comico|@(nhn|nhnent)\.com" README.md skills/ tasks/030-feat-post-edit-parent/ 2>/dev/null | grep -vE "사내 Dooray|NHN 도메인"


### PR DESCRIPTION
## Summary

GitHub Issue #60 — `dooray post edit` 에 `--parent <ref>` 옵션 추가하여 기존 업무의 상위 업무를 설정/변경 가능. `post create --parent` 와 동일한 ref 형식 (`<project>/<number>` 또는 raw postId).

- `client.setPostParent` (이미 존재, `POST .../set-parent-post` endpoint) 호출
- `client.updatePost` 직후 sequential 호출 (atomic 보장 없음 → partial-failure 시 stderr 안내 + non-zero exit)
- interactive ($EDITOR) 모드 진입 시 옵션 무시 + stderr 경고 (mention/cc 패턴 답습)
- dry-run JSON 에 `parentChange` 표시 (raw 입력 그대로, resolve 전)
- **unset (top-level 화) 미지원** — cmux-browser spike 결과 Dooray API 가 `unset-parent-post` endpoint 미제공. CLI 에서는 변경만, 해제는 웹 UI 에서 처리

## Commits

```
a41cd9e fix(docs): address docs-verifier findings for plan030
73486b6 docs: document post edit --parent; complete task 030
70f1922 feat(commands): add --parent option to post edit
0eeaaea docs(task): revise plan030 phases per critic feedback
```

## Test plan

- [x] `pnpm tsc --noEmit` — 0 오류
- [x] `pnpm test` — 107/107 passed
- [x] live API 실증 (사용자 환경): parent 설정·동일 ref idempotent·dry-run JSON·interactive 경고 1 cycle 200 OK
- [x] code-reviewer PASS (9개 항목 + spinner pair + partial-failure UX)
- [x] docs-verifier PASS (5축 + PII gate + planning docs 영향 표 + 갱신 시점 분리)

## Pipeline

build-with-teams (critic REVISE 1회 → ACCEPT, code-reviewer PASS, docs-verifier UPDATE_NEEDED 1회 → PASS).