### PR TITLE
fix(resolvers): guard undefined name + add helpHint to matchByName (Issue #65)

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -383,7 +383,7 @@ export interface ProjectMemberListResponse {
 
 export interface MemberGroup {
   id: string;
-  code: string;
+  code?: string;  // optional — 실제 API 응답에서 누락 케이스 존재 (ADR-026)
   project: ProjectInfo;
   createdAt: string;
   updatedAt: string;

--- a/src/cache/types.ts
+++ b/src/cache/types.ts
@@ -55,7 +55,7 @@ export const MEMBER_GROUPS_TTL_MS = 86_400_000; // 24h
 
 export interface CachedMemberGroup {
   id: string;
-  code: string;
+  code?: string;  // optional — 실제 API 응답에서 누락 케이스 존재 (ADR-026)
 }
 
 export const WIKIS_TTL_MS = 86_400_000; // 24h — wiki home은 거의 불변

--- a/src/commands/project/groups.ts
+++ b/src/commands/project/groups.ts
@@ -21,7 +21,7 @@ export const projectGroupsCommand = new Command("groups")
 
     output(globalOpts, {
       headers: ["ID", "Code"],
-      rows: groups.map((g) => [g.id, g.code]),
+      rows: groups.map((g) => [g.id, g.code ?? ""]),
       raw: groups,
       ids: groups.map((g) => g.id),
     });

--- a/src/commands/project/groups.ts
+++ b/src/commands/project/groups.ts
@@ -21,7 +21,7 @@ export const projectGroupsCommand = new Command("groups")
 
     output(globalOpts, {
       headers: ["ID", "Code"],
-      rows: groups.map((g) => [g.id, g.code ?? ""]),
+      rows: groups.map((g) => [g.id, g.code ?? "-"]),
       raw: groups,
       ids: groups.map((g) => g.id),
     });

--- a/src/resolvers/match.test.ts
+++ b/src/resolvers/match.test.ts
@@ -42,6 +42,15 @@ describe("matchByName", () => {
     }
   });
 
+  it("name 이 빈 문자열인 항목도 매칭에서 제외 (PR #67 review)", () => {
+    const items: TestItem[] = [
+      { name: "", id: "1" },
+      { name: "foo", id: "2" },
+    ];
+    // 빈 문자열은 정확일치(input="")가 아닌 한 후보 아님 — input="foo" 일 때 id:2 만 매치
+    expect(matchByName(items, "foo", "그룹", render).id).toBe("2");
+  });
+
   it("items 빈 배열은 후보/hint 없이 기본 not-found", () => {
     try {
       matchByName([], "x", "그룹", render, { helpHint: "..." });

--- a/src/resolvers/match.test.ts
+++ b/src/resolvers/match.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { matchByName } from "./match.js";
+import { DoorayCliError } from "../utils/errors.js";
+
+interface TestItem {
+  name: string;
+  id: string;
+}
+const render = (i: TestItem) => `${i.name} (${i.id})`;
+
+describe("matchByName", () => {
+  it("정확일치 1건 반환", () => {
+    const items: TestItem[] = [
+      { name: "foo", id: "1" },
+      { name: "bar", id: "2" },
+    ];
+    expect(matchByName(items, "foo", "그룹", render).id).toBe("1");
+  });
+
+  it("name 이 undefined 인 항목은 매칭에서 제외 (가드)", () => {
+    // @ts-expect-error — 의도적 undefined 주입 (실제 API 응답 시뮬레이션)
+    const items: TestItem[] = [{ name: undefined, id: "1" }, { name: "foo", id: "2" }];
+    expect(matchByName(items, "foo", "그룹", render).id).toBe("2");
+  });
+
+  it("not-found 시 후보 5개 + 전체 수 + helpHint 출력", () => {
+    const items: TestItem[] = Array.from({ length: 7 }, (_, i) => ({
+      name: `g${i}`,
+      id: `${i}`,
+    }));
+    try {
+      matchByName(items, "missing", "그룹", render, {
+        helpHint: "dooray project groups <project>",
+      });
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(DoorayCliError);
+      const msg = (e as DoorayCliError).message;
+      expect(msg).toContain("그룹을(를) 찾을 수 없습니다: missing");
+      expect(msg).toContain("사용 가능한 그룹 (5/7):");
+      expect(msg).toContain("전체 목록: dooray project groups <project>");
+    }
+  });
+
+  it("items 빈 배열은 후보/hint 없이 기본 not-found", () => {
+    try {
+      matchByName([], "x", "그룹", render, { helpHint: "..." });
+    } catch (e) {
+      const msg = (e as DoorayCliError).message;
+      expect(msg).toBe("그룹을(를) 찾을 수 없습니다: x");
+    }
+  });
+});

--- a/src/resolvers/match.ts
+++ b/src/resolvers/match.ts
@@ -13,12 +13,14 @@ export interface NameRecord {
  * @param input 사용자 입력
  * @param label 에러 메시지에 들어갈 도메인 명 (예: "태그", "멤버")
  * @param renderCandidate 후보 한 줄 표현 (예: m => `${m.name} (${m.id})`)
+ * @param options.helpHint not-found 시 전체 목록 조회 안내 (예: "dooray project groups <project>")
  */
 export function matchByName<T extends NameRecord>(
   items: T[],
   input: string,
   label: string,
   renderCandidate: (item: T) => string,
+  options?: { helpHint?: string },
 ): T {
   const exact = items.filter((i) => i.name === input);
   if (exact.length === 1) return exact[0];
@@ -30,7 +32,7 @@ export function matchByName<T extends NameRecord>(
     );
   }
 
-  const partial = items.filter((i) => i.name.includes(input));
+  const partial = items.filter((i) => i.name?.includes(input) ?? false);
   if (partial.length === 1) return partial[0];
   if (partial.length > 1) {
     throw new DoorayCliError(
@@ -40,8 +42,19 @@ export function matchByName<T extends NameRecord>(
     );
   }
 
+  const SAMPLE_LIMIT = 5;
+  let counter = "";
+  let hint = "";
+  if (items.length > 0) {
+    const sampleLines = items
+      .slice(0, SAMPLE_LIMIT)
+      .map((i) => `  - ${renderCandidate(i)}`)
+      .join("\n");
+    counter = `\n사용 가능한 ${label} (${Math.min(SAMPLE_LIMIT, items.length)}/${items.length}):\n${sampleLines}`;
+    hint = options?.helpHint ? `\n전체 목록: ${options.helpHint}` : "";
+  }
   throw new DoorayCliError(
-    `${label}을(를) 찾을 수 없습니다: ${input}`,
+    `${label}을(를) 찾을 수 없습니다: ${input}${counter}${hint}`,
     EXIT_PARAM_ERROR,
   );
 }

--- a/src/resolvers/match.ts
+++ b/src/resolvers/match.ts
@@ -32,7 +32,8 @@ export function matchByName<T extends NameRecord>(
     );
   }
 
-  const partial = items.filter((i) => i.name?.includes(input) ?? false);
+  // 빈 문자열 / undefined name 은 매칭 후보에서 제외 (Issue #65, PR #67 review)
+  const partial = items.filter((i) => !!i.name && i.name.includes(input));
   if (partial.length === 1) return partial[0];
   if (partial.length > 1) {
     throw new DoorayCliError(

--- a/src/resolvers/member-group.ts
+++ b/src/resolvers/member-group.ts
@@ -37,9 +37,20 @@ export async function resolveMemberGroup(
   input: string,
 ): Promise<{ id: string; code: string }> {
   const groups = await ensureMemberGroups(client, projectId);
+  // code 가 없는 그룹은 매칭 불가 — 사전 필터 (Dooray API 응답 mismatch, ADR-026)
+  const valid = groups.filter((g) => typeof g.code === "string" && g.code.length > 0);
+  const skipped = groups.length - valid.length;
+  if (skipped > 0) {
+    process.stderr.write(
+      `⚠  ${skipped}개 그룹에 code 가 없어 매칭에서 제외했습니다 (Dooray API 응답 mismatch — ADR-026).\n`,
+    );
+  }
   // CachedMemberGroup은 { id, code } — name 필드 없음. matchByName은 name 필드 사용
   // → 어댑터: code를 name처럼 사용
-  const adapter = groups.map((g) => ({ name: g.code, id: g.id, code: g.code }));
-  const match = matchByName(adapter, input, "그룹", (g) => `${g.code} (${g.id})`);
+  // code 가 string 임을 필터로 보장했으므로 단언 안전
+  const adapter = valid.map((g) => ({ name: g.code as string, id: g.id, code: g.code as string }));
+  const match = matchByName(adapter, input, "그룹", (g) => `${g.code} (${g.id})`, {
+    helpHint: "dooray project groups <project>",
+  });
   return { id: match.id, code: match.code };
 }

--- a/src/resolvers/member-group.ts
+++ b/src/resolvers/member-group.ts
@@ -31,6 +31,12 @@ export async function ensureMemberGroups(
   return items;
 }
 
+// code 가 string 이며 비어있지 않음을 좁히는 type predicate
+// → filter 결과 항목에서 `as string` 단언 없이 code 를 사용 가능
+function hasValidCode(g: CachedMemberGroup): g is CachedMemberGroup & { code: string } {
+  return typeof g.code === "string" && g.code.length > 0;
+}
+
 export async function resolveMemberGroup(
   client: DoorayApiClient,
   projectId: string,
@@ -38,7 +44,7 @@ export async function resolveMemberGroup(
 ): Promise<{ id: string; code: string }> {
   const groups = await ensureMemberGroups(client, projectId);
   // code 가 없는 그룹은 매칭 불가 — 사전 필터 (Dooray API 응답 mismatch, ADR-026)
-  const valid = groups.filter((g) => typeof g.code === "string" && g.code.length > 0);
+  const valid = groups.filter(hasValidCode);
   const skipped = groups.length - valid.length;
   if (skipped > 0) {
     process.stderr.write(
@@ -46,9 +52,8 @@ export async function resolveMemberGroup(
     );
   }
   // CachedMemberGroup은 { id, code } — name 필드 없음. matchByName은 name 필드 사용
-  // → 어댑터: code를 name처럼 사용
-  // code 가 string 임을 필터로 보장했으므로 단언 안전
-  const adapter = valid.map((g) => ({ name: g.code as string, id: g.id, code: g.code as string }));
+  // → 어댑터: code를 name처럼 사용 (predicate 로 code 가 string 임이 좁혀짐)
+  const adapter = valid.map((g) => ({ name: g.code, id: g.id, code: g.code }));
   const match = matchByName(adapter, input, "그룹", (g) => `${g.code} (${g.id})`, {
     helpHint: "dooray project groups <project>",
   });

--- a/tasks/032-fix-member-group-resolver-guard/index.json
+++ b/tasks/032-fix-member-group-resolver-guard/index.json
@@ -2,7 +2,7 @@
   "name": "032-fix-member-group-resolver-guard",
   "description": "GitHub Issue #65 — resolveMemberGroup 가 code 누락 그룹에서 'Cannot read properties of undefined (reading includes)' 추락. 원인: src/resolvers/match.ts line 33 `i.name.includes(input)` 가드 부재 + member-group.ts adapter 가 `g.code` 를 name 으로 사용 (cmux-browser spike 2026-05-18 결과: 공식 스키마는 code required 지만 실제 응답이 누락하는 케이스 존재 — ADR-026 wiki 함정과 동일 mismatch). fix: match.ts undefined 가드 + helpHint 옵션 + not-found 시 후보 5개 + 안내, member-group.ts adapter 사전 필터, MemberGroup.code optional 완화. 신규 ADR 불요 (ADR-026 한 줄 확장).",
   "created_at": "2026-05-18T01:10:34Z",
-  "status": "pending",
+  "status": "completed",
   "current_phase": 1,
   "total_phases": 1,
   "error_message": null,
@@ -12,7 +12,7 @@
       "number": 1,
       "title": "match.ts 가드 + helpHint + member-group.ts adapter + 타입 완화 + 테스트 + docs",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],


### PR DESCRIPTION
## Summary

GitHub Issue #65 — `dooray post edit --cc-group "..."` 호출 시 `Cannot read properties of undefined (reading 'includes')` 추락.

**진짜 원인**: `src/resolvers/match.ts:33` 의 `i.name.includes(input)` 가드 부재 + member-group adapter 가 `{name: g.code}` 형태인데 일부 응답 그룹의 `g.code` 가 undefined (Dooray 공식 스키마 ↔ 실제 응답 mismatch, ADR-026 추가 함정).

## Changes

- `match.ts`: `i.name?.includes` 가드 + `helpHint` 옵션 + not-found 후보 5개 출력
- `member-group.ts`: adapter 가 `code` 누락 그룹 사전 필터 + stderr 안내 + helpHint 전달
- `types.ts` / `cache/types.ts`: `MemberGroup.code` / `CachedMemberGroup.code` optional 완화
- `commands/project/groups.ts`: `g.code ?? ""` 빈 문자열 폴백 (Code 컬럼 표시)
- `match.test.ts` 신규 (4 케이스: 가드 / not-found / helpHint / 빈 배열)

## Commits

```
764c73a fix(resolvers): guard undefined name + add helpHint to matchByName (Issue #65)
```

## Test plan

- [x] `pnpm tsc --noEmit` — 0 오류
- [x] `pnpm test` — 17 files / 122 tests PASS (match.test.ts 4 신규)
- [x] critic ACCEPT-WITH-RESERVATIONS (Major 3건은 plan 본문 결함, executor 가 자체 수정해서 현재 worktree 통과)
- [x] code-reviewer PASS (LOW 1: SAMPLE_LIMIT 상수 추출 선택사항)
- [x] docs-verifier PASS (사전 UPDATE_NEEDED 2건 + TTL pre-existing 1건 → main `44e8e77` 일괄 정리)

## Pipeline

build-with-teams (critic Major 3 + docs-verifier UPDATE 1 → 모두 ACCEPT).