### PR TITLE
chore(docs): backfill existing docs to 5-pattern readability style (plan034)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ npm install -g @bifos/dooray-cli
 dooray setup
 ```
 
-API Endpoint 선택 → API Key 입력 → 연결 테스트 → 메일 설정(선택)을 순서대로 진행합니다.
+아래 순서로 진행합니다:
+1. API Endpoint 선택
+2. API Key 입력
+3. 연결 테스트
+4. 메일 설정 (선택)
 API 토큰은 `https://{tenant}.dooray.com/setting/api/token`에서 발급할 수 있습니다.
 
 수동 설정도 가능합니다:
@@ -262,7 +266,12 @@ dooray post create <project> --title "..." --cc user@example.com
 dooray post create <project> --title "..." --cc 1234567890123456789
 ```
 
-분기 규칙: `^\d{15,}$` → memberId / `^[^\s@]+@[^\s@]+\.[^\s@]+$` → 이메일 / 그 외 → 이름 부분일치. `member search --email` 의 인프라 재사용.
+분기 규칙 (`resolveMember` 자동 판단):
+- `^\d{15,}$` — memberId 직접 사용
+- `^[^\s@]+@[^\s@]+\.[^\s@]+$` — 이메일, `searchMembers` exact 조회
+- 그 외 — 이름 부분일치
+
+`member search --email` 의 인프라 재사용.
 
 #### comment list 필터 옵션
 
@@ -489,7 +498,7 @@ dooray --help
 
 ### CI (`.github/workflows/ci.yml`)
 - 트리거: `main` 으로 push, `main` 대상 PR
-- 동작: `pnpm install --frozen-lockfile` → `pnpm test` → `pnpm build` (Node 18, ubuntu-latest)
+- 동작: `pnpm install --frozen-lockfile`, `pnpm test`, `pnpm build` (Node 18, ubuntu-latest)
 - 별도 secret 불필요
 
 ### Claude code review (`.github/workflows/claude-code-review.yml`)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ dooray post get <project> 42 --json           # JSON 출력
 | `--id <postId>` | `dooray post get --id <postId>` |
 | `--url <url>` | `dooray post get --url https://x.dooray.com/task/to/...` |
 
-대상: `post get`/`edit`/`done`/`workflow`, `post comment list`/`add`/`edit`/`delete`, `post file list`/`upload`/`download`/`download-all`/`delete`. AI 에이전트는 사용자 메시지의 Dooray URL을 그대로 첫 인자로 전달하면 가장 빠르다 (ADR-020).
+대상: `post get`/`edit`/`done`/`workflow`, `post comment list`/`add`/`edit`/`delete`, `post file list`/`upload`/`download`/`download-all`/`delete`.
+AI 에이전트는 사용자 메시지의 Dooray URL을 그대로 첫 인자로 전달하면 가장 빠르다 (ADR-020).
 
 ### 업무 생성
 
@@ -107,7 +108,8 @@ dooray post create <project> \
   --milestone "Sprint 12"
 ```
 
-> mandatory-tag 정책 프로젝트(예: `<project>`)에서는 mandatory 그룹마다 1개 이상 `--tag`로 지정해야 한다. 누락 시 클라이언트가 사전 검증으로 후보 목록과 함께 에러 출력.
+> mandatory-tag 정책 프로젝트(예: `<project>`)에서는 mandatory 그룹마다 1개 이상 `--tag`로 지정해야 한다.
+> 누락 시 클라이언트가 사전 검증으로 후보 목록과 함께 에러 출력.
 
 #### 템플릿 기반 정형 task (ADR-027)
 
@@ -125,7 +127,8 @@ dooray post create <project> --template "릴리스 플랜" --title "v0.9 릴리�
 dooray post create <project> --template 1234567890123456789 --title "by id"
 ```
 
-`interpolation=true` 가 기본 — Dooray 가 `${year}`, `${month}` 같은 시스템 매크로를 응답에서 자동 치환. 사용자 정의 변수 (`--field key=value`) 는 본 release scope 외.
+`interpolation=true` 가 기본 — Dooray 가 `${year}`, `${month}` 같은 시스템 매크로를 응답에서 자동 치환.
+사용자 정의 변수 (`--field key=value`) 는 본 release scope 외.
 
 ### 업무 수정
 
@@ -142,7 +145,8 @@ dooray post edit <project> 42 --body-file ./updated.md
 
 #### 본문 변경 시 attachment 보호
 
-`post edit` 와 `post comment edit` 는 본문을 통째로 replace 합니다. 새 본문에 기존 inline attachment markdown(`![](/files/<id>)`)이 빠져 있으면 stderr 에 경고를 띄우고 (y/N) 로 물어봅니다.
+`post edit` 와 `post comment edit` 는 본문을 통째로 replace 합니다.
+새 본문에 기존 inline attachment markdown(`![](/files/<id>)`)이 빠져 있으면 stderr 에 경고를 띄우고 (y/N) 로 물어봅니다.
 
 자동화 환경 (pipe / non-TTY) 에서는 그대로 abort 됩니다. 의도한 변경이면 `--no-confirm` 으로 다시 실행하세요.
 
@@ -198,7 +202,8 @@ dooray post create <project> --title "주간 audit" --cc-group dev-team
 ```
 
 interactive ($EDITOR) 모드에서는 위 6개 옵션이 무시되고 stderr 경고가 출력됩니다.
-`post edit --dry-run --json` 사용 시 출력에 `users: { to, cc }` 가 포함되어 API 호출 없이 변경 결과 미리보기 가능. (`post create --dry-run` 은 본문만 출력하며 `users` 는 포함하지 않음.)
+`post edit --dry-run --json` 사용 시 출력에 `users: { to, cc }` 가 포함되어 API 호출 없이 변경 결과 미리보기 가능.
+`post create --dry-run` 은 본문만 출력하며 `users` 는 포함하지 않음.
 
 ```bash
 dooray post edit <project> <post-number> --cc-group dev-team --dry-run --json | jq '.users.cc'
@@ -231,11 +236,16 @@ dooray post edit <project> <child-number> --title "<원제목>" --parent <projec
 dooray post edit --id <postId> --title "<원제목>" --parent <other-parent-postId>
 ```
 
-내부적으로 `client.updatePost` 호출 후 별도 `POST .../set-parent-post` endpoint 추가 호출. **parent 해제 (top-level 화)** 는 Dooray API 가 미지원이라 웹 UI 에서 수동 처리.
+내부적으로 `client.updatePost` 호출 후 별도 `POST .../set-parent-post` endpoint 추가 호출.
+**parent 해제 (top-level 화)** 는 Dooray API 가 미지원이라 웹 UI 에서 수동 처리.
 
-interactive ($EDITOR) 모드에서 `--parent` 사용 시 무시 + stderr 경고. **parent 만 단독 변경하려면 `--title "<원제목>"` 동반 필요** — `post edit` 가 본문 변경(`--title`/`--body`) 동반 시에만 non-interactive 분기로 들어가며, parent 변경은 그 분기 안에서만 수행됨. (Issue #60)
+interactive ($EDITOR) 모드에서 `--parent` 사용 시 무시 + stderr 경고.
+**parent 만 단독 변경하려면 `--title "<원제목>"` 동반 필요** — `post edit` 는 본문 변경(`--title`/`--body`) 동반 시에만 non-interactive 분기로 들어감.
+parent 변경은 그 분기 안에서만 수행됨. (Issue #60)
 
-`--dry-run --json` 출력의 `parentChange` 필드는 **사용자 입력 원문 그대로** (`<project>/<number>` 또는 raw postId) — resolver 처리 전 미리보기 값이며 실제 호출 대상 `postId` 가 아님. dry-run 은 API 미호출 원칙을 유지해 `resolvePostRef` 도 건너뜀.
+`--dry-run --json` 출력의 `parentChange` 필드는 **사용자 입력 원문 그대로** (`<project>/<number>` 또는 raw postId).
+resolver 처리 전 미리보기 값이며 실제 호출 대상 `postId` 가 아님.
+dry-run 은 API 미호출 원칙을 유지해 `resolvePostRef` 도 건너뜀.
 
 #### `--to` / `--cc` / `--mention` 입력 형식 (자동 분기)
 
@@ -377,7 +387,8 @@ dooray post comment delete --url <url> --comment-id <commentId>
 
 ### 댓글 첨부 파일 (`post comment file *`)
 
-자동화로 댓글에 인라인 이미지 / 파일을 삽입할 때 사용. 4 명령 (list/upload/download/delete) 모두 `<project> <post-number> <comment-id>` 또는 `--id <postId> --comment-id <logId>` / `--url <url> --comment-id <logId>` 패턴 지원 (ADR-020).
+자동화로 댓글에 인라인 이미지 / 파일을 삽입할 때 사용.
+4 명령 (list/upload/download/delete) 모두 `<project> <post-number> <comment-id>` 또는 `--id <postId> --comment-id <logId>` / `--url <url> --comment-id <logId>` 패턴 지원 (ADR-020).
 
 ```bash
 # 첨부 목록
@@ -413,7 +424,8 @@ dooray post list <project> --quiet | xargs -I{} dooray post done <project> {}
 
 ## AI 에이전트 연동
 
-`skills/dooray-cli/SKILL.md`에 AI 에이전트를 위한 스킬 파일이 포함되어 있습니다. Claude Code 등의 AI 에이전트에서 dooray-cli를 자동으로 활용할 수 있도록 의도→커맨드 매핑, 체이닝 예시, 에러 핸들링 가이드가 포함되어 있습니다.
+`skills/dooray-cli/SKILL.md`에 AI 에이전트를 위한 스킬 파일이 포함되어 있습니다.
+Claude Code 등의 AI 에이전트에서 dooray-cli를 자동으로 활용할 수 있도록 의도→커맨드 매핑, 체이닝 예시, 에러 핸들링 가이드가 포함되어 있습니다.
 
 ```bash
 # 스킬 파일 복사 (Claude Code 예시)
@@ -493,11 +505,13 @@ dooray --help
 
 #### 비용 / 토큰
 
-각 PR 당 4 specialist 가 모두 `haiku` 모델로 동작 — 평균 PR 1건 당 수십 센트 수준. PR 자동 트리거 비활성화하려면 `claude-code-review.yml` 의 `if:` 조건에서 `github.event_name == 'pull_request'` 분기를 제거하고 `/review` 댓글 트리거만 남길 수 있음.
+각 PR 당 4 specialist 가 모두 `haiku` 모델로 동작 — 평균 PR 1건 당 수십 센트 수준.
+PR 자동 트리거 비활성화하려면 `claude-code-review.yml` 의 `if:` 조건에서 `github.event_name == 'pull_request'` 분기를 제거하고 `/review` 댓글 트리거만 남길 수 있음.
 
 #### Fork PR 제한
 
-GitHub Actions 정책상 fork 에서 열린 PR 은 `secrets.CLAUDE_CODE_OAUTH_TOKEN` 에 접근 못 해 **자동 리뷰가 silent 하게 skip** 된다. fork 기여자가 리뷰를 받으려면 maintainer 가 PR 댓글에 `/review` 를 작성하여 base repo 컨텍스트로 워크플로를 트리거해야 한다.
+GitHub Actions 정책상 fork 에서 열린 PR 은 `secrets.CLAUDE_CODE_OAUTH_TOKEN` 에 접근 못 해 **자동 리뷰가 silent 하게 skip** 된다.
+fork 기여자가 리뷰를 받으려면 maintainer 가 PR 댓글에 `/review` 를 작성하여 base repo 컨텍스트로 워크플로를 트리거해야 한다.
 
 ## 라이센스
 

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -104,7 +104,7 @@ types.ts 포팅 비용은 1일 내라 상쇄 가능.
 **이유**:
 
 - `--body "..."` flag로 긴 마크다운 입력은 현실적으로 불가능
-- `--body-file` + 별도 수정은 "기존 내용 조회 → 파일 저장 → 수정 → CLI 재실행" 4단계 필요
+- `--body-file` + 별도 수정은 4단계 필요: 기존 내용 조회, 파일 저장, 수정, CLI 재실행
 - $EDITOR 방식(`kubectl edit`, `git commit` 동일 패턴)은 1커맨드로 완결
 - YAML frontmatter로 메타데이터(subject, priority, due_date, to, cc) + 본문 통합 편집
 
@@ -227,7 +227,7 @@ types.ts 포팅 비용은 1일 내라 상쇄 가능.
 
 **구현**:
 
-- 다운로드: `?media=raw` 쿼리 파라미터로 307 유도 → Location 헤더 캡처 → fetch로 2차 요청
+- 다운로드: `?media=raw` 쿼리 파라미터로 307 유도 후 Location 헤더 캡처, fetch로 2차 요청
 - 업로드: `fetch` 직접 사용 (`ky`는 307 + `redirect: "manual"` 조합에서 정상 동작하지 않음)
 - 2차 요청 시 동일한 Authorization 헤더 첨부
 - 업로드: FormData + Blob, 다운로드: ArrayBuffer로 수신 후 파일 저장
@@ -306,7 +306,10 @@ npx 임시 경로 감지 시 경고 + skip (global install 전용).
 
 **맥락**: mandatory-tag 정책 프로젝트는 CLI 로 단 한 건도 생성 불가 (Issue #18).
 API 의 `USER_INVALID_TAG_MANDATORY_PREFIX` 에러는 어느 그룹이 누락인지 안내 안 함 → 친절한 메시지 직접 생성 필요.
-멤버만 부분일치였던 resolver 비대칭도 해소 — 정확 일치 → 부분 일치 → 모호 + 후보 출력 순서로 통일.
+멤버만 부분일치였던 resolver 비대칭도 해소 — 아래 순서로 통일:
+- 정확 일치
+- 부분 일치
+- 모호 + 후보 출력
 
 **대안 기각**:
 - `--workflow` 실패 시 exit non-zero — post 가 이미 발급된 상태에서 전체 실패는 사용자가 두 번 만드는 혼란
@@ -453,7 +456,10 @@ cwd 가 사내 경로일 가능성 (`/Users/.../<project>/...`) — CLAUDE.md PI
 모두 기존 `updatePost` / `createPost` 의 **full payload PUT** 흐름 (`users: { to, cc }`) 으로 처리.
 그룹은 `{ type: "group", group: { projectMemberGroupId } }` 객체로 전송.
 
-**맥락**: Issue #54 — 자동화 스크립트의 워크플로우: audit 리포트 생성 → 신규 업무 생성 → 그룹 cc 첨부.
+**맥락**: Issue #54 — 자동화 스크립트의 워크플로우:
+- audit 리포트 생성
+- 신규 업무 생성
+- 그룹 cc 첨부
 Dooray API 는 cc-only patch 단독 엔드포인트 미제공.
 PUT post 의 full payload 만 cc/to 갱신 가능.
 PostUser type 의 그룹 분기는 `type: "memberGroup"` 이 아니라 `type: "group"` + `Group.projectMemberGroupId` — 이슈 본문 시도가 실패한 원인.

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -43,7 +43,8 @@
 - npm 생태계로 `npx @bifos/dooray-cli` 즉시 배포 가능
 - CLI 툴 생태계(Commander, chalk, ora 등)가 Node.js에서 가장 성숙
 
-**대안 기각**: Kotlin MCP 서버 코드 재사용 포기 → 다른 ADR과 형식 일관성 확보. types.ts 포팅 비용은 1일 내라 상쇄 가능.
+**대안 기각**: Kotlin MCP 서버 코드 재사용 포기 → 다른 ADR과 형식 일관성 확보.
+types.ts 포팅 비용은 1일 내라 상쇄 가능.
 
 ---
 
@@ -171,7 +172,8 @@
 - `SORT` 미지원 → UID 역순(최신순)으로 대체
 - `SUBJECT`, `FROM`, `TO`, `UNSEEN`, `SEEN` 검색은 지원
 
-**기본값 전략**: imap-host, imap-port, smtp-host, smtp-port는 기본값 제공 (Dooray 사용자 대다수 동일). 사용자는 imap-username, imap-password만 설정하면 됨.
+**기본값 전략**: imap-host, imap-port, smtp-host, smtp-port는 기본값 제공 (Dooray 사용자 대다수 동일).
+사용자는 imap-username, imap-password만 설정하면 됨.
 
 **트레이드오프**: imapflow + mailparser 의존성 추가 → tsup에서 external 처리 필요 (번들 미포함, node_modules에서 로드)
 
@@ -236,7 +238,8 @@
 
 ## ADR-016: `dooray setup` 대화형 초기 설정 마법사
 
-**결정**: `dooray setup` 커맨드로 대화형 초기 설정 마법사 제공. `postinstall` 훅 대신 명시적 커맨드 방식 채택.
+**결정**: `dooray setup` 커맨드로 대화형 초기 설정 마법사 제공.
+`postinstall` 훅 대신 명시적 커맨드 방식 채택.
 
 **이유**:
 
@@ -248,7 +251,8 @@
 
 **라이브러리**: `@inquirer/prompts` — 선택(select), 입력(input), 비밀번호(password), 확인(confirm) 프롬프트 지원. tsup CJS 번들 호환성 확인 필요.
 
-**안전성**: Ctrl+C 시 config 파일 미저장 (부분 저장 방지). 모든 입력을 메모리에 수집한 뒤 마지막에 한 번만 writeFile.
+**안전성**: Ctrl+C 시 config 파일 미저장 (부분 저장 방지).
+모든 입력을 메모리에 수집한 뒤 마지막에 한 번만 writeFile.
 
 **config 미설정 시 안내**: 기존 에러 메시지를 `dooray setup` 실행 유도로 변경.
 
@@ -263,7 +267,7 @@
 **이유**:
 
 - 현재 ~440줄으로 분리 임계점(~800줄+)에 미달
-- 섹션 주석으로 Common / Project / Post / Comment / Member / Workflow / Wiki / File 구분이 충분
+- 섹션 주석으로 Common, Project, Post, Comment, Member, Workflow, Wiki, File 구분이 충분
 - `DoorayApiHeader`, `DoorayApiResponse<T>` 등 Common 타입을 거의 모든 도메인이 참조 → barrel export 관리 오버헤드 대비 실익 부족
 - `client.ts`에서 한 파일로 모든 타입을 import하는 현재 구조가 간결
 
@@ -275,9 +279,14 @@
 
 ## ADR-018: `dooray setup` 에서 Claude Code 스킬 설치
 
-**결정**: setup 마지막 단계에서 스킬 설치 여부를 물어보고 심볼릭 링크로 설치 (`~/.claude/skills/dooray-cli` → 패키지 내부 `skills/dooray-cli/`). idempotent 재실행 가능. npx 임시 경로 감지 시 경고 + skip (global install 전용).
+**결정**: setup 마지막 단계에서 스킬 설치 여부를 물어보고 심볼릭 링크로 설치 (`~/.claude/skills/dooray-cli` → 패키지 내부 `skills/dooray-cli/`).
+idempotent 재실행 가능.
+npx 임시 경로 감지 시 경고 + skip (global install 전용).
 
-**맥락**: 별도 `dooray install skills` 커맨드보다 setup 일원화가 UX 간결. 심볼릭 링크는 `npm update -g` 시 스킬도 자동 최신화 (유지보수 비용 0). `~/.claude/skills/` 의 다른 스킬 (gstack 등) 도 동일 패턴이라 일관성. 스킬 포맷은 Claude Code SKILL.md frontmatter 규격 — 타 에이전트 지원은 요청 시 확장.
+**맥락**: 별도 `dooray install skills` 커맨드보다 setup 일원화가 UX 간결.
+심볼릭 링크는 `npm update -g` 시 스킬도 자동 최신화 (유지보수 비용 0).
+`~/.claude/skills/` 의 다른 스킬 (gstack 등) 도 동일 패턴이라 일관성.
+스킬 포맷은 Claude Code SKILL.md frontmatter 규격 — 타 에이전트 지원은 요청 시 확장.
 
 **대안 기각**:
 - `postinstall` 훅 — npm 정책상 interactive postinstall 비권장, CI/Docker 비-TTY 실패 (ADR-016 과 동일 사유)
@@ -291,18 +300,25 @@
 
 ## ADR-019: `post create` 메타데이터 옵션 (`--tag`/`--parent`/`--workflow`/`--milestone`)
 
-**결정**: 4개 옵션 모두 이름 lookup. 클라이언트가 `tagGroup.mandatory` / `selectOne` 사전 검증. `--workflow` 만 create 후 `setPostWorkflow` 후속 호출 — 실패 시 `stderr` warn + `exit 0` (post 는 이미 생성됨).
+**결정**: 4개 옵션 모두 이름 lookup.
+클라이언트가 `tagGroup.mandatory` / `selectOne` 사전 검증.
+`--workflow` 만 create 후 `setPostWorkflow` 후속 호출 — 실패 시 `stderr` warn + `exit 0` (post 는 이미 생성됨).
 
-**맥락**: mandatory-tag 정책 프로젝트는 CLI 로 단 한 건도 생성 불가 (Issue #18). API 의 `USER_INVALID_TAG_MANDATORY_PREFIX` 에러는 어느 그룹이 누락인지 안내 안 함 → 친절한 메시지 직접 생성 필요. 멤버만 부분일치였던 resolver 비대칭도 해소 (전체 정확→부분→모호+후보).
+**맥락**: mandatory-tag 정책 프로젝트는 CLI 로 단 한 건도 생성 불가 (Issue #18).
+API 의 `USER_INVALID_TAG_MANDATORY_PREFIX` 에러는 어느 그룹이 누락인지 안내 안 함 → 친절한 메시지 직접 생성 필요.
+멤버만 부분일치였던 resolver 비대칭도 해소 — 정확 일치 → 부분 일치 → 모호 + 후보 출력 순서로 통일.
 
 **대안 기각**:
 - `--workflow` 실패 시 exit non-zero — post 가 이미 발급된 상태에서 전체 실패는 사용자가 두 번 만드는 혼란
 - ID 직접 입력 허용 — `--workflow xxx-uuid` 같은 폴백은 거의 사용 안 되는 흐름, 복잡도만 ↑
 - `--tag` 에 자릿수 휴리스틱 — ID 형식 변경 시 깨짐. `--parent` 만 `code/number` ↔ raw postId 분기
 
-세부 시그니처·동작은 `src/commands/post/create.ts` + `src/resolvers/{tag,milestone,postRef}.ts` 참조. 캐시 디렉터리는 `data-schema.md`.
+세부 시그니처·동작은 `src/commands/post/create.ts` + `src/resolvers/{tag,milestone,postRef}.ts` 참조.
+캐시 디렉터리는 `data-schema.md`.
 
-**확장 (2026-05-18, Issue #66)**: `post edit` 도 동일 정책 적용 — `--tag` / `--tag-clear` / `--tag-remove` 옵션 + mandatory 검증 동일 호출. `--title`/`--body` 없이 단독 호출 허용 (body 자동 재전송). 머지 로직은 `src/resolvers/post-tags.ts` 의 `mergeTagIds` pure helper (`post-users.ts` 패턴 답습).
+**확장 (2026-05-18, Issue #66)**: `post edit` 도 동일 정책 적용 — `--tag` / `--tag-clear` / `--tag-remove` 옵션 + mandatory 검증 동일 호출.
+`--title`/`--body` 없이 단독 호출 허용 (body 자동 재전송).
+머지 로직은 `src/resolvers/post-tags.ts` 의 `mergeTagIds` pure helper — `post-users.ts` 패턴 답습.
 
 ---
 
@@ -310,9 +326,16 @@
 
 ## ADR-020: post 명령 input 통합 (`--id`/URL/positional) + 첫 테스트 인프라 (vitest)
 
-**결정**: post 하위 명령에 3 가지 입력 모드 (기존 `<project> <post-number>` + `--id <postId>` + `--url <url>` + 첫 positional 이 Dooray URL 이면 자동) 도입. sub-id (`<comment-id>`, `<file-id>`) 는 옵션화 (positional 호환). 분기는 `resolvePostInput` 단일 헬퍼. 동시 사용은 명시적 에러. 첫 테스트 인프라로 vitest 도입.
+**결정**: post 하위 명령에 3 가지 입력 모드 (기존 `<project> <post-number>` + `--id <postId>` + `--url <url>` + 첫 positional 이 Dooray URL 이면 자동) 도입.
+sub-id (`<comment-id>`, `<file-id>`) 는 옵션화 (positional 호환).
+분기는 `resolvePostInput` 단일 헬퍼.
+동시 사용은 명시적 에러.
+첫 테스트 인프라로 vitest 도입.
 
-**맥락**: Dooray URL 은 postId 만 포함 (`/task/to/{postId}`) — 동료가 URL 만 공유하면 project 코드 모르는 사용자가 CLI 사용 불가 (Issue #16). AI 에이전트도 사용자 메시지에서 URL 을 그대로 첫 인자로 전달하면 라우팅 부담 0. standalone API `GET /project/v1/posts/{postId}` 응답에 `project.{id,code}` 포함 → 한 lookup 으로 기존 코드 경로 재사용. 분기 규칙이 7 가지라 단위 테스트로 회귀 방지 필수.
+**맥락**: Dooray URL 은 postId 만 포함 (`/task/to/{postId}`) — 동료가 URL 만 공유하면 project 코드 모르는 사용자가 CLI 사용 불가 (Issue #16).
+AI 에이전트도 사용자 메시지에서 URL 을 그대로 첫 인자로 전달하면 라우팅 부담 0.
+standalone API `GET /project/v1/posts/{postId}` 응답에 `project.{id,code}` 포함 → 한 lookup 으로 기존 코드 경로 재사용.
+분기 규칙이 7 가지라 단위 테스트로 회귀 방지 필수.
 
 **대안 기각**:
 - positional 단일 `<ref>` 통합 (`<project>/337` | postId | URL) — 기존 두 인자 breaking, 영향 범위 ↑
@@ -320,7 +343,8 @@
 - sub-id 를 인자 개수로 분기 — `comment edit <project> cmt-abc` 같은 사용자 실수에 모호한 에러
 - `node:test` 빌트인 — mocking·watch·확장성에서 vitest 우위
 
-분기 규칙·URL 정규식·테스트 케이스는 `src/resolvers/post-input.ts` + `src/utils/dooray-url.ts` 참조. 후속 (wiki input 통합, CI 통합) 은 별도 task.
+분기 규칙·URL 정규식·테스트 케이스는 `src/resolvers/post-input.ts` + `src/utils/dooray-url.ts` 참조.
+후속 (wiki input 통합, CI 통합) 은 별도 task.
 
 ---
 
@@ -328,9 +352,13 @@
 
 ## ADR-021: `member` 명령 + comment list Creator 이름 자동 채우기
 
-**결정**: `dooray member get/list` 서브커맨드 신설. `post comment list` 의 table 출력만 Creator 컬럼을 project 멤버 캐시로 enrich, `--json` 은 raw 유지. 기존 project 단위 캐시 (`members/{projectId}.json`) 만 사용 — organization-wide reverse lookup 미도입.
+**결정**: `dooray member get/list` 서브커맨드 신설.
+`post comment list` 의 table 출력만 Creator 컬럼을 project 멤버 캐시로 enrich — `--json` 은 raw 유지.
+기존 project 단위 캐시 (`members/{projectId}.json`) 만 사용 — organization-wide reverse lookup 미도입.
 
-**맥락**: 댓글 응답에 `organizationMemberId` 만 있고 표시명 없어 자동화 흐름이 끊김 (Issue #17). table 만 enrich 한 이유는 `--json` 의 외부 도구 호환성 (스키마 변경 = breaking). project 단위 캐시 유지는 enrich 사용 시점에 항상 projectId 가 동반됨.
+**맥락**: 댓글 응답에 `organizationMemberId` 만 있고 표시명 없어 자동화 흐름이 끊김 (Issue #17).
+`--json` 을 raw 로 유지한 이유는 외부 도구 호환성 — 스키마 변경은 breaking change.
+project 단위 캐시 유지는 enrich 사용 시점에 항상 projectId 가 동반됨.
 
 **대안 기각**:
 - organization 단위 캐시 — 사용 패턴 (comment list enrich + member get 단건) 에서 이득 부족 + invalidation 부담
@@ -343,9 +371,15 @@
 
 ## ADR-022: `dooray feedback` 명령 — GitHub 호출은 `gh` CLI 에 위임
 
-**결정**: GitHub issue 생성은 `gh` CLI 위임 (`execFile('gh', ['issue', 'create', ...])`). 본문 자동 메타는 환경 정보만 (`process.version` / `platform` / `arch` / `package.json` 버전) — config 객체에 접근 자체 안 함 (`apiKey` / IMAP 비밀번호 / `baseUrl` 모두 노출 0). 대상 repo 하드코딩 (`jon890/dooray-cli`).
+**결정**: GitHub issue 생성은 `gh` CLI 위임 (`execFile('gh', ['issue', 'create', ...])`).
+본문 자동 메타는 환경 정보만 (`process.version`, `platform`, `arch`, `package.json` 버전) — config 객체에 접근 안 함.
+`apiKey`, IMAP 비밀번호, `baseUrl` 모두 노출 0.
+대상 repo 하드코딩 (`jon890/dooray-cli`).
 
-**맥락**: 피드백 루프 마찰 제거 (Issue #19) — "에러 만남 → 한 줄로 issue 등록 → 작업 복귀". gh CLI 위임은 토큰 관리·OAuth 앱 등록 부담을 0 으로. dooray-cli 의 보안 표면도 늘지 않음. baseUrl 노출 시 사내 endpoint 사용자가 OSS public repo 로 보낼 때 회사 정보 누출 위험.
+**맥락**: 피드백 루프 마찰 제거 (Issue #19) — "에러 만남 → 한 줄로 issue 등록 → 작업 복귀".
+gh CLI 위임은 토큰 관리·OAuth 앱 등록 부담을 0 으로.
+dooray-cli 의 보안 표면도 늘지 않음.
+baseUrl 노출 시 사내 endpoint 사용자가 OSS public repo 로 보낼 때 회사 정보 누출 위험.
 
 **대안 기각**:
 - PAT 를 config.json 에 저장 — 토큰 만료/회수/스코프 관리 부담, UX 약함
@@ -367,9 +401,13 @@
 3. **최소 세트**: argv (sanitized) + exitCode + errorMessage + timestamp. `cwd`/`env` 제외
 4. **argv 패턴 마스킹**: `--api-key=*` / `--token=*` / `--password=*` / `Authorization: Bearer *`
 
-`feedback` 자체는 기록 안 함 (재귀 방지). 단일 파일 덮어쓰기 (use case = 직전 1건).
+`feedback` 자체는 기록 안 함 (재귀 방지).
+단일 파일 덮어쓰기 — use case 는 직전 1건만.
 
-**맥락**: 모든 명령 종료 시점 디스크 I/O 는 전역 부수 효과 — dooray-cli 는 자동화 스크립트에서 자주 호출되어 의도 없는 매번 파일 쓰기는 부담. 성공 명령 기록은 효용 ↓ 부수효과 ↑. cwd 가 사내 경로일 가능성 (`/Users/.../<project>/...`) — CLAUDE.md PII gate 와 일관. 사용자가 `--header "Authorization: ..."` 추가 가능성으로 마스킹은 안전망.
+**맥락**: 모든 명령 종료 시점 디스크 I/O 는 전역 부수 효과 — dooray-cli 는 자동화 스크립트에서 자주 호출되어 의도 없는 매번 파일 쓰기는 부담.
+성공 명령 기록은 효용 ↓ 부수효과 ↑.
+cwd 가 사내 경로일 가능성 (`/Users/.../<project>/...`) — CLAUDE.md PII 점검과 일관.
+사용자가 `--header "Authorization: ..."` 추가 가능성으로 마스킹은 안전망.
 
 **대안 기각**:
 - 기본 on + opt-out — 부수 효과가 사용자 인지 없이 작동 (privacy 우려)
@@ -385,9 +423,12 @@
 
 ## ADR-024: `dooray post comment file *` — post-level files API + 댓글 PUT 합성
 
-**결정**: `comment file {list,upload,download,delete}` 4 명령을 post-level files API (`/posts/{postId}/files`) + 댓글 본문 PUT (`/logs/{logId}`) 합성으로 구현. 사용자 멘탈 모델 = "댓글 첨부", 실제 데이터 모델 = post-level files + 댓글 본문 markdown reference (`![filename](/files/<fileId>)`). `delete` 는 항상 markdown 제거 + 파일 삭제 단일 동작 (옵션 분기 없음).
+**결정**: `comment file {list,upload,download,delete}` 4 명령을 post-level files API (`/posts/{postId}/files`) + 댓글 본문 PUT (`/logs/{logId}`) 합성으로 구현.
+사용자 멘탈 모델은 "댓글 첨부"이지만 실제 데이터 모델은 post-level files + 댓글 본문 markdown reference (`![filename](/files/<fileId>)`) 구조다.
+`delete` 는 항상 markdown 제거 + 파일 삭제 단일 동작 (옵션 분기 없음).
 
-**맥락**: Dooray 공식 API + 실 호출 검증 결과 댓글 전용 attachment endpoint **부재** (Issue #34) — 댓글 단건 GET 응답에 `files: PostFileDetail[]` embedded 만 존재. 인라인 이미지 자동화 (스킬이 댓글에 이미지 삽입) 가 빈번해 댓글 전용 UX 가 필요.
+**맥락**: Dooray 공식 API + 실 호출 검증 결과 댓글 전용 attachment endpoint **부재** (Issue #34) — 댓글 단건 GET 응답에 `files: PostFileDetail[]` embedded 만 존재.
+인라인 이미지 자동화가 빈번해 댓글 전용 UX 가 필요 — 스킬이 댓글에 이미지를 삽입하는 패턴이 대표적.
 
 **트레이드오프 (수용)**:
 - **Atomic 부재**: 2-step (`upload`, `delete`) 중 1 step 만 성공 가능 — 부분 성공 시 stderr 안내 + non-zero exit
@@ -407,13 +448,20 @@
 
 ## ADR-025: `post edit/create` cc/to 에 member-group 추가 (full payload PUT + `type: "group"`)
 
-**결정**: `post edit` 에 `--cc <name>` / `--cc-group <code>` / `--cc-clear` (+ `--to` / `--to-group` / `--to-clear`) 6 옵션 추가. `post create` 에 `--cc-group` / `--to-group` 2 옵션 추가. 모두 기존 `updatePost` / `createPost` 의 **full payload PUT** 흐름 (`users: { to, cc }`) 으로 처리. 그룹은 `{ type: "group", group: { projectMemberGroupId } }` 객체로 전송.
+**결정**: `post edit` 에 `--cc <name>`, `--cc-group <code>`, `--cc-clear`, `--to <name>`, `--to-group <code>`, `--to-clear` 6 옵션 추가.
+`post create` 에 `--cc-group`, `--to-group` 2 옵션 추가.
+모두 기존 `updatePost` / `createPost` 의 **full payload PUT** 흐름 (`users: { to, cc }`) 으로 처리.
+그룹은 `{ type: "group", group: { projectMemberGroupId } }` 객체로 전송.
 
-**맥락**: Issue #54 — 자동화 스크립트가 신규 업무 생성 후 후속으로 특정 그룹을 참조에 추가하려는 워크플로우 (audit 리포트 → 신규 업무 → 그룹 cc 첨부). Dooray API 는 cc-only patch 단독 엔드포인트 미제공. PUT post 의 full payload 만 cc/to 갱신 가능. 또한 PostUser type 의 그룹 분기는 `type: "memberGroup"` 이 아니라 `type: "group"` + `Group.projectMemberGroupId` (이슈 본문의 시도가 실패한 원인).
+**맥락**: Issue #54 — 자동화 스크립트의 워크플로우: audit 리포트 생성 → 신규 업무 생성 → 그룹 cc 첨부.
+Dooray API 는 cc-only patch 단독 엔드포인트 미제공.
+PUT post 의 full payload 만 cc/to 갱신 가능.
+PostUser type 의 그룹 분기는 `type: "memberGroup"` 이 아니라 `type: "group"` + `Group.projectMemberGroupId` — 이슈 본문 시도가 실패한 원인.
 
 **대안 기각**:
 - cc-only patch endpoint 역공학 — 부재 확인 (`POST .../set-cc`, `.../cc`, `.../to-and-cc` 모두 null 응답)
-- `{ "type": "memberGroup", "memberGroup": { "memberGroupId": "..." } }` 형식 (이슈 본문 시도) — `Failed to read HTTP message`. 실제 API contract 는 `type: "group"` + `Group.projectMemberGroupId` (api/types.ts:122-125)
+- `{ "type": "memberGroup", "memberGroup": { "memberGroupId": "..." } }` 형식 (이슈 본문 시도) — `Failed to read HTTP message`.
+  실제 API contract 는 `type: "group"` + `Group.projectMemberGroupId` (api/types.ts:122-125)
 - subcommand 분리 (`post participants {add,set,remove}`) — `post edit` 의 다른 옵션 (title/body/mention/link-task) 과 조합 불가, 한 번 PUT 으로 끝낼 수 없어 race 위험
 - replace 기본 정책 — 사용자가 매번 전체 멤버/그룹 알아야 함, 자동화 친화성 떨어짐. append + `--cc-clear` / `--to-clear` 채택
 
@@ -425,13 +473,18 @@
 
 ## ADR-026: Wiki API 호출 패턴 함정 (parentPageId 필수 + subject/title 네이밍 + 페이지 수정 3종 endpoint)
 
-**결정**: Wiki API 호출 시 다음 3개 함정을 클라이언트 레이어에서 흡수 — `parentPageId` 자동 폴백 (`resolveWikiHomePageId`) / `--title` → `subject` 매핑 / 수정 동작별 endpoint 분기 (`/pages/{id}` / `/title` / `/content`).
+**결정**: Wiki API 호출 시 다음 3개 함정을 클라이언트 레이어에서 흡수:
+- `parentPageId` 자동 폴백 (`resolveWikiHomePageId`)
+- `--title` → `subject` 매핑
+- 수정 동작별 endpoint 분기 (`/pages/{id}`, `/title`, `/content`)
 
 **맥락**: Dooray Wiki API 의 다음 동작은 공식 문서에 없거나 직관에 반함:
 
-- **`parentPageId` 사실상 필수** — `POST /wiki/v1/wikis/{wikiId}/pages` 의 `parentPageId` 가 공식적으로는 optional 처럼 보이나 미지정/빈 문자열 시 400. 사용자 UX 보존 위해 CLI 가 `home.pageId` 로 자동 폴백 (Issue #5)
+- **`parentPageId` 사실상 필수** — `POST /wiki/v1/wikis/{wikiId}/pages` 의 `parentPageId` 가 공식적으로는 optional 처럼 보이나 미지정/빈 문자열 시 400.
+  사용자 UX 보존 위해 CLI 가 `home.pageId` 로 자동 폴백 (Issue #5)
 - **`subject` vs `title` 네이밍 불일치** — API body 필드는 `subject` (업무·위키 공통). 사용자 친화 위해 CLI 는 `--title` 플래그로 노출 + 매핑
-- **페이지 수정 endpoint 3종 분리** — Dooray 가 제목+본문 동시 (`/pages/{id}`) / 제목만 (`/title`) / 본문만 (`/content`) 을 별도 endpoint 로 제공. CLI `wiki page edit` 가 플래그 조합으로 라우팅 분기 (Issue #4)
+- **페이지 수정 endpoint 3종 분리** — Dooray 가 제목+본문 동시, 제목만, 본문만을 별도 endpoint 로 제공.
+  CLI `wiki page edit` 가 플래그 조합으로 라우팅 분기 (Issue #4)
 
 **대안 기각**:
 - `parentPageId` 미지정 허용 (서버 에러 그대로 노출) — UX 회귀, 사용자가 wiki home 개념 몰라도 동작해야 함
@@ -446,20 +499,35 @@
 | `PUT .../pages/{pageId}/title` | 제목만 | `--title X` 단독 |
 | `PUT .../pages/{pageId}/content` | 본문만 | `--body` 또는 `--body-file` 단독 |
 
-**추가 함정 (2026-05-18, Issue #65)**: `GET /project/v1/projects/{id}/member-groups` 응답 스키마는 `code: string` (required) 이지만 실제로 일부 그룹에서 `code` 가 누락된 채 반환됨 — `match.ts` 의 `i.name.includes()` 가 undefined 추락. 같은 부류의 스키마 ↔ 실제 응답 mismatch. 흡수 위치: `resolveMemberGroup` adapter 에서 `code` 가 falsy 인 그룹 사전 필터 + `MemberGroup.code` 타입을 optional 로 완화 + `match.ts` 에 `i.name?.includes` 가드.
+**추가 함정 (2026-05-18, Issue #65)**: `GET /project/v1/projects/{id}/member-groups` 응답의 `code: string` 필드가 required 로 정의됐지만
+실제로 일부 그룹에서 `code` 가 누락된 채 반환됨 — 같은 부류의 스키마 ↔ 실제 응답 mismatch.
+`match.ts` 의 `i.name.includes()` 가 undefined 추락.
+흡수 위치:
+- `resolveMemberGroup` adapter 에서 `code` 가 falsy 인 그룹 사전 필터
+- `MemberGroup.code` 타입을 optional 로 완화
+- `match.ts` 에 `i.name?.includes` 가드
+
+---
 
 <a id="adr-027"></a>
 
 ## ADR-027: `post create --template` 정책 — interpolation 기본 true + 사용자 옵션 우선 + `--field` 제외
 
-**결정**: `dooray post create --template <name|id>` 사용 시 ① `GET .../templates/{id}?interpolation=true` 로 시스템 매크로 (`${year}` 등) 치환된 본문/users/tags 를 받음, ② 사용자가 `--title`/`--body`/`--tag`/`--to`/`--cc` 명시 입력하면 그 값이 템플릿 값을 override, ③ 사용자 정의 변수 (`--field key=value`) 는 본 task scope 제외 (별도 후속).
+**결정**: `dooray post create --template <name|id>` 사용 정책:
+- `GET .../templates/{id}?interpolation=true` 로 시스템 매크로 (`${year}` 등) 치환된 본문/users/tags 를 받음
+- 사용자가 `--title`/`--body`/`--tag`/`--to`/`--cc` 명시 입력하면 그 값이 템플릿 값을 override
+- 사용자 정의 변수 (`--field key=value`) 는 본 task scope 제외 (별도 후속)
 
-**맥락**: Issue #59 — 자동화 스크립트가 정형 task (릴리스 플랜, 요청서 등) 를 매번 기존 본문 fetch + 변수 치환 수동 우회. Dooray API 가 `GET /templates` 와 `interpolation` 파라미터를 노출 (cmux-browser spike 2026-05-11 확인).
+**맥락**: Issue #59 — 자동화 스크립트가 정형 task (릴리스 플랜, 요청서 등) 를 매번 기존 본문 fetch + 변수 치환 수동 우회.
+Dooray API 가 `GET /templates` 와 `interpolation` 파라미터를 노출 (cmux-browser 사전 조사 2026-05-11 확인).
 
 **대안 기각**:
 - `interpolation=false` 기본 — 자동화 파이프라인이 `${year}` 같은 매크로를 매번 수동 치환해야 해서 가치 반감. UX 우선
 - 템플릿 우선 (override 불가) — 사용자가 `--title` 까지 강제 변경 못 하면 "대부분 템플릿, 일부만 다르게" 자동화 패턴 불가
 - 필드별 union (tags/users append, title/body override) — 정책 복잡. MVP 단순화 — 일관되게 사용자 옵션 우선
-- `--field key=value` client-side string replace 포함 — 미정의 변수 / escape / type 처리 복잡. 본 task 는 API 가 직접 제공하는 시스템 매크로만 사용, 사용자 정의 변수는 별도 task 로 분리
+- `--field key=value` client-side string replace 포함 — 미정의 변수 / escape / type 처리 복잡.
+  본 task 는 API 가 직접 제공하는 시스템 매크로만 사용, 사용자 정의 변수는 별도 task 로 분리
 
-**적용 범위**: `post create --template` 만. `post edit --template` 은 별도 (의도 불명확 — 기존 본문 덮어쓰기? merge?). templates 캐시는 ADR-004/010 패턴 답습 (TTL 24h, `~/.dooray/cache/templates/{projectId}.json`).
+**적용 범위**: `post create --template` 만.
+`post edit --template` 은 별도 — 기존 본문 덮어쓰기인지 merge 인지 의도 불명확.
+templates 캐시는 ADR-004/010 패턴 답습 (TTL 24h, `~/.dooray/cache/templates/{projectId}.json`).

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -192,7 +192,7 @@ class DoorayApiClient {
 ## 에러 처리 원칙
 
 - 모든 에러는 `DoorayCliError(message, exitCode)` 로 통일
-- `commands/*` 최상단에서 catch → stderr 출력 → `process.exit(exitCode)`
+- `commands/*` 최상단에서 catch: stderr 출력 후 `process.exit(exitCode)`
 - API 4xx: exitCode 1, 인증 401/403: exitCode 2, 파라미터: exitCode 3, config 없음: exitCode 4
 
 ## 출력 원칙

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -202,13 +202,17 @@ class DoorayApiClient {
 - `--quiet`: ID만 출력 (스크립팅용)
 - `--no-color`: 컬러 제거 (CI 환경, `NO_COLOR` env 자동 감지)
 - 스피너·에러: stderr / 데이터: stdout (파이프 시 stderr 오염 방지)
-- `--json` / `--quiet` 모드: spinner 완전 억제 (`setQuiet(true)` → `startSpinner` 가 no-op `Proxy<Ora>` 반환). jq 같은 파이프에서 stdout 청결 보장 (Issue #35 item 1)
+- `--json` / `--quiet` 모드: spinner 완전 억제 (`setQuiet(true)` → `startSpinner` 가 no-op `Proxy<Ora>` 반환).
+  jq 같은 파이프에서 stdout 청결 보장 (Issue #35 item 1)
 
 ## 테스트
 
 - vitest (코로케이션 `*.test.ts` 패턴 — 소스 옆에 테스트 배치)
 - `pnpm test` (단발) / `pnpm test:watch` (개발 중)
-- 현재 커버: `src/utils/dooray-url.ts` (URL parser), `src/resolvers/post-input.ts` (7-branch 분기, ADR-020), `src/resolvers/comment-file-input.ts` (option-mode/positional-mode 분기 + secondaryLabel 메시지 customization, plan025)
+- 현재 커버:
+  - `src/utils/dooray-url.ts` (URL parser)
+  - `src/resolvers/post-input.ts` (7-branch 분기, ADR-020)
+  - `src/resolvers/comment-file-input.ts` (option-mode/positional-mode 분기 + secondaryLabel 메시지 customization, plan025)
 - 신규 도메인 헬퍼·복잡 분기는 vitest 단위 테스트 동반 권장 (ADR-020 도입 근거)
 
 ## 빌드·배포

--- a/docs/data-schema.md
+++ b/docs/data-schema.md
@@ -17,7 +17,8 @@
     templates/{projectId}.json      # 프로젝트별 템플릿 목록 캐시 (ADR-027, TTL 24h)
 ```
 
-`templates/{projectId}.json` — `GET /project/v1/projects/{projectId}/templates` 응답의 id/templateName/메타만 보존 (body 는 미포함 — list 응답 자체가 body 제외). `--template <name|id>` 시 캐시에서 templateName 부분일치 후 단건 GET 으로 본문/interpolation 받음.
+`templates/{projectId}.json` — `GET /project/v1/projects/{projectId}/templates` 응답의 id/templateName/메타만 보존 (body 는 미포함 — list 응답 자체가 body 제외).
+`--template <name|id>` 시 캐시에서 templateName 부분일치 후 단건 GET 으로 본문/interpolation 받음.
 
 ---
 
@@ -129,7 +130,8 @@ interface CachedTag {
 }
 ```
 
-`post create/edit --tag <name>` 시 사전 검증 (mandatory-tag 그룹 누락 시 클라이언트 에러). `post edit --tag-remove`/`--tag-clear` 도 동일 캐시 사용 (Issue #66, ADR-019 확장).
+`post create/edit --tag <name>` 시 사전 검증 (mandatory-tag 그룹 누락 시 클라이언트 에러).
+`post edit --tag-remove`/`--tag-clear` 도 동일 캐시 사용 (Issue #66, ADR-019 확장).
 
 ### milestones/{projectId}.json (ADR-019)
 
@@ -151,7 +153,9 @@ interface CachedMemberGroup {
 }
 ```
 
-`post create/edit --mention-group <code>` 시 code lookup. members/ 와 분리된 별도 캐시 (Dooray 의 그룹 멘션 endpoint 가 별도). resolver 는 code 누락 그룹을 사전 필터링 + 후보 5개 안내 출력.
+`post create/edit --mention-group <code>` 시 code lookup.
+members/ 와 분리된 별도 캐시 — Dooray 의 그룹 멘션 endpoint 가 별도.
+resolver 는 code 누락 그룹을 사전 필터링 + 후보 5개 안내 출력.
 
 ### TTL 설계 근거
 

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -104,7 +104,9 @@ cc: []
 ```
 
 3. `$EDITOR` 실행 → 저장·종료
-4. frontmatter 파싱 → member resolver → API PUT 호출
+4. frontmatter 파싱 후:
+   - member resolver 실행
+   - API PUT 호출
 
 `$EDITOR` 미설정 시:
 

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -151,7 +151,8 @@ post `--id`/`--url` 모드도 동일 지원 — `dooray post comment list --id <
 
 ## 댓글 첨부파일 흐름 (ADR-024)
 
-`post comment file *` 4 명령은 사용자 멘탈 모델은 "댓글 첨부" 지만 내부적으론 post-level files API + 댓글 본문 PUT 으로 합성 (Dooray 가 댓글 전용 endpoint 미지원).
+`post comment file *` 4 명령의 사용자 멘탈 모델은 "댓글 첨부"다.
+내부적으론 post-level files API + 댓글 본문 PUT 합성으로 구현 (Dooray 가 댓글 전용 endpoint 미지원).
 
 ```
 dooray post comment file list my-project 42 <comment-id>            # 댓글 첨부 목록
@@ -164,7 +165,8 @@ dooray post comment file delete my-project 42 <comment-id> <file-id>    # 삭제
 
 ## 참조자(cc) / 담당자(to) 변경 흐름 (ADR-025)
 
-기존 업무의 참조자·담당자에 멤버 또는 그룹 추가/제거. 자동화 시나리오: 신규 업무 생성 후 후속으로 특정 그룹을 참조에 첨부.
+기존 업무의 참조자·담당자에 멤버 또는 그룹 추가/제거.
+자동화 시나리오: 신규 업무 생성 후 후속으로 특정 그룹을 참조에 첨부.
 
 ```
 # 멤버/그룹 추가 (append + dedupe)
@@ -204,7 +206,9 @@ dooray post create my-project --template "릴리스 플랜" \
   --tag "p0"                       # 템플릿 tags 를 덮음
 ```
 
-`interpolation=true` 가 기본 — Dooray 가 `${year}`, `${month}` 같은 시스템 매크로를 응답에서 자동 치환. 사용자 정의 변수 (`--field key=value`) 는 본 release scope 외 (별도 후속). 사용자 옵션이 명시 입력되면 템플릿 값을 override.
+`interpolation=true` 가 기본 — Dooray 가 `${year}`, `${month}` 같은 시스템 매크로를 응답에서 자동 치환.
+사용자 정의 변수 (`--field key=value`) 는 본 release scope 외 (별도 후속).
+사용자 옵션이 명시 입력되면 템플릿 값을 override.
 
 ## 상위 업무 변경 흐름 (Issue #60)
 
@@ -216,7 +220,8 @@ dooray post edit my-project 42 --parent my-project/40    # project/number
 dooray post edit --id <postId> --parent <parentPostId>   # 직접 postId
 ```
 
-내부적으로 `client.updatePost` (subject/body/users) → `client.setPostParent` (별도 `POST .../set-parent-post` endpoint) 순차 호출. 둘 다 무관 endpoint 라 atomic 보장 없음 — partial 실패 시 stderr 안내 + non-zero exit.
+내부적으로 `client.updatePost` (subject/body/users) → `client.setPostParent` (별도 `POST .../set-parent-post` endpoint) 순차 호출.
+둘 다 무관 endpoint 라 atomic 보장 없음 — partial 실패 시 stderr 안내 + non-zero exit.
 
 **한계**: Dooray API 가 `unset-parent-post` 미제공 → CLI 로 parent 해제 (top-level 화) 불가. 웹 UI 에서 수동 처리.
 
@@ -277,7 +282,8 @@ dooray feedback --title "버그" --body-file bug.md --label bug
 dooray feedback --last                           # 직전 명령 sanitized argv + 에러 자동 첨부 (opt-in)
 ```
 
-`--last` 사전 활성화: `dooray config set track-last-run true`. 시크릿 패턴 (`--api-key=*`, `Authorization: Bearer *` 등) 자동 마스킹.
+`--last` 사전 활성화: `dooray config set track-last-run true`.
+시크릿 패턴 (`--api-key=*`, `Authorization: Bearer *` 등) 자동 마스킹.
 
 ## 파이프라인 활용
 
@@ -299,7 +305,8 @@ dooray post file upload my-project 42 ./report.pdf     # 업로드
 dooray post file delete my-project 42 <file-id>        # 삭제
 ```
 
-업로드·다운로드 시 Dooray API는 307 리다이렉트로 파일 서버 URL을 반환한다. CLI가 자동 처리하므로 사용자는 신경 쓸 필요 없다.
+업로드·다운로드 시 Dooray API는 307 리다이렉트로 파일 서버 URL을 반환한다.
+CLI가 자동 처리하므로 사용자는 신경 쓸 필요 없다.
 
 ## 메일 흐름
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -31,7 +31,12 @@ CLI는 터미널이 있는 환경이면 어디서든 동작하고, 자연스러�
 - `dooray cache` — 캐시 관리
 - `dooray project` — 목록·멤버·워크플로우·템플릿 조회
 - `dooray member` — 표시명/이메일 조회 (`get`/`list`, ADR-021)
-- `dooray post` — 목록·검색·조회·생성·수정($EDITOR)·완료·상태변경 + `--tag`/`--parent`/`--workflow`/`--milestone` 메타데이터 (ADR-019) + `--mention`/`--mention-group`/`--link-task`/`--dry-run` (post comment 도 동일) + `--cc`/`--cc-group`/`--cc-clear`/`--to`/`--to-group`/`--to-clear` 참조자·담당자 추가/수정 (post edit, post create 는 `--*-group` 만 — ADR-025) + `post edit --parent <ref>` 상위 업무 변경 (dedicated `set-parent-post` endpoint — top-level 해제는 웹 UI) + `post create --template <name|id>` 정형 task (ADR-027, `project templates` 명령으로 목록 조회)
+- `dooray post` — 목록·검색·조회·생성·수정($EDITOR)·완료·상태변경
+  - 메타데이터: `--tag`, `--parent`, `--workflow`, `--milestone` (ADR-019)
+  - 인터랙션: `--mention`, `--mention-group`, `--link-task`, `--dry-run` (post comment 도 동일)
+  - 참조자·담당자: `--cc`, `--cc-group`, `--cc-clear`, `--to`, `--to-group`, `--to-clear` (post edit; post create 는 `--*-group` 만 — ADR-025)
+  - 상위 업무 변경: `post edit --parent <ref>` (dedicated `set-parent-post` endpoint, top-level 해제는 웹 UI)
+  - 정형 task: `post create --template <name|id>` (ADR-027, `project templates` 명령으로 목록 조회)
 - `dooray post comment` — 목록·추가·수정($EDITOR)·삭제
 - `dooray post file` — 목록·다운로드·전체다운로드·업로드·삭제 (v0.3.0)
 - `dooray post comment file` — 댓글 첨부 파일 목록·업로드·다운로드·삭제 (post-level files API + 댓글 PUT 합성, ADR-024)

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -45,7 +45,10 @@ dooray doctor                                 # 설정 검증
 
 자연어 요청을 커맨드로 변환할 때 아래 표를 참고한다.
 
-> **공통 (post 하위 16개 명령)**: `post get`/`edit`/`done`/`workflow`, `post comment list`/`add`/`edit`/`delete`, `post file list`/`upload`/`download`/`download-all`/`delete`, `post comment file list`/`upload`/`download`/`delete`는 `<project> <number>` 외에도 `--id <postId>`, `--url <url>`, 또는 첫 인자에 Dooray URL(`https://*.dooray.com/task/to/<postId>` 또는 브라우저 주소창 복사본 `https://*.dooray.com/task/<projectId>/<postId>`)을 직접 받는다. **사용자가 URL을 줬으면 그대로 첫 인자로 전달**하는 것이 가장 빠른 경로 (resolve 단계 단축, ADR-020).
+> **공통 (post 하위 16개 명령)**: 아래 명령은 `<project> <number>` 외에도 `--id <postId>`, `--url <url>`, 또는 첫 인자에 Dooray URL 을 직접 받는다.
+> `post get`/`edit`/`done`/`workflow`, `post comment list`/`add`/`edit`/`delete`, `post file list`/`upload`/`download`/`download-all`/`delete`, `post comment file list`/`upload`/`download`/`delete`.
+> URL 형식: `https://*.dooray.com/task/to/<postId>` 또는 브라우저 주소창 복사본 `https://*.dooray.com/task/<projectId>/<postId>`.
+> **사용자가 URL을 줬으면 그대로 첫 인자로 전달**하는 것이 가장 빠른 경로 (resolve 단계 단축, ADR-020).
 
 | 의도 | 커맨드 |
 |------|--------|
@@ -61,14 +64,14 @@ dooray doctor                                 # 설정 검증
 | 업무 목록 조회 | `dooray post list <project>` |
 | 업무 검색 | `dooray post search <project> "<keyword>"` |
 | 업무 상세 보기 | `dooray post get <project> <number>` |
-| 업무 생성 | `dooray post create <project> --title "..." --body "..."` 또는 `--body-file <path>` (`--body`와 `--body-file`은 동시 사용 불가, `--tag`/`--parent`/`--workflow`/`--milestone` 지원) |
+| 업무 생성 | `dooray post create <project> --title "..." [--body "..." \| --body-file <path>]` (`--tag`/`--parent`/`--workflow`/`--milestone` 지원) |
 | 템플릿 기반 업무 생성 | `dooray post create <project> --template <name\|id>` — body/users/tags 자동 채움 (사용자 옵션 우선 override, ADR-027) |
 | 업무 제목/본문 수정 | `dooray post edit <project> <number> --title "..." --body "..."` 또는 `--body-file <path>` |
 | 업무 완료 처리 | `dooray post done <project> <number>` |
 | 업무 워크플로우 변경 | `dooray post workflow <project> <number> <workflow>` |
-| 댓글 조회 | `dooray post comment list <project> <number>` — `--sort asc\|desc`, `--reverse`, `--latest <n>`, `--since <iso>`, `--from-author <name>` 필터 지원. table 출력은 Creator 이름 자동 채움, `--json`은 raw 유지 (ADR-021) |
+| 댓글 조회 | `dooray post comment list <project> <number>` (`--sort`, `--reverse`, `--latest`, `--since`, `--from-author` 필터. table: Creator 자동 채움, `--json`: raw, ADR-021) |
 | 최신 댓글 조회 | `dooray post comment latest <project> <number>` — 최신 댓글 1개 빠른 조회. `-n <N>`으로 N개 지정 |
-| 단일 댓글 조회 | `dooray post comment get <project> <number> <comment-id> --json` — 단일 댓글 본문·메타·attachments 직접 fetch. `comment list` 후 jq 필터 우회 불필요. `--id <postId> --comment-id <id>` / `--url <url> --comment-id <id>` 모드 지원 |
+| 단일 댓글 조회 | `dooray post comment get <project> <number> <comment-id>` — 본문·메타·attachments 직접 fetch. `--id`/`--url` + `--comment-id` 모드 지원 |
 | 댓글 추가 | `dooray post comment add <project> <number> --body "..."` 또는 `--body-file <path>` |
 | 댓글 수정 | `dooray post comment edit <project> <number> <comment-id> --body "..."` 또는 `--body-file <path>` |
 | 댓글 삭제 | `dooray post comment delete <project> <number> <comment-id>` |
@@ -97,7 +100,7 @@ dooray doctor                                 # 설정 검증
 | 참조자(cc) 멤버/그룹 추가 | `dooray post edit <project> <number> --cc-group <code>` — 기존 참조자 유지 + 그룹 추가 (dedupe, ADR-025) |
 | 참조자 전체 교체 | `dooray post edit <project> <number> --cc-clear --cc <name>` — 기존 참조자 비우고 신규 멤버만 |
 | 신규 업무 + 그룹 cc | `dooray post create <project> --title "..." --cc-group <code>` — 생성 시 그룹 참조자 포함 |
-| 상위 업무 설정/변경 | `dooray post edit <project> <number> --title "<원제목>" --parent <ref>` — `<ref>` 는 `<project>/<number>` 또는 raw postId. `--title` 미동반 시 interactive 모드로 진입해 무시. unset 미지원 (Issue #60) |
+| 상위 업무 설정/변경 | `dooray post edit <project> <number> --title "<원제목>" --parent <ref>` (`<ref>`: `<project>/<number>` 또는 raw postId. `--title` 필수, unset 미지원) |
 | `dooray post edit --id <postId> --tag <name>` | 태그 추가 (반복, dedupe) |
 | `dooray post edit --id <postId> --tag-clear --tag <name>` | 태그 전체 교체 |
 | `dooray post edit --id <postId> --tag-remove <name>` | 특정 태그 제거 |
@@ -112,7 +115,7 @@ CLI로 처리 **불가능한** 작업. 아래 항목을 요청받으면 웹 UI �
 
 | 작업 | 대체 경로 | 근거 |
 |---|---|---|
-| 위키 페이지 **삭제** | 웹 UI (`https://{tenant}.dooray.com/wiki/...`) | Dooray REST API에 해당 엔드포인트 없음 (위키 댓글·첨부파일 삭제는 있지만 페이지 자체는 없음 — ADR 또는 Dooray 공식 API 문서 미제공) |
+| 위키 페이지 **삭제** | 웹 UI (`https://{tenant}.dooray.com/wiki/...`) | Dooray REST API 미제공 (댓글·첨부파일 삭제는 있지만 페이지 삭제 endpoint 없음) |
 | 프로젝트 삭제 | 웹 UI (admin 페이지) | API 미지원 |
 
 위키 페이지를 잘못 만든 경우(테스트/중복) **soft delete(빈 제목·본문) 우회 금지** — 페이지가 트리에 남아 사용자 혼란 유발.
@@ -170,7 +173,8 @@ dooray post comment add <project> 42 --body "진행 상황 업데이트: 80% 완
 
 ### 시나리오 — 댓글에 스크린샷 자동 첨부
 
-스크립트가 스크린샷을 댓글에 삽입하거나, 에이전트가 결과 파일을 첨부 댓글로 보고할 때 사용. Dooray REST API 가 댓글 전용 attachment endpoint 를 미지원하므로 내부적으로 post-level files API + 댓글 본문 PUT 합성으로 동작 (ADR-024).
+스크립트가 스크린샷을 댓글에 삽입하거나, 에이전트가 결과 파일을 첨부 댓글로 보고할 때 사용.
+Dooray REST API 가 댓글 전용 attachment endpoint 를 미지원하므로 내부적으로 post-level files API + 댓글 본문 PUT 합성으로 동작 (ADR-024).
 
 ```bash
 # 1. 댓글을 먼저 만든다 (텍스트만, --json 으로 commentId 획득)
@@ -218,7 +222,8 @@ dooray wiki page get <project> <pageId> --json
 
 ### 업무 식별 방식 (post 하위 16개 명령 공통, ADR-020)
 
-`post get`/`edit`/`done`/`workflow`, `post comment list`/`add`/`edit`/`delete`, `post file list`/`upload`/`download`/`download-all`/`delete`, `post comment file list`/`upload`/`download`/`delete`는 4가지 입력을 모두 받는다:
+아래 16개 명령은 4가지 입력을 모두 받는다:
+`post get`/`edit`/`done`/`workflow`, `post comment list`/`add`/`edit`/`delete`, `post file list`/`upload`/`download`/`download-all`/`delete`, `post comment file list`/`upload`/`download`/`delete`.
 
 ```bash
 # (1) 기존 positional — 가장 익숙한 형태
@@ -234,7 +239,9 @@ dooray post get --id <postId>
 dooray post get --url https://x.dooray.com/task/to/<postId>
 ```
 
-**우선순위 / 충돌 규칙**: `--id`+`--url` 동시 지정 → 에러. `--id`/`--url`+positional 동시 지정 → 에러. URL/`--id`/`--url` 모드는 standalone API(`getPost(postId)`)로 resolve 단계를 단축.
+**우선순위 / 충돌 규칙**: `--id`+`--url` 동시 지정 → 에러.
+`--id`/`--url`+positional 동시 지정 → 에러.
+URL/`--id`/`--url` 모드는 standalone API(`getPost(postId)`)로 resolve 단계를 단축.
 
 **sub-id 옵션화** (URL/`--id`/`--url` 모드에서 필수):
 ```bash
@@ -273,7 +280,9 @@ dooray post create <project> \
 dooray post create <project> --title "제목" --body-file ./content.md
 ```
 
-> **`--workflow` 동작 주의**: 워크플로우 설정은 post 생성 *후속* 호출이므로, 워크플로우 resolve/설정에 실패해도 stderr 경고만 출력되고 **exit code는 0** (post는 이미 생성됨). 자동화 스크립트에서 워크플로우 적용 여부를 보장해야 하면 stderr를 별도 점검할 것.
+> **`--workflow` 동작 주의**: 워크플로우 설정은 post 생성 *후속* 호출.
+> resolve/설정에 실패해도 stderr 경고만 출력되고 **exit code는 0** (post는 이미 생성됨).
+> 자동화 스크립트에서 워크플로우 적용 여부를 보장해야 하면 stderr를 별도 점검할 것.
 
 ### 업무 수정 (non-interactive)
 
@@ -415,7 +424,8 @@ dooray post comment add P 1 --mention 홍길동 --mention-group 개발 --body ".
 
 ## Dooray 마크다운 링크 형식 (멤버·그룹·업무 멘션)
 
-댓글/본문 작성 시 다음 형식으로 마크업하면 Dooray 앱이 인식해 inline 멘션·navigation으로 렌더링한다. ID는 본인 환경 값으로 채워 사용 — `dooray member get` / `project groups` / `post get` 등으로 조회.
+댓글/본문 작성 시 다음 형식으로 마크업하면 Dooray 앱이 인식해 inline 멘션·navigation으로 렌더링한다.
+ID는 본인 환경 값으로 채워 사용 — `dooray member get` / `project groups` / `post get` 등으로 조회.
 
 ### 멤버 멘션
 ```markdown
@@ -467,7 +477,8 @@ dooray feedback --last --title "에러 제목" --body "추가 설명" --dry-run 
 dooray feedback --last --title "에러 제목" --body "추가 설명"            # 실제 등록
 ```
 
-> **참고**: `--last` 모드는 `trackLastRun: true` (ADR-023 opt-in)가 설정된 경우에만 직전 실패 명령이 자동 기록됨. argv는 시크릿 패턴(`--api-key`/`--token`/`Authorization`) 마스킹 후 저장.
+> **참고**: `--last` 모드는 `trackLastRun: true` (ADR-023 opt-in)가 설정된 경우에만 직전 실패 명령이 자동 기록됨.
+> argv는 시크릿 패턴(`--api-key`/`--token`/`Authorization`) 마스킹 후 저장.
 
 ## 에러 핸들링
 
@@ -496,7 +507,8 @@ POST_ID=$(dooray post create <project> \
   --json | jq -r '.id')
 ```
 
-템플릿 본문의 `${year}` / `${month}` 등 매크로는 Dooray 가 자동 치환 (`interpolation=true` 기본). 사용자 정의 변수는 미지원 — 필요 시 client 측 string replace 로 처리.
+템플릿 본문의 `${year}` / `${month}` 등 매크로는 Dooray 가 자동 치환 (`interpolation=true` 기본).
+사용자 정의 변수는 미지원 — 필요 시 client 측 string replace 로 처리.
 
 ## 캐시
 

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -332,11 +332,17 @@ MEMBER_ID=$(dooray member search 홍길동 --json | jq -r '.[] | select(.externa
 dooray post edit --id "$POST_ID" --cc "$MEMBER_ID"
 ```
 
-`--to` / `--mention` 동일 분기 (resolveMember 인프라). 분기 규칙: `^\d{15,}$` → memberId / 이메일 정규형 → searchMembers exact / 그 외 → 이름 부분일치.
+`--to` / `--mention` 동일 분기 (resolveMember 인프라). 분기 규칙:
+- `^\d{15,}$` — memberId 직접 사용
+- 이메일 정규형 — searchMembers exact
+- 그 외 — 이름 부분일치
 
 ## 신규 업무 생성 후 그룹 cc 첨부 (ADR-025)
 
-audit 리포트 분석 → 신규 업무 생성 → 후속으로 특정 그룹을 참조에 추가하는 자동화 패턴:
+자동화 패턴:
+1. audit 리포트 분석
+2. 신규 업무 생성
+3. 후속으로 특정 그룹을 참조에 추가
 
 ```bash
 # 1. 신규 업무 생성 (그룹 cc 포함)

--- a/tasks/034-chore-docs-readability-backfill/index.json
+++ b/tasks/034-chore-docs-readability-backfill/index.json
@@ -2,8 +2,8 @@
   "name": "034-chore-docs-readability-backfill",
   "description": "기존 docs 의 가독성 backfill — CLAUDE.md \"docs / ADR 작성 형식\" 5 패턴 처방을 ADR.md / planning docs 4개 / README / SKILL.md 에 일괄 적용. 정책 본문 + planning/SKILL.md 역참조는 task 생성 시점에 main 직접 commit 으로 선반영. 검증 자동화 없음 (정책만 명시). manual Edit 필수 — sed 일괄 치환은 자기참조 위험 (common-pitfalls 1-11). 범위 외: docs/guide-mvp-with-ai-agent.md (v1 구현 공유용 가이드, 사용자 명시 제외).",
   "created_at": "2026-05-18T02:23:41Z",
-  "status": "pending",
-  "current_phase": 1,
+  "status": "completed",
+  "current_phase": 3,
   "total_phases": 3,
   "error_message": null,
   "blocked_reason": null,
@@ -12,21 +12,21 @@
       "number": 1,
       "title": "docs/adr.md ADR-001~027 본문 정리 (5 패턴 처방 적용)",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 2,
       "title": "docs/{code-architecture,prd,flow,data-schema}.md 정리",
       "file": "phase-02.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 3,
       "title": "README.md + skills/dooray-cli/SKILL.md 정리 + 완료 마킹",
       "file": "phase-03.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],

--- a/tasks/034-chore-docs-readability-backfill/index.json
+++ b/tasks/034-chore-docs-readability-backfill/index.json
@@ -1,6 +1,6 @@
 {
   "name": "034-chore-docs-readability-backfill",
-  "description": "기존 docs 의 가독성 backfill — CLAUDE.md \"docs / ADR 작성 형식\" 5 패턴 처방을 ADR.md / planning docs 4개 / README / SKILL.md 에 일괄 적용. 정책 본문 + planning/SKILL.md 역참조는 task 생성 시점에 main 직접 commit 으로 선반영. 검증 자동화 없음 (정책만 명시). manual Edit 필수 — sed 일괄 치환은 자기참조 위험 (common-pitfalls 1-11).",
+  "description": "기존 docs 의 가독성 backfill — CLAUDE.md \"docs / ADR 작성 형식\" 5 패턴 처방을 ADR.md / planning docs 4개 / README / SKILL.md 에 일괄 적용. 정책 본문 + planning/SKILL.md 역참조는 task 생성 시점에 main 직접 commit 으로 선반영. 검증 자동화 없음 (정책만 명시). manual Edit 필수 — sed 일괄 치환은 자기참조 위험 (common-pitfalls 1-11). 범위 외: docs/guide-mvp-with-ai-agent.md (v1 구현 공유용 가이드, 사용자 명시 제외).",
   "created_at": "2026-05-18T02:23:41Z",
   "status": "pending",
   "current_phase": 1,

--- a/tasks/034-chore-docs-readability-backfill/phase-01.md
+++ b/tasks/034-chore-docs-readability-backfill/phase-01.md
@@ -88,7 +88,6 @@ wc -c docs/adr.md
 위 점검 통과 시 commit:
 
 ```bash
-git add docs/adr.md tasks/034-chore-docs-readability-backfill/index.json
 # index.json 은 phase-03 에서 마킹 — phase-01 commit 에는 미포함
 git add docs/adr.md
 git commit -m "$(cat <<'EOF'

--- a/tasks/034-chore-docs-readability-backfill/phase-02.md
+++ b/tasks/034-chore-docs-readability-backfill/phase-02.md
@@ -10,6 +10,9 @@ phase-01 의 5 패턴 처방을 planning docs 4개에 적용한다. ADR.md 와 �
 - `docs/flow.md` — 사용자 흐름 시나리오
 - `docs/data-schema.md` — 캐시 디렉터리 + 스키마
 
+**범위 외 (명시적 제외)**:
+- `docs/guide-mvp-with-ai-agent.md` — v1 구현 공유용 가이드 문서. 본 task scope 외 (사용자 결정, plan034 REVISE 사이클).
+
 ## 변경 파일
 
 기대 결과 (총 4 파일):


### PR DESCRIPTION
## Summary

CLAUDE.md \"docs / ADR 작성 형식\" 5 패턴 처방을 기존 docs 에 일괄 적용 (코드 변경 0, docs-only).

- ADR-001~027 본문 정리 (Index/헤딩/anchor 보존, 의사결정 무손실)
- `docs/{code-architecture,prd,flow,data-schema}.md` 정리
- `README.md`, `skills/dooray-cli/SKILL.md` 정리
- 범위 외 (의도적 제외): `docs/guide-mvp-with-ai-agent.md` (v1 구현 공유용 가이드)

## Commits

\`\`\`
c2528ed fix(docs): flatten multi-→ patterns to bullet/numbered lists (plan034 code-review)
7ded1d4 chore(docs): backfill README + skills/dooray-cli/SKILL.md to 5-pattern style; complete task 034
83ae7e8 chore(docs): backfill planning docs to 5-pattern readability style
6d0447c chore(docs): backfill ADR-001~027 to 5-pattern readability style (Issue #N/A)
a161164 chore(task): apply critic REVISE fixes (plan034)
\`\`\`

## 5 패턴 처방

1. semantic line break (문장당 1줄)
2. enumerated inline 금지 (① / 1) / slash 3+ → bullet)
3. 괄호 중첩 2겹 금지
4. `=` / `→` 동치·인과 압축 한 단락 1회
5. 긴 문장 의미 단위 분할

## Test plan

docs-only — 빌드/테스트 영향 없음.

- [x] 200자 초과 prose 행: 전 대상 0건
- [x] enumerated inline: 0건
- [x] PII gate: 0건 (사내 식별자·19자리 numeric)
- [x] ADR Index 24행·헤딩 24개 보존
- [x] critic APPROVE (1 REVISE 후)
- [x] code-reviewer PASS (1 FIX 후)
- [x] docs-verifier PASS