### PR TITLE
feat(commands): add post edit --tag / --tag-clear / --tag-remove (Issue #66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,22 @@ dooray post edit <project> <post-number> --cc-group dev-team --dry-run --json | 
 # 출력 예: [{ "type": "group", "group": { "projectMemberGroupId": "...", "members": [] } }, ...]
 ```
 
+#### 생성 후 태그 변경 (Issue #66)
+
+```bash
+# 기존 태그 유지 + 신규 추가 (dedupe)
+dooray post edit --id <postId> --tag "<group>: <name>"
+
+# 기존 태그 전부 제거 + 신규만 적용
+dooray post edit --id <postId> --tag-clear --tag "<group>: <name>"
+
+# 특정 태그만 제거 (기존 유지)
+dooray post edit --id <postId> --tag-remove "<group>: <name>"
+```
+
+`--title` / `--body` 없이 단독 호출 가능 — 기존 본문은 자동 재전송.
+mandatory tag 그룹은 `post create` 와 동일하게 사전 검증 (ADR-019).
+
 #### 상위 업무 변경 (`--parent`)
 
 ```bash

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -98,6 +98,9 @@ dooray doctor                                 # 설정 검증
 | 참조자 전체 교체 | `dooray post edit <project> <number> --cc-clear --cc <name>` — 기존 참조자 비우고 신규 멤버만 |
 | 신규 업무 + 그룹 cc | `dooray post create <project> --title "..." --cc-group <code>` — 생성 시 그룹 참조자 포함 |
 | 상위 업무 설정/변경 | `dooray post edit <project> <number> --title "<원제목>" --parent <ref>` — `<ref>` 는 `<project>/<number>` 또는 raw postId. `--title` 미동반 시 interactive 모드로 진입해 무시. unset 미지원 (Issue #60) |
+| `dooray post edit --id <postId> --tag <name>` | 태그 추가 (반복, dedupe) |
+| `dooray post edit --id <postId> --tag-clear --tag <name>` | 태그 전체 교체 |
+| `dooray post edit --id <postId> --tag-remove <name>` | 특정 태그 제거 |
 
 > **제목 옵션 네이밍**: `post` 와 `wiki page` 모두 `--title` 표준. `post`의 `--subject`는 deprecated alias로 당분간 동작하되, 새 코드에서는 `--title` 사용을 권장.
 
@@ -351,6 +354,22 @@ dooray post edit --id "$CHILD_ID" --title "subtask A" --parent <project>/<parent
 ```
 
 **한계** (cmux-browser spike 결과): Dooray API 가 `unset-parent-post` 미제공 → CLI 로 parent 해제 불가. 필요 시 웹 UI 에서 처리.
+
+---
+
+## 태그 사후 분류 자동화 (Issue #66)
+
+분류 분석 결과를 받아 태그를 재분류하는 자동화는 단독 호출 패턴이 효율적:
+
+```bash
+# 분석 스크립트가 분류한 태그 이름을 cli 로 적용 — body fetch 불요
+POST_ID=$(...)
+CATEGORY=$(...)
+dooray post edit --id "$POST_ID" --tag "분류: $CATEGORY"
+```
+
+태그만 변경하는 시나리오에서 `--title` / `--body` 강제 없음.
+mandatory 그룹은 친절한 에러 메시지로 안내 (ADR-019).
 
 ---
 

--- a/src/commands/post/edit.ts
+++ b/src/commands/post/edit.ts
@@ -9,6 +9,8 @@ import { prependMentions } from "../../utils/mention.js";
 import { appendTaskLinks } from "../../utils/task-link.js";
 import { resolveTaskLinks } from "../../resolvers/task-link.js";
 import { resolveUserAdditions, mergeUsers } from "../../resolvers/post-users.js";
+import { lookupTagIds, validateMandatoryCoverage } from "../../resolvers/tag.js";
+import { mergeTagIds } from "../../resolvers/post-tags.js";
 import { resolvePostRef } from "../../resolvers/postRef.js";
 import type { OutputOptions } from "../../formatters/table.js";
 import {
@@ -54,6 +56,9 @@ export const postEditCommand = new Command("edit")
   .option("--to-group <code>", "담당자(to) 그룹 추가 (반복 가능, 그룹 코드 부분일치)", (v, prev: string[]) => [...prev, v], [] as string[])
   .option("--to-clear", "기존 담당자 전부 제거 후 신규만 적용")
   .option("--parent <ref>", "상위 업무 변경 — project/number 또는 raw postId (post create 와 동일 — unset 은 미지원, 웹 UI 에서 처리)")
+  .option("--tag <name>", "태그 추가 (반복 가능, 기존 태그 유지 + 신규 추가 + dedupe)", (v, prev: string[]) => [...prev, v], [] as string[])
+  .option("--tag-clear", "기존 태그 전부 제거 후 --tag 만 적용")
+  .option("--tag-remove <name>", "특정 태그 제거 (반복 가능, 이름 부분일치)", (v, prev: string[]) => [...prev, v], [] as string[])
   .option("--dry-run", "API 호출 없이 합성된 본문만 stdout 출력 (mention/link-task 적용 결과 미리보기)")
   .option("--no-confirm", "누락 attachment 경고 시 confirm 없이 진행 (자동화용)")
   .action(async (project, postNumberStr, opts) => {
@@ -67,6 +72,9 @@ export const postEditCommand = new Command("edit")
     const ccGroups: string[] = (opts.ccGroup ?? []).filter((s: string) => s.length > 0);
     const toNames: string[] = (opts.to ?? []).filter((s: string) => s.length > 0);
     const toGroups: string[] = (opts.toGroup ?? []).filter((s: string) => s.length > 0);
+    const tagAdditions: string[] = (opts.tag ?? []).filter((s: string) => s.length > 0);
+    const tagRemovals: string[] = (opts.tagRemove ?? []).filter((s: string) => s.length > 0);
+    const hasTagChange = tagAdditions.length > 0 || tagRemovals.length > 0 || !!opts.tagClear;
 
     startSpinner("업무 조회 중...");
     const { projectId, postId, postNumber, projectCode } = await resolvePostInput(client, {
@@ -87,7 +95,7 @@ export const postEditCommand = new Command("edit")
       );
     }
 
-    const nonInteractive = title || opts.body || opts.bodyFile;
+    const nonInteractive = title || opts.body || opts.bodyFile || hasTagChange;
 
     if (nonInteractive) {
       // Non-interactive mode: apply only specified changes
@@ -147,6 +155,15 @@ export const postEditCommand = new Command("edit")
         ccUsers = mergeUsers(ccUsers, additions, !!opts.ccClear);
       }
 
+      let finalTagIds: string[] | undefined;
+      if (hasTagChange) {
+        const existingTagIds = post.tags.map((t) => t.id);
+        const additionIds = await lookupTagIds(client, projectId, tagAdditions);
+        const removalIds = await lookupTagIds(client, projectId, tagRemovals);
+        finalTagIds = mergeTagIds(existingTagIds, additionIds, removalIds, !!opts.tagClear);
+        await validateMandatoryCoverage(client, projectId, finalTagIds);
+      }
+
       if (opts.dryRun) {
         stopSpinner(false);
         const globalOpts = postEditCommand.optsWithGlobals() as OutputOptions;
@@ -155,6 +172,7 @@ export const postEditCommand = new Command("edit")
           process.stdout.write(JSON.stringify({
             body: previewBody,
             users: { to: toUsers, cc: ccUsers },
+            ...(finalTagIds !== undefined && { tagIds: finalTagIds }),
             ...(opts.parent && { parentChange: opts.parent }),
           }) + "\n");
         } else {
@@ -174,6 +192,7 @@ export const postEditCommand = new Command("edit")
         dueDate: post.dueDate,
         dueDateFlag: post.dueDateFlag,
         users: { to: toUsers, cc: ccUsers },
+        ...(finalTagIds !== undefined && { tagIds: finalTagIds }),
       });
       stopSpinner(true, "업무 수정 완료");
 
@@ -212,6 +231,11 @@ export const postEditCommand = new Command("edit")
       if (opts.parent) {
         process.stderr.write(
           "⚠  --parent 는 --title/--body 와 함께 사용 시에만 적용됩니다.\n",
+        );
+      }
+      if (hasTagChange) {
+        process.stderr.write(
+          "⚠  --tag / --tag-clear / --tag-remove 는 --title/--body 와 함께 사용 시에만 적용됩니다.\n",
         );
       }
       const original = serializePostFrontmatter(post, members);

--- a/src/commands/post/edit.ts
+++ b/src/commands/post/edit.ts
@@ -233,11 +233,9 @@ export const postEditCommand = new Command("edit")
           "⚠  --parent 는 --title/--body 와 함께 사용 시에만 적용됩니다.\n",
         );
       }
-      if (hasTagChange) {
-        process.stderr.write(
-          "⚠  --tag / --tag-clear / --tag-remove 는 --title/--body 와 함께 사용 시에만 적용됩니다.\n",
-        );
-      }
+      // tag 관련 옵션은 nonInteractive 분기에서만 처리됨 (hasTagChange 가
+      // nonInteractive 조건에 포함). 여기 도달은 hasTagChange=false 이므로
+      // 경고 불요 — cc/parent 처럼 nonInteractive 조건에 미포함 옵션과 다름.
       const original = serializePostFrontmatter(post, members);
       const edited = await openInEditor(original);
 

--- a/src/resolvers/post-tags.test.ts
+++ b/src/resolvers/post-tags.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { mergeTagIds } from "./post-tags.js";
+
+describe("mergeTagIds", () => {
+  it("append + dedupe (기존 [a,b] + 추가 [b,c] → [a,b,c])", () => {
+    expect(mergeTagIds(["a", "b"], ["b", "c"], [], false)).toEqual(["a", "b", "c"]);
+  });
+  it("clear + add (기존 [a,b] clear + 추가 [c] → [c])", () => {
+    expect(mergeTagIds(["a", "b"], ["c"], [], true)).toEqual(["c"]);
+  });
+  it("remove (기존 [a,b,c] - [b] → [a,c])", () => {
+    expect(mergeTagIds(["a", "b", "c"], [], ["b"], false)).toEqual(["a", "c"]);
+  });
+  it("순서 clear → remove → add ([a,b] clear remove[a] add[c,d] → [c,d])", () => {
+    expect(mergeTagIds(["a", "b"], ["c", "d"], ["a"], true)).toEqual(["c", "d"]);
+  });
+});

--- a/src/resolvers/post-tags.ts
+++ b/src/resolvers/post-tags.ts
@@ -1,0 +1,23 @@
+/**
+ * 기존 tagIds + 추가/제거/clear 입력을 머지해 최종 tagIds 산출 (pure).
+ *
+ * 적용 순서: clear → remove → add (중복 제거)
+ *
+ * @param existing 현재 post 의 tagIds (post.tags.map(t => t.id))
+ * @param additions 추가할 tagIds (name → id 변환 후)
+ * @param removals 제거할 tagIds
+ * @param clear true 면 existing 무시
+ */
+export function mergeTagIds(
+  existing: string[],
+  additions: string[],
+  removals: string[],
+  clear: boolean,
+): string[] {
+  const base = clear ? [] : existing;
+  const afterRemove = removals.length > 0
+    ? base.filter((id) => !removals.includes(id))
+    : base;
+  if (additions.length === 0) return afterRemove;
+  return Array.from(new Set([...afterRemove, ...additions]));
+}

--- a/src/resolvers/tag.test.ts
+++ b/src/resolvers/tag.test.ts
@@ -7,7 +7,7 @@ vi.mock("../cache/store.js", () => ({
   isExpired: vi.fn().mockReturnValue(true),
 }));
 
-import { validateMandatoryTags } from "./tag.js";
+import { validateMandatoryTags, lookupTagIds, validateMandatoryCoverage } from "./tag.js";
 import { DoorayCliError } from "../utils/errors.js";
 import type { DoorayApiClient } from "../api/client.js";
 
@@ -54,5 +54,46 @@ describe("validateMandatoryTags", () => {
     const client = mockClient([{ id: "1", name: "x" }]);
     // tagGroup 없으므로 groupId = null, groupMandatory = false → 무시
     await expect(validateMandatoryTags(client, "<project>")).resolves.toBeUndefined();
+  });
+});
+
+describe("lookupTagIds", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("mandatory 그룹 있는 fixture 에서도 throw 안 함 (mandatory skip)", async () => {
+    // mandatory 그룹 있는 프로젝트에서 단순 name lookup — throw 하면 안 됨
+    const client = mockClient([
+      { id: "t1", name: "중요", tagGroup: { id: "g1", name: "분류", mandatory: true, selectOne: false } },
+      { id: "t2", name: "보통", tagGroup: { id: "g1", name: "분류", mandatory: true, selectOne: false } },
+    ]);
+    await expect(lookupTagIds(client, "<project>", ["중요"])).resolves.toEqual(["t1"]);
+  });
+
+  it("빈 names 배열 → 빈 배열 반환", async () => {
+    const client = mockClient([]);
+    await expect(lookupTagIds(client, "<project>", [])).resolves.toEqual([]);
+  });
+});
+
+describe("validateMandatoryCoverage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("mandatory 그룹 커버 시 통과", async () => {
+    const client = mockClient([
+      { id: "t1", name: "중요", tagGroup: { id: "g1", name: "분류", mandatory: true, selectOne: false } },
+    ]);
+    await expect(validateMandatoryCoverage(client, "<project>", ["t1"])).resolves.toBeUndefined();
+  });
+
+  it("mandatory 그룹 미충족 시 DoorayCliError throw", async () => {
+    const client = mockClient([
+      { id: "t1", name: "중요", tagGroup: { id: "g1", name: "분류", mandatory: true, selectOne: false } },
+    ]);
+    // "분류" 그룹의 태그가 selectedTagIds 에 없음
+    await expect(validateMandatoryCoverage(client, "<project>", [])).rejects.toBeInstanceOf(DoorayCliError);
   });
 });

--- a/src/resolvers/tag.ts
+++ b/src/resolvers/tag.ts
@@ -153,7 +153,12 @@ export async function lookupTagIds(
   if (names.length === 0) return [];
   const tags = await ensureTags(client, projectId);
   return names.map((n) =>
-    matchByName(tags, n, "태그", (t) => `${t.name} (${t.id})`).id
+    matchByName(
+      tags,
+      n,
+      "태그",
+      (t) => (t.groupName ? `${t.groupName} / ${t.name} (${t.id})` : `${t.name} (${t.id})`),
+    ).id
   );
 }
 
@@ -188,5 +193,27 @@ export async function validateMandatoryCoverage(
         EXIT_PARAM_ERROR,
       );
     }
+  }
+
+  // selectOne 그룹 검증 (resolveTags 와 동등 정책 — post create/edit 일관성, Issue #66)
+  const selectOneGroups = new Map<string, { name: string; tags: string[] }>();
+  for (const t of tags) {
+    if (!t.groupSelectOne || !t.groupId || !selectedSet.has(t.id)) continue;
+    const entry = selectOneGroups.get(t.groupId) ?? { name: t.groupName ?? t.groupId, tags: [] };
+    entry.tags.push(t.name);
+    selectOneGroups.set(t.groupId, entry);
+  }
+  const violators: string[] = [];
+  for (const [, info] of selectOneGroups) {
+    if (info.tags.length > 1) {
+      violators.push(`${info.name} (선택: ${info.tags.join(", ")})`);
+    }
+  }
+  if (violators.length > 0) {
+    throw new DoorayCliError(
+      `다음 태그 그룹은 1개만 선택 가능합니다:\n` +
+        violators.map((v) => `  - ${v}`).join("\n"),
+      EXIT_PARAM_ERROR,
+    );
   }
 }

--- a/src/resolvers/tag.ts
+++ b/src/resolvers/tag.ts
@@ -139,3 +139,54 @@ export async function resolveTags(
 
   return selected.map((t) => t.id);
 }
+
+/**
+ * 입력된 이름들을 tagIds 로 변환만 (mandatory 검증 skip).
+ * `--tag-remove` / `--tag` 같이 머지 전 단계의 name lookup 에 사용.
+ * `resolveTags` 와 달리 mandatory 그룹 충족 검사 안 함.
+ */
+export async function lookupTagIds(
+  client: DoorayApiClient,
+  projectId: string,
+  names: string[],
+): Promise<string[]> {
+  if (names.length === 0) return [];
+  const tags = await ensureTags(client, projectId);
+  return names.map((n) =>
+    matchByName(tags, n, "태그", (t) => `${t.name} (${t.id})`).id
+  );
+}
+
+/**
+ * 머지된 최종 tagIds 가 프로젝트의 mandatory 그룹을 모두 커버하는지 검증.
+ * `--tag` 류 옵션 적용 후 최종 결과 검사용.
+ * `validateMandatoryTags` 가 "tag 입력 없이 mandatory 그룹 있으면 throw" 인 반면,
+ * 이 함수는 selectedTagIds 가 모든 mandatory 그룹의 ID 중 하나씩을 포함하는지 검사.
+ */
+export async function validateMandatoryCoverage(
+  client: DoorayApiClient,
+  projectId: string,
+  selectedTagIds: string[],
+): Promise<void> {
+  const tags = await ensureTags(client, projectId);
+  const selectedSet = new Set(selectedTagIds);
+  const mandatoryGroups = new Map<string, { groupName: string; tagsInGroup: CachedTag[] }>();
+  for (const t of tags) {
+    if (t.groupMandatory && t.groupId) {
+      if (!mandatoryGroups.has(t.groupId)) {
+        mandatoryGroups.set(t.groupId, { groupName: t.groupName ?? t.groupId, tagsInGroup: [] });
+      }
+      mandatoryGroups.get(t.groupId)!.tagsInGroup.push(t);
+    }
+  }
+  for (const [, info] of mandatoryGroups) {
+    const covered = info.tagsInGroup.some((t) => selectedSet.has(t.id));
+    if (!covered) {
+      const candidates = info.tagsInGroup.map((t) => `${t.name} (${t.id})`).join(", ");
+      throw new DoorayCliError(
+        `필수 태그 그룹 "${info.groupName}" 에서 최소 1개 선택 필요\n후보: ${candidates}`,
+        EXIT_PARAM_ERROR,
+      );
+    }
+  }
+}

--- a/src/resolvers/tag.ts
+++ b/src/resolvers/tag.ts
@@ -177,12 +177,13 @@ export async function validateMandatoryCoverage(
   const selectedSet = new Set(selectedTagIds);
   const mandatoryGroups = new Map<string, { groupName: string; tagsInGroup: CachedTag[] }>();
   for (const t of tags) {
-    if (t.groupMandatory && t.groupId) {
-      if (!mandatoryGroups.has(t.groupId)) {
-        mandatoryGroups.set(t.groupId, { groupName: t.groupName ?? t.groupId, tagsInGroup: [] });
-      }
-      mandatoryGroups.get(t.groupId)!.tagsInGroup.push(t);
+    if (!t.groupMandatory || !t.groupId) continue;
+    let group = mandatoryGroups.get(t.groupId);
+    if (!group) {
+      group = { groupName: t.groupName ?? `그룹 ${t.groupId}`, tagsInGroup: [] };
+      mandatoryGroups.set(t.groupId, group);
     }
+    group.tagsInGroup.push(t);
   }
   for (const [, info] of mandatoryGroups) {
     const covered = info.tagsInGroup.some((t) => selectedSet.has(t.id));
@@ -199,7 +200,7 @@ export async function validateMandatoryCoverage(
   const selectOneGroups = new Map<string, { name: string; tags: string[] }>();
   for (const t of tags) {
     if (!t.groupSelectOne || !t.groupId || !selectedSet.has(t.id)) continue;
-    const entry = selectOneGroups.get(t.groupId) ?? { name: t.groupName ?? t.groupId, tags: [] };
+    const entry = selectOneGroups.get(t.groupId) ?? { name: t.groupName ?? `그룹 ${t.groupId}`, tags: [] };
     entry.tags.push(t.name);
     selectOneGroups.set(t.groupId, entry);
   }

--- a/tasks/033-feat-post-edit-tag-options/index.json
+++ b/tasks/033-feat-post-edit-tag-options/index.json
@@ -2,8 +2,8 @@
   "name": "033-feat-post-edit-tag-options",
   "description": "GitHub Issue #66 — `dooray post edit --tag <name>` / `--tag-clear` / `--tag-remove <name>` 옵션 추가. post create --tag 패턴 + ADR-025 cc/to merge 패턴 답습. 결정점: --tag 는 --title/--body 없이도 단독 호출 허용 (사용자 결정 옵션 B, 2026-05-18). body 는 post.body.content 자동 재전송, mandatory tag 검증 동일 적용. cc-group 단독 호출 허용은 별도 follow-up issue. 신규 ADR 불요 — ADR-019 한 줄 확장.",
   "created_at": "2026-05-18T01:56:20Z",
-  "status": "pending",
-  "current_phase": 1,
+  "status": "completed",
+  "current_phase": 2,
   "total_phases": 2,
   "error_message": null,
   "blocked_reason": null,
@@ -12,14 +12,14 @@
       "number": 1,
       "title": "post-tags.ts (mergeTagIds) + edit.ts 옵션 3개 + mandatory 검증 + interactive 경고 + 단위 테스트",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 2,
       "title": "README + skills/dooray-cli/SKILL.md + 완료 마킹",
       "file": "phase-02.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],

--- a/tasks/033-feat-post-edit-tag-options/phase-01.md
+++ b/tasks/033-feat-post-edit-tag-options/phase-01.md
@@ -13,7 +13,7 @@ Issue #66: 생성된 업무에 태그를 사후 추가/교체/제거하는 자�
 코드 컨텍스트:
 - `src/commands/post/edit.ts:90` — `const nonInteractive = title || opts.body || opts.bodyFile;`
 - `src/commands/post/edit.ts:167-177` — `updatePost` 호출 (subject/body/priority/dueDate/users 만 — tagIds 미포함)
-- `src/resolvers/tag.ts` — `resolveTags(client, projectId, names): string[]` + `validateMandatoryTags(client, projectId, tagIds): void`
+- `src/resolvers/tag.ts` — `resolveTags(client, projectId, names): string[]` (mandatory 그룹 충족 검증 포함, post create 용) + `validateMandatoryTags(client, projectId): void` (2-인자, 입력 없이 mandatory 그룹 존재 여부만 검사 — post create 사전 검증 전용). 본 task 에서 신규 `lookupTagIds(client, projectId, names): string[]` (mandatory skip) + `validateMandatoryCoverage(client, projectId, selectedTagIds): void` (머지 결과 커버리지) 추가 export
 - `src/resolvers/post-users.ts` — `mergeUsers(existing, additions, clear)` pure function 패턴 (테스트 가능 단위로 분리)
 - `src/api/types.ts:211` — `PostDetail.tags: Tag[]`, `Tag.id: string`
 - `src/api/types.ts:250` — `UpdatePostRequest.tagIds?: string[]`
@@ -251,15 +251,17 @@ node dist/index.js post edit --id <postId> --tag "<g>: <n>" --dry-run --json
 # 5) interactive 모드 (--tag 만 있어도 단독 nonInteractive 진입 — 경고 없음. 반대로 $EDITOR 강제 분기에 --tag 주면 경고)
 ```
 
-executor 메모: post 가 mandatory tag 그룹 정책을 가진 프로젝트면 --tag-clear 가 mandatory 위반 → `validateMandatoryTags` 가 친절한 에러 (ADR-019). 그 흐름도 1회 실증.
+executor 메모: post 가 mandatory tag 그룹 정책을 가진 프로젝트면 --tag-clear 가 mandatory 위반 → `validateMandatoryCoverage` 가 친절한 에러 (ADR-019 확장). 그 흐름도 1회 실증.
+
+**tag.test.ts mock fixture (critic minor #3)**: `lookupTagIds` mandatory-skip 검증 케이스는 `ensureTags` mock 이 `groupMandatory: true` 인 CachedTag 를 포함하는 fixture 사용 — "mandatory 그룹 있는 프로젝트에서 lookup 만 호출 시 throw 안 함" 을 확인.
 
 ## code-review-pitfalls 회피 항목
 
-- **1-1 (validation 전 spinner)**: post 조회 spinner 는 기존 흐름. `resolveTags` / `validateMandatoryTags` 는 spinner 안에서 호출 — 기존 cc 흐름과 동일 패턴
+- **1-1 (validation 전 spinner)**: post 조회 spinner 는 기존 흐름. `lookupTagIds` / `validateMandatoryCoverage` 는 spinner 안에서 호출 — 기존 cc 흐름과 동일 패턴
 - **1-2 (spinner leak)**: try/catch 가 이미 있음 — 신규 코드는 그 안에서만
-- **2-2 (catch 분기)**: `validateMandatoryTags` 가 throw 하면 그대로 상위 catch 로 전파 — 별도 처리 없음
-- **3-3 (테스트 mock mirror)**: `mergeTagIds` pure function — mock 불요
-- **외과적 변경**: cc/to 단독 호출 동작은 본 task 에서 변경 금지 (trigger 확장만, 흐름 그대로)
+- **2-2 (catch 분기)**: `validateMandatoryCoverage` 가 throw 하면 그대로 상위 catch 로 전파 — 별도 처리 없음
+- **3-3 (테스트 mock mirror)**: `mergeTagIds` pure function — mock 불요. `tag.test.ts` 는 `ensureTags` mock 만 필요
+- **외과적 변경**: cc/to 단독 호출 동작은 본 task 에서 변경 금지 (trigger 확장 0 — tag 만)
 
 ## 성공 기준
 

--- a/tasks/033-feat-post-edit-tag-options/phase-01.md
+++ b/tasks/033-feat-post-edit-tag-options/phase-01.md
@@ -20,10 +20,12 @@ Issue #66: 생성된 업무에 태그를 사후 추가/교체/제거하는 자�
 
 ## 변경 파일 (정확)
 
-기대 결과 (총 4 파일):
+기대 결과 (총 6 파일):
 ```
 src/resolvers/post-tags.ts                            (신규 — mergeTagIds pure)
 src/resolvers/post-tags.test.ts                       (신규 — 4 케이스)
+src/resolvers/tag.ts                                  (수정 — lookupTagIds + validateMandatoryCoverage 신규 export)
+src/resolvers/tag.test.ts                             (신규 또는 추가 — 2 케이스: lookupTagIds + validateMandatoryCoverage)
 src/commands/post/edit.ts                             (수정 — 옵션 3개 + 흐름)
 tasks/033-feat-post-edit-tag-options/index.json       (완료 마킹 phase-02 에서)
 ```
@@ -32,7 +34,7 @@ tasks/033-feat-post-edit-tag-options/index.json       (완료 마킹 phase-02 �
 
 ## 작업 항목 (5개 이하)
 
-### 1. `src/resolvers/post-tags.ts` — 신규 pure helper
+### 1. `src/resolvers/post-tags.ts` + `post-tags.test.ts` — pure helper + 단위 테스트 4 케이스
 
 ```ts
 /**
@@ -60,7 +62,7 @@ export function mergeTagIds(
 }
 ```
 
-### 2. `src/resolvers/post-tags.test.ts` — 단위 테스트 (4 케이스)
+단위 테스트 (`post-tags.test.ts`):
 
 ```ts
 import { describe, it, expect } from "vitest";
@@ -70,22 +72,80 @@ describe("mergeTagIds", () => {
   it("append + dedupe (기존 [a,b] + 추가 [b,c] → [a,b,c])", () => {
     expect(mergeTagIds(["a", "b"], ["b", "c"], [], false)).toEqual(["a", "b", "c"]);
   });
-
   it("clear + add (기존 [a,b] clear + 추가 [c] → [c])", () => {
     expect(mergeTagIds(["a", "b"], ["c"], [], true)).toEqual(["c"]);
   });
-
   it("remove (기존 [a,b,c] - [b] → [a,c])", () => {
     expect(mergeTagIds(["a", "b", "c"], [], ["b"], false)).toEqual(["a", "c"]);
   });
-
   it("순서 clear → remove → add ([a,b] clear remove[a] add[c,d] → [c,d])", () => {
     expect(mergeTagIds(["a", "b"], ["c", "d"], ["a"], true)).toEqual(["c", "d"]);
   });
 });
 ```
 
-### 3. `src/commands/post/edit.ts` — 옵션 3개 + nonInteractive 트리거 확장
+### 2. `src/resolvers/tag.ts` — 신규 helper 2개 + 단위 테스트
+
+**critic CRITICAL 1+2 fix (사용자 결정)**: 기존 `validateMandatoryTags` (2인자, post create 의 사전 검증 전용) 와 `resolveTags` (mandatory 검증 포함) 는 **그대로 유지**. 본 task 에서 신규 helper 2개 추가.
+
+```ts
+/**
+ * 입력된 이름들을 tagIds 로 변환만 (mandatory 검증 skip).
+ * `--tag-remove` / `--tag-clear` 같이 머지 전 단계의 name lookup 에 사용.
+ * `resolveTags` 와 달리 mandatory 그룹 충족 검사 안 함.
+ */
+export async function lookupTagIds(
+  client: DoorayApiClient,
+  projectId: string,
+  names: string[],
+): Promise<string[]> {
+  if (names.length === 0) return [];
+  const tags = await ensureTags(client, projectId);
+  return names.map((n) =>
+    matchByName(tags, n, "태그", (t) => `${t.name} (${t.id})`).id
+  );
+}
+
+/**
+ * 머지된 최종 tagIds 가 프로젝트의 mandatory 그룹을 모두 커버하는지 검증.
+ * `--tag` 류 옵션 적용 후 최종 결과 검사용.
+ * `validateMandatoryTags` 가 "tag 입력 없이 mandatory 그룹 있으면 throw" 인 반면,
+ * 이 함수는 selectedTagIds 가 모든 mandatory 그룹의 ID 중 하나씩을 포함하는지 검사.
+ */
+export async function validateMandatoryCoverage(
+  client: DoorayApiClient,
+  projectId: string,
+  selectedTagIds: string[],
+): Promise<void> {
+  const tags = await ensureTags(client, projectId);
+  const selectedSet = new Set(selectedTagIds);
+  const mandatoryGroups = new Map<string, { groupName: string; tagsInGroup: CachedTag[] }>();
+  for (const t of tags) {
+    if (t.groupMandatory && t.groupId) {
+      if (!mandatoryGroups.has(t.groupId)) {
+        mandatoryGroups.set(t.groupId, { groupName: t.groupName ?? t.groupId, tagsInGroup: [] });
+      }
+      mandatoryGroups.get(t.groupId)!.tagsInGroup.push(t);
+    }
+  }
+  for (const [, info] of mandatoryGroups) {
+    const covered = info.tagsInGroup.some((t) => selectedSet.has(t.id));
+    if (!covered) {
+      const candidates = info.tagsInGroup.map((t) => `${t.name} (${t.id})`).join(", ");
+      throw new DoorayCliError(
+        `필수 태그 그룹 "${info.groupName}" 에서 최소 1개 선택 필요\n후보: ${candidates}`,
+        EXIT_PARAM_ERROR,
+      );
+    }
+  }
+}
+```
+
+**테스트** (`src/resolvers/tag.test.ts` 신규 또는 기존 파일 추가) — 2 케이스 최소:
+- `lookupTagIds`: 이름 배열 → id 배열 변환 (mandatory throw 안 함을 확인)
+- `validateMandatoryCoverage`: mandatory 그룹 미충족 시 throw / 충족 시 통과
+
+### 3. `src/commands/post/edit.ts` — 옵션 3개 + nonInteractive 트리거 확장 + 흐름
 
 #### 3.1 옵션 정의 (line ~56 `--parent` 옆에 추가)
 
@@ -95,53 +155,42 @@ describe("mergeTagIds", () => {
 .option("--tag-remove <name>", "특정 태그 제거 (반복 가능, 이름 부분일치)", (v, prev: string[]) => [...prev, v], [] as string[])
 ```
 
-#### 3.2 action 안에서 처리
+#### 3.2 nonInteractive 트리거 확장 (line 90) — **`|| hasTagChange` 만 추가**
 
 ```ts
-import { resolveTags, validateMandatoryTags } from "../../resolvers/tag.js";
+import { lookupTagIds, validateMandatoryCoverage } from "../../resolvers/tag.js";
 import { mergeTagIds } from "../../resolvers/post-tags.js";
 
 const tagAdditions = (opts.tag ?? []) as string[];
 const tagRemovals = (opts.tagRemove ?? []) as string[];
 const hasTagChange = tagAdditions.length > 0 || tagRemovals.length > 0 || !!opts.tagClear;
-```
 
-#### 3.3 nonInteractive 트리거 확장 (line 90)
-
-```ts
 // before
 const nonInteractive = title || opts.body || opts.bodyFile;
-// after
-const nonInteractive = title || opts.body || opts.bodyFile || hasTagChange
-  || toNames.length > 0 || toGroups.length > 0 || opts.toClear
-  || ccNames.length > 0 || ccGroups.length > 0 || opts.ccClear
-  || !!opts.parent;
+// after — hasTagChange 만 추가. cc/to/parent 동작은 본 task scope 외 (별도 follow-up issue)
+const nonInteractive = title || opts.body || opts.bodyFile || hasTagChange;
 ```
 
-(cc/to/parent 도 사실상 nonInteractive 진입 트리거이므로 같이 정리. 단 cc-group 단독 호출 허용은 별도 follow-up 이라 본 PR scope 에는 추가만 — 동작 자체는 hasTagChange 만 신규 흐름)
+**critic MAJOR 1 fix**: cc/to/parent trigger 확장은 본 task scope 외. 별도 follow-up issue 로 분리. 본 PR 은 tag 동작만 추가.
 
-**주의**: cc/to 단독 호출 동작은 본 task scope 외. trigger 확장은 하되 (안 하면 hasTagChange 외 단독 호출도 의도와 다르게 nonInteractive 진입), cc/to 단독 호출의 실제 적용 흐름은 별도 검증 후 follow-up. 만약 scope 충돌 우려가 있으면 trigger 도 `|| hasTagChange` 만 추가하고 cc/to 는 그대로 둘 것 (executor 가 코드 읽고 판단).
+#### 3.3 tagIds 계산 + mandatory 커버리지 검증 (nonInteractive 분기 안에서)
 
-#### 3.4 tagIds 계산 + mandatory 검증 (nonInteractive 분기 안에서)
-
-`updatePost` 호출 직전:
+`updatePost` 호출 직전. **신규 helper 2개 사용** (critic CRITICAL 1+2 fix):
 
 ```ts
 let finalTagIds: string[] | undefined;
 if (hasTagChange) {
   const existingTagIds = post.tags.map((t) => t.id);
-  const additionIds = tagAdditions.length > 0
-    ? await resolveTags(client, projectId, tagAdditions)
-    : [];
-  const removalIds = tagRemovals.length > 0
-    ? await resolveTags(client, projectId, tagRemovals)
-    : [];
+  // tagAdditions 는 mandatory 검증 안 거치고 단순 name → id 변환 (lookupTagIds)
+  // 머지 결과 (finalTagIds) 가 mandatory 그룹 커버하는지는 validateMandatoryCoverage 가 검사
+  const additionIds = await lookupTagIds(client, projectId, tagAdditions);
+  const removalIds = await lookupTagIds(client, projectId, tagRemovals);
   finalTagIds = mergeTagIds(existingTagIds, additionIds, removalIds, !!opts.tagClear);
-  await validateMandatoryTags(client, projectId, finalTagIds);
+  await validateMandatoryCoverage(client, projectId, finalTagIds);
 }
 ```
 
-#### 3.5 updatePost body 에 tagIds 반영
+#### 3.4 updatePost body 에 tagIds 반영 + body 자동 재전송 안전
 
 ```ts
 await client.updatePost(projectId, postId, {
@@ -154,6 +203,8 @@ await client.updatePost(projectId, postId, {
   ...(finalTagIds !== undefined && { tagIds: finalTagIds }),
 });
 ```
+
+**critic MAJOR 2 fix**: `--tag` 단독 호출 시 `newBody = null` → `post.body.content` 자동 재전송. 이때 `checkAndGuardDropped` (line 96-99) 는 `newBody != null` 조건이라 skip — 의도된 동작. 재전송 (server 가 보낸 그대로 다시 전송) 은 attachment 보존이라 drop 발생 안 함. executor 가 "newBody null 가드 추가" 식으로 오변경 금지.
 
 ### 4. interactive 모드 경고 + dry-run JSON 확장
 
@@ -232,9 +283,11 @@ grep -cE '^\s*\.option\("--tag(-clear|-remove)?\s' src/commands/post/edit.ts
 grep -nE "mergeTagIds\(" src/commands/post/edit.ts
 # 기대: 1줄
 
-# 5. mandatory 검증 호출
-grep -nE "validateMandatoryTags\(" src/commands/post/edit.ts
+# 5. mandatory 커버리지 검증 호출 (신규 helper)
+grep -nE "validateMandatoryCoverage\(" src/commands/post/edit.ts
 # 기대: 1줄
+grep -nE "^export async function (lookupTagIds|validateMandatoryCoverage)\b" src/resolvers/tag.ts
+# 기대: 2줄
 
 # 6. CLI help 노출
 node dist/index.js post edit --help 2>&1 | grep -cE "\-\-tag"
@@ -255,14 +308,18 @@ node dist/index.js post edit --help 2>&1 | grep -cE "\-\-tag"
 # cwd: /Users/nhn/personal/dooray-cli
 # branch: feat/033-post-edit-tag-options (main 에서 분기)
 git add src/resolvers/post-tags.ts src/resolvers/post-tags.test.ts \
+        src/resolvers/tag.ts src/resolvers/tag.test.ts \
         src/commands/post/edit.ts
 git commit -m "$(cat <<'EOF'
 feat(commands): add --tag / --tag-clear / --tag-remove to post edit (Issue #66 phase 1/2)
 
 - post-tags.ts: mergeTagIds pure helper (clear → remove → add → dedupe)
-- post edit.ts: 옵션 3개 + nonInteractive trigger 에 hasTagChange + validateMandatoryTags
-- post-tags.test.ts: 4 케이스 (append+dedupe / clear+add / remove / 복합)
-- --title/--body 없이 단독 호출 허용 (body 자동 재전송, ADR-019)
+- tag.ts: lookupTagIds (mandatory skip — name→id 변환 전용) +
+  validateMandatoryCoverage (머지 결과 커버리지 검사) 신규 helper
+- post edit.ts: 옵션 3개 + nonInteractive trigger 에 hasTagChange (cc/to/parent
+  는 별도 follow-up) + lookupTagIds + mergeTagIds + validateMandatoryCoverage
+- 단위 테스트: post-tags 4 케이스 + tag 2 케이스 (lookup + coverage)
+- --title/--body 없이 단독 호출 허용 (body 자동 재전송, ADR-019 확장)
 - interactive 경고 + dry-run JSON 에 tagIds 노출
 EOF
 )"


### PR DESCRIPTION
## Summary

GitHub Issue #66 — `dooray post edit` 에 사후 태그 변경 옵션 3개 추가 (ADR-019 확장).

- `--tag <name>` (반복) — 기존 태그 유지 + 신규 추가 + dedupe
- `--tag-clear` — 기존 태그 전부 비우고 신규만
- `--tag-remove <name>` (반복) — 특정 태그 제거 (기존 유지)
- `--title`/`--body` 없이 단독 호출 허용 — 기존 본문 자동 재전송
- mandatory + selectOne 그룹 검증 동일 적용 (post create 동등)
- interactive 모드 미진입 (tag 옵션은 nonInteractive 조건에 포함)

## Key design

- **새 helper 2개 분리** (책임 명확): `lookupTagIds` (mandatory skip — name→id 변환) + `validateMandatoryCoverage` (머지 결과 커버리지 + selectOne 검사). 기존 `validateMandatoryTags` (post create 사전 검증 전용) 와 `resolveTags` 보존
- **머지 순서**: clear → remove → add → dedupe (`mergeTagIds` pure helper)
- **nonInteractive trigger**: `|| hasTagChange` 만 추가 — cc/to/parent 동작 회귀 0

## Commits

```
6063d2c fix(resolvers): add selectOne check + groupName hint to lookupTagIds/coverage
f93640f fix(commands): remove unreachable tag warning in interactive branch
7db1d67 docs: document post edit --tag options + complete task 033
59c8a05 feat(commands): add --tag / --tag-clear / --tag-remove to post edit (phase 1/2)
f38b40b docs(task): apply critic minor notes (signature + naming + fixture)
3530dc0 docs(task): revise plan033 phase-01 per critic feedback
```

## Test plan

- [x] `pnpm tsc --noEmit` — 0 오류
- [x] `pnpm test` — 17 files / 126 PASS (post-tags 4 + tag lookup/coverage 신규)
- [x] critic ACCEPT (REVISE 1차 → minor 정정 → APPROVE)
- [x] code-reviewer APPROVE (HIGH 0 / MEDIUM·LOW fix 후 PASS)
- [x] docs-verifier PASS (사전 docs UPDATE 2건 + 사후 VIOLATION 1건 + UPDATE 1건 모두 반영 후 PASS)

## Pipeline

build-with-teams (critic REVISE 2회 + code-reviewer FIX_NEEDED 1회 + docs-verifier UPDATE 2회 + VIOLATION 1회 → 모두 ACCEPT). executor 자체 진행 사고 1회 (reset 후 plan v2 강제 재투입).