### PR TITLE
feat(wiki): add wiki page file 5 commands (Issue #70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,43 @@ dooray wiki page edit <project> <page-id> --body "..." | --body-file <path>  # �
 dooray wiki page edit <project> <page-id>                                     # $EDITOR (플래그 없을 때)
 ```
 
+#### 위키 페이지 첨부파일 (Issue #70)
+
+post 의 `post file` 명령군과 동일 패턴 — `<project> <page-id>` 외에도 `--id`/`--url`/positional URL 지원.
+
+```bash
+# 목록 (general 첨부 + inline image 둘 다 표시, type 컬럼)
+dooray wiki page file list <project> <page-id>
+
+# 업로드 (기본 general — 페이지 하단 첨부 영역)
+dooray wiki page file upload <project> <page-id> --file ./SKILL.md
+# stdout: attachFileId + 파일 메타 출력
+
+# 인라인 이미지 업로드 (본문 markdown 은 사용자가 직접 박음)
+dooray wiki page file upload <project> <page-id> --file ./diagram.png --type inline_image
+# stdout 에 본문 삽입용 markdown snippet 안내
+
+# 다운로드
+dooray wiki page file download <project> <page-id> --file-id <id> -o ./
+
+# 페이지 모든 첨부 (files + images) 일괄 다운로드
+dooray wiki page file download-all <project> <page-id> -o ./attachments/
+
+# 삭제 (confirm 없이 즉시)
+dooray wiki page file delete <project> <page-id> --file-id <id>
+
+# URL 모드 (--id 모드는 --project 동반 필요)
+dooray wiki page file list "https://<tenant>.dooray.com/wiki/<wikiId>/<pageId>"
+dooray wiki page file upload --id <pageId> --project <project> --file ./README.md
+```
+
+**주의**:
+- `upload` 시 multipart 필드 순서 (`type` → `file`) 가 중요.
+  클라이언트가 자동으로 강제 (ADR-029 참조)
+- `inline_image` 로 올린 파일은 본문에 markdown 으로 박혀야 위키에서 보임.
+  upload stdout 의 snippet 을 복사해서 `dooray wiki page edit` 으로 본문에 직접 추가
+- `delete` 는 confirm 없이 즉시 삭제 (실수 방지 책임은 호출자)
+
 ### 메일
 
 IMAP을 통해 Dooray 메일을 조회할 수 있습니다. 메일 설정은 `dooray setup`에서 한 번에 진행하거나, 수동으로 설정할 수 있습니다.

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -82,6 +82,11 @@ dooray doctor                                 # 설정 검증
 | 위키 페이지 수정 (제목) | `dooray wiki page edit <project> <page-id> --title "..."` |
 | 위키 페이지 수정 (본문) | `dooray wiki page edit <project> <page-id> --body "..."` 또는 `--body-file ./new.md` |
 | 위키 페이지 수정 (에디터) | `dooray wiki page edit <project> <page-id>` (플래그 없으면 $EDITOR 열림) |
+| 위키 페이지 첨부 목록 | `dooray wiki page file list <project> <page-id>` (general + inline 합산, type 컬럼) |
+| 위키 페이지 첨부 업로드 | `dooray wiki page file upload <project> <page-id> --file <path> [--type inline_image]` (multipart type 순서 ADR-029) |
+| 위키 페이지 첨부 다운로드 | `dooray wiki page file download <project> <page-id> --file-id <id> -o <dir>` |
+| 위키 페이지 첨부 일괄 다운로드 | `dooray wiki page file download-all <project> <page-id> -o <dir>` (files + images 전부) |
+| 위키 페이지 첨부 삭제 | `dooray wiki page file delete <project> <page-id> --file-id <id>` (confirm 없음) |
 | 메일 목록 조회 | `dooray mail list` |
 | 안읽은 메일 | `dooray mail list --unread` |
 | 메일 제목 검색 | `dooray mail list --search "<keyword>"` |
@@ -193,6 +198,21 @@ dooray wiki pages <project> --json
 
 # 2. 페이지 내용 조회
 dooray wiki page get <project> <pageId> --json
+```
+
+### 위키 페이지 첨부파일 — 스킬 파일 팀 공유 (Issue #70)
+
+**스킬 파일 팀 공유**: 팀 위키에 스킬 파일 (예: `SKILL.md`) 을 `wiki page file upload` 로 첨부 → 팀원이 `wiki page file download-all` 로 일괄 받아 `~/.claude/skills/` 에 그대로 설치.
+
+```bash
+# 업로드 (일반 첨부)
+dooray wiki page file upload <project> <page-id> --file ~/.claude/skills/my-skill/SKILL.md
+
+# 팀원 쪽에서 일괄 다운로드
+dooray wiki page file download-all <project> <page-id> -o ~/.claude/skills/my-skill/
+
+# 첨부 목록 확인 (type 컬럼: general / inline_image)
+dooray wiki page file list <project> <page-id>
 ```
 
 ## 단일 댓글 본문 fetch

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -38,6 +38,8 @@ import type {
   UpdateWikiPageRequest,
   UpdateWikiPageTitleRequest,
   UpdateWikiPageContentRequest,
+  WikiPageFileType,
+  UploadWikiPageFileResponse,
   DoorayApiUnitResponse,
   DoorayErrorResponse,
   PostFileListResponse,
@@ -664,6 +666,114 @@ export class DoorayApiClient {
     try {
       return await this.api
         .delete(`project/v1/projects/${projectId}/posts/${postId}/files/${fileId}`)
+        .json<DoorayApiUnitResponse>();
+    } catch (e) {
+      throw await toDoorayCliError(e);
+    }
+  }
+
+  // ─── Wiki Page Files (ADR-029) ──────────────────────
+
+  async uploadWikiPageFile(
+    wikiId: string,
+    pageId: string,
+    filePath: string,
+    type: WikiPageFileType,
+  ): Promise<UploadWikiPageFileResponse> {
+    try {
+      const fileName = basename(filePath);
+      const fileBuffer = await readFile(filePath);
+
+      // ADR-029: type 필드를 file 필드보다 먼저 append (Dooray 서버 순서 의존)
+      const buildFormData = (): FormData => {
+        const fd = new FormData();
+        fd.append("type", type);
+        fd.append("file", new Blob([fileBuffer]), fileName);
+        return fd;
+      };
+
+      const url = `${this.baseUrl}wiki/v1/wikis/${wikiId}/pages/${pageId}/files`;
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { Authorization: this.authHeader },
+        body: buildFormData(),
+        redirect: "manual",
+      });
+
+      if (res.status === 307) {
+        const location = res.headers.get("location");
+        if (!location) {
+          throw new DoorayCliError("위키 파일 업로드 리다이렉트 URL을 받지 못했습니다.", EXIT_API_ERROR);
+        }
+        // 재시도 시에도 FormData 새로 빌드 (type → file 순서 보장)
+        const uploadRes = await fetch(location, {
+          method: "POST",
+          headers: { Authorization: this.authHeader },
+          body: buildFormData(),
+        });
+        if (!uploadRes.ok) {
+          throw new DoorayCliError(`위키 파일 업로드 실패 (${uploadRes.status})`, EXIT_API_ERROR);
+        }
+        return await uploadRes.json() as UploadWikiPageFileResponse;
+      }
+
+      if (!res.ok) {
+        throw new DoorayCliError(`위키 파일 업로드 실패 (${res.status})`, EXIT_API_ERROR);
+      }
+      return await res.json() as UploadWikiPageFileResponse;
+    } catch (e) {
+      if (e instanceof DoorayCliError) throw e;
+      throw await toDoorayCliError(e);
+    }
+  }
+
+  async downloadWikiPageFile(
+    wikiId: string,
+    pageId: string,
+    fileId: string,
+  ): Promise<{ buffer: ArrayBuffer; fileName: string }> {
+    try {
+      const res = await this.api
+        .get(`wiki/v1/wikis/${wikiId}/pages/${pageId}/files/${fileId}`, {
+          redirect: "manual",
+          throwHttpErrors: false,
+        });
+
+      const location = res.headers.get("location");
+      if (!location) {
+        throw new DoorayCliError("위키 파일 다운로드 리다이렉트 URL을 받지 못했습니다.", EXIT_API_ERROR);
+      }
+
+      const fileRes = await fetch(location, {
+        headers: { Authorization: this.authHeader },
+      });
+      if (!fileRes.ok) {
+        throw new DoorayCliError(`위키 파일 다운로드 실패 (${fileRes.status})`, EXIT_API_ERROR);
+      }
+
+      const disposition = fileRes.headers.get("content-disposition");
+      let fileName = `file-${fileId}`;
+      if (disposition) {
+        const match = disposition.match(/filename\*?=(?:UTF-8''|"?)([^";]+)/i);
+        if (match) fileName = decodeURIComponent(match[1].replace(/"/g, ""));
+      }
+
+      const buffer = await fileRes.arrayBuffer();
+      return { buffer, fileName };
+    } catch (e) {
+      if (e instanceof DoorayCliError) throw e;
+      throw await toDoorayCliError(e);
+    }
+  }
+
+  async deleteWikiPageFile(
+    wikiId: string,
+    pageId: string,
+    fileId: string,
+  ): Promise<DoorayApiUnitResponse> {
+    try {
+      return await this.api
+        .delete(`wiki/v1/wikis/${wikiId}/pages/${pageId}/files/${fileId}`)
         .json<DoorayApiUnitResponse>();
     } catch (e) {
       throw await toDoorayCliError(e);

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -739,6 +739,15 @@ export class DoorayApiClient {
           throwHttpErrors: false,
         });
 
+      // ADR-015: 파일 다운로드 endpoint 는 항상 307 redirect 응답.
+      // 307 외 status 는 에러 (200 직접 응답 케이스는 Dooray 가 보장하지 않음).
+      if (res.status !== 307) {
+        throw new DoorayCliError(
+          `위키 파일 다운로드 실패 (예상 status 307, 실제 ${res.status})`,
+          EXIT_API_ERROR,
+        );
+      }
+
       const location = res.headers.get("location");
       if (!location) {
         throw new DoorayCliError("위키 파일 다운로드 리다이렉트 URL을 받지 못했습니다.", EXIT_API_ERROR);
@@ -755,7 +764,8 @@ export class DoorayApiClient {
       let fileName = `file-${fileId}`;
       if (disposition) {
         const match = disposition.match(/filename\*?=(?:UTF-8''|"?)([^";]+)/i);
-        if (match) fileName = decodeURIComponent(match[1].replace(/"/g, ""));
+        // basename 으로 path traversal 방지 (서버 응답 헤더의 ../ 등 제거)
+        if (match) fileName = basename(decodeURIComponent(match[1].replace(/"/g, "")));
       }
 
       const buffer = await fileRes.arrayBuffer();

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -451,6 +451,12 @@ export interface WikiPageBody {
   content?: string;
 }
 
+export interface WikiPageFile {
+  id: string;
+  name: string;
+  size: number;
+}
+
 export interface WikiPageDetail {
   id: string;
   wikiId: string;
@@ -462,6 +468,8 @@ export interface WikiPageDetail {
   createdAt?: string;
   updatedAt?: string;
   parentPageId?: string;
+  files?: WikiPageFile[];
+  images?: WikiPageFile[];
 }
 
 export type WikiPageResponse = DoorayApiResponse<WikiPageDetail>;
@@ -492,6 +500,20 @@ export interface UpdateWikiPageTitleRequest {
 export interface UpdateWikiPageContentRequest {
   body: WikiPageBody;
 }
+
+export type WikiPageFileType = "general" | "inline_image";
+
+export interface UploadWikiPageFileResult {
+  id: string;
+  attachFileId: string;
+  name: string;
+  mimeType: string;
+  type: WikiPageFileType;
+  size: number;
+  createdAt: string;
+}
+
+export type UploadWikiPageFileResponse = DoorayApiResponse<UploadWikiPageFileResult>;
 
 export interface CreateWikiPageResult {
   id: string;

--- a/src/commands/wiki/page-file/delete.ts
+++ b/src/commands/wiki/page-file/delete.ts
@@ -1,0 +1,80 @@
+import { Command } from "commander";
+import { getConfigOrThrow } from "../../../config/store.js";
+import { DoorayApiClient } from "../../../api/client.js";
+import { resolveWikiPageInput } from "../../../resolvers/wiki-page-input.js";
+import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
+import { DoorayCliError } from "../../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
+
+export const wikiPageFileDeleteCommand = new Command("delete")
+  .description("위키 페이지 첨부파일 삭제")
+  .argument("[arg1]", "프로젝트 코드, Dooray Wiki URL, 또는 (`--id`/`--url` 모드일 때) 파일 ID")
+  .argument("[arg2]", "page-id 또는 (`--id`/`--url` 모드일 때) 파일 ID")
+  .argument("[arg3]", "파일 ID (positional 3개 모드)")
+  .option("--id <pageId>", "위키 페이지 ID")
+  .option("--url <url>", "Dooray Wiki URL")
+  .option("--project <code>", "프로젝트 코드 (--id 모드에서 wikiId 해석용)")
+  .option("--file-id <fileId>", "파일 ID (positional 대체)")
+  .action(async (arg1, arg2, arg3, opts) => {
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+
+    let projectArg: string | undefined;
+    let pageIdArg: string | undefined;
+    let fileId: string | undefined = opts.fileId;
+
+    if (opts.id || opts.url) {
+      if (arg2 || arg3) {
+        throw new DoorayCliError(
+          "--id/--url 모드에서는 파일 ID 외 추가 positional 인자를 받지 않습니다. --file-id 옵션 사용을 권장합니다.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+      fileId = fileId ?? arg1;
+    } else if (arg3) {
+      projectArg = arg1;
+      pageIdArg = arg2;
+      fileId = fileId ?? arg3;
+    } else if (arg1 && !arg2) {
+      projectArg = arg1;
+      if (!fileId) {
+        throw new DoorayCliError(
+          "URL/--id 모드에서는 --file-id 옵션이 필요합니다.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+    } else {
+      projectArg = arg1;
+      pageIdArg = arg2;
+      if (!fileId) {
+        throw new DoorayCliError(
+          "<file-id>가 필요합니다. positional 3번째 또는 --file-id 옵션을 사용하세요.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+    }
+
+    if (!fileId) {
+      throw new DoorayCliError("파일 ID가 필요합니다.", EXIT_PARAM_ERROR);
+    }
+
+    // resolveWikiPageInput 을 startSpinner 보다 먼저 호출 (1-1 회피)
+    const { wikiId, pageId } = await resolveWikiPageInput(client, {
+      projectArg,
+      pageIdArg,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+      project: opts.project,
+    });
+
+    startSpinner("파일 삭제 중...");
+    try {
+      await client.deleteWikiPageFile(wikiId, pageId, fileId);
+      stopSpinner(true, "삭제 완료");
+
+      process.stdout.write(`파일(${fileId})이 삭제되었습니다.\n`);
+    } catch (e) {
+      stopSpinner(false);
+      throw e;
+    }
+  });

--- a/src/commands/wiki/page-file/download-all.ts
+++ b/src/commands/wiki/page-file/download-all.ts
@@ -5,6 +5,8 @@ import { getConfigOrThrow } from "../../../config/store.js";
 import { DoorayApiClient } from "../../../api/client.js";
 import { resolveWikiPageInput } from "../../../resolvers/wiki-page-input.js";
 import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
+import { DoorayCliError } from "../../../utils/errors.js";
+import { EXIT_API_ERROR } from "../../../utils/exit-codes.js";
 import type { WikiPageFile } from "../../../api/types.js";
 
 export const wikiPageFileDownloadAllCommand = new Command("download-all")
@@ -65,6 +67,9 @@ export const wikiPageFileDownloadAllCommand = new Command("download-all")
 
     process.stdout.write(`\n완료: ${successCount}/${allFiles.length}\n`);
     if (failures.length > 0) {
-      process.exit(1);
+      throw new DoorayCliError(
+        `${failures.length}개 파일 다운로드 실패 (성공: ${successCount}/${allFiles.length})`,
+        EXIT_API_ERROR,
+      );
     }
   });

--- a/src/commands/wiki/page-file/download-all.ts
+++ b/src/commands/wiki/page-file/download-all.ts
@@ -1,0 +1,70 @@
+import { Command } from "commander";
+import { writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { getConfigOrThrow } from "../../../config/store.js";
+import { DoorayApiClient } from "../../../api/client.js";
+import { resolveWikiPageInput } from "../../../resolvers/wiki-page-input.js";
+import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
+import type { WikiPageFile } from "../../../api/types.js";
+
+export const wikiPageFileDownloadAllCommand = new Command("download-all")
+  .description("위키 페이지의 모든 첨부파일 다운로드 (general + inline image)")
+  .argument("[project]", "프로젝트 코드 (또는 첫 인자에 Dooray Wiki URL)")
+  .argument("[page-id]", "위키 페이지 ID (project와 함께 사용)")
+  .option("--id <pageId>", "위키 페이지 ID (--project 동반 필요)")
+  .option("--url <url>", "Dooray Wiki URL")
+  .option("--project <code>", "프로젝트 코드 (--id 모드에서 wikiId 해석용)")
+  .option("-o, --output <dir>", "저장 디렉토리", ".")
+  .action(async (project, pageIdArg, opts) => {
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+
+    // resolveWikiPageInput 을 startSpinner 보다 먼저 호출 (1-1 회피)
+    const { wikiId, pageId } = await resolveWikiPageInput(client, {
+      projectArg: project,
+      pageIdArg,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+      project: opts.project,
+    });
+
+    startSpinner("파일 목록 조회 중...");
+    let allFiles: WikiPageFile[];
+    try {
+      const pageRes = await client.getWikiPage(wikiId, pageId);
+      allFiles = [...(pageRes.result.files ?? []), ...(pageRes.result.images ?? [])];
+    } catch (e) {
+      stopSpinner(false);
+      throw e;
+    }
+
+    if (allFiles.length === 0) {
+      stopSpinner(true, "첨부파일 없음");
+      process.stdout.write("첨부파일이 없습니다.\n");
+      return;
+    }
+
+    stopSpinner(true, `${allFiles.length}개 파일 다운로드 시작`);
+
+    await mkdir(opts.output, { recursive: true });
+
+    let successCount = 0;
+    const failures: { fileId: string; error: string }[] = [];
+
+    for (const f of allFiles) {
+      try {
+        const { buffer, fileName } = await client.downloadWikiPageFile(wikiId, pageId, f.id);
+        await writeFile(join(opts.output, fileName), Buffer.from(buffer));
+        process.stdout.write(`✓ ${fileName}\n`);
+        successCount++;
+      } catch (e) {
+        failures.push({ fileId: f.id, error: e instanceof Error ? e.message : String(e) });
+        process.stderr.write(`✗ ${f.name} (${f.id}): ${e instanceof Error ? e.message : String(e)}\n`);
+      }
+    }
+
+    process.stdout.write(`\n완료: ${successCount}/${allFiles.length}\n`);
+    if (failures.length > 0) {
+      process.exit(1);
+    }
+  });

--- a/src/commands/wiki/page-file/download.ts
+++ b/src/commands/wiki/page-file/download.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import { writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { getConfigOrThrow } from "../../../config/store.js";
 import { DoorayApiClient } from "../../../api/client.js";
 import { resolveWikiPageInput } from "../../../resolvers/wiki-page-input.js";
@@ -73,7 +73,8 @@ export const wikiPageFileDownloadCommand = new Command("download")
     startSpinner("파일 다운로드 중...");
     try {
       const { buffer, fileName } = await client.downloadWikiPageFile(wikiId, pageId, fileId);
-      const outputPath = join(opts.output, fileName);
+      // 방어적 basename — client 가 이미 sanitize 하지만 출력 경로 조합 전 한 번 더
+      const outputPath = join(opts.output, basename(fileName));
       await writeFile(outputPath, Buffer.from(buffer));
       stopSpinner(true, `다운로드 완료: ${outputPath}`);
 

--- a/src/commands/wiki/page-file/download.ts
+++ b/src/commands/wiki/page-file/download.ts
@@ -1,0 +1,85 @@
+import { Command } from "commander";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { getConfigOrThrow } from "../../../config/store.js";
+import { DoorayApiClient } from "../../../api/client.js";
+import { resolveWikiPageInput } from "../../../resolvers/wiki-page-input.js";
+import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
+import { DoorayCliError } from "../../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
+
+export const wikiPageFileDownloadCommand = new Command("download")
+  .description("위키 페이지 첨부파일 다운로드")
+  .argument("[arg1]", "프로젝트 코드, Dooray Wiki URL, 또는 (`--id`/`--url` 모드일 때) 파일 ID")
+  .argument("[arg2]", "page-id 또는 (`--id`/`--url` 모드일 때) 파일 ID")
+  .argument("[arg3]", "파일 ID (positional 3개 모드)")
+  .option("--id <pageId>", "위키 페이지 ID")
+  .option("--url <url>", "Dooray Wiki URL")
+  .option("--project <code>", "프로젝트 코드 (--id 모드에서 wikiId 해석용)")
+  .option("--file-id <fileId>", "파일 ID (positional 대체)")
+  .option("-o, --output <dir>", "저장 디렉토리", ".")
+  .action(async (arg1, arg2, arg3, opts) => {
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+
+    let projectArg: string | undefined;
+    let pageIdArg: string | undefined;
+    let fileId: string | undefined = opts.fileId;
+
+    if (opts.id || opts.url) {
+      if (arg2 || arg3) {
+        throw new DoorayCliError(
+          "--id/--url 모드에서는 파일 ID 외 추가 positional 인자를 받지 않습니다. --file-id 옵션 사용을 권장합니다.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+      fileId = fileId ?? arg1;
+    } else if (arg3) {
+      projectArg = arg1;
+      pageIdArg = arg2;
+      fileId = fileId ?? arg3;
+    } else if (arg1 && !arg2) {
+      projectArg = arg1;
+      if (!fileId) {
+        throw new DoorayCliError(
+          "URL/--id 모드에서는 --file-id 옵션이 필요합니다.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+    } else {
+      projectArg = arg1;
+      pageIdArg = arg2;
+      if (!fileId) {
+        throw new DoorayCliError(
+          "<file-id>가 필요합니다. positional 3번째 또는 --file-id 옵션을 사용하세요.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+    }
+
+    if (!fileId) {
+      throw new DoorayCliError("파일 ID가 필요합니다.", EXIT_PARAM_ERROR);
+    }
+
+    // resolveWikiPageInput 을 startSpinner 보다 먼저 호출 (1-1 회피)
+    const { wikiId, pageId } = await resolveWikiPageInput(client, {
+      projectArg,
+      pageIdArg,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+      project: opts.project,
+    });
+
+    startSpinner("파일 다운로드 중...");
+    try {
+      const { buffer, fileName } = await client.downloadWikiPageFile(wikiId, pageId, fileId);
+      const outputPath = join(opts.output, fileName);
+      await writeFile(outputPath, Buffer.from(buffer));
+      stopSpinner(true, `다운로드 완료: ${outputPath}`);
+
+      process.stdout.write(`${outputPath}\n`);
+    } catch (e) {
+      stopSpinner(false);
+      throw e;
+    }
+  });

--- a/src/commands/wiki/page-file/index.ts
+++ b/src/commands/wiki/page-file/index.ts
@@ -1,0 +1,15 @@
+import { Command } from "commander";
+import { wikiPageFileListCommand } from "./list.js";
+import { wikiPageFileUploadCommand } from "./upload.js";
+import { wikiPageFileDownloadCommand } from "./download.js";
+import { wikiPageFileDownloadAllCommand } from "./download-all.js";
+import { wikiPageFileDeleteCommand } from "./delete.js";
+
+export const wikiPageFileCommand = new Command("file")
+  .description("위키 페이지 첨부파일 관련 명령 (Issue #70, ADR-029)");
+
+wikiPageFileCommand.addCommand(wikiPageFileListCommand);
+wikiPageFileCommand.addCommand(wikiPageFileUploadCommand);
+wikiPageFileCommand.addCommand(wikiPageFileDownloadCommand);
+wikiPageFileCommand.addCommand(wikiPageFileDownloadAllCommand);
+wikiPageFileCommand.addCommand(wikiPageFileDeleteCommand);

--- a/src/commands/wiki/page-file/list.ts
+++ b/src/commands/wiki/page-file/list.ts
@@ -1,0 +1,53 @@
+import { Command } from "commander";
+import { getConfigOrThrow } from "../../../config/store.js";
+import { DoorayApiClient } from "../../../api/client.js";
+import { resolveWikiPageInput } from "../../../resolvers/wiki-page-input.js";
+import { output, type OutputOptions } from "../../../formatters/table.js";
+import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+export const wikiPageFileListCommand = new Command("list")
+  .description("위키 페이지 첨부파일 목록 조회 (general + inline image)")
+  .argument("[project]", "프로젝트 코드 (또는 첫 인자에 Dooray Wiki URL)")
+  .argument("[page-id]", "위키 페이지 ID (project와 함께 사용)")
+  .option("--id <pageId>", "위키 페이지 ID (--project 동반 필요)")
+  .option("--url <url>", "Dooray Wiki URL")
+  .option("--project <code>", "프로젝트 코드 (--id 모드에서 wikiId 해석용)")
+  .action(async (project, pageIdArg, opts) => {
+    const globalOpts = wikiPageFileListCommand.optsWithGlobals() as OutputOptions;
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+
+    // resolveWikiPageInput 을 startSpinner 보다 먼저 호출 (1-1 회피)
+    const { wikiId, pageId } = await resolveWikiPageInput(client, {
+      projectArg: project,
+      pageIdArg,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+      project: opts.project,
+    });
+
+    startSpinner("첨부파일 목록 조회 중...");
+    try {
+      const res = await client.getWikiPage(wikiId, pageId);
+      const files = (res.result.files ?? []).map((f) => ({ ...f, type: "general" as const }));
+      const images = (res.result.images ?? []).map((f) => ({ ...f, type: "inline_image" as const }));
+      const merged = [...files, ...images];
+      stopSpinner(true, `첨부파일 ${merged.length}개 (general ${files.length} + inline ${images.length})`);
+
+      output(globalOpts, {
+        headers: ["ID", "Type", "파일명", "크기"],
+        rows: merged.map((f) => [f.id, f.type, f.name, formatSize(f.size)]),
+        raw: merged,
+        ids: merged.map((f) => f.id),
+      });
+    } catch (e) {
+      stopSpinner(false);
+      throw e;
+    }
+  });

--- a/src/commands/wiki/page-file/upload.ts
+++ b/src/commands/wiki/page-file/upload.ts
@@ -1,0 +1,98 @@
+import { Command } from "commander";
+import { getConfigOrThrow } from "../../../config/store.js";
+import { DoorayApiClient } from "../../../api/client.js";
+import { resolveWikiPageInput } from "../../../resolvers/wiki-page-input.js";
+import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
+import { DoorayCliError } from "../../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
+import type { WikiPageFileType } from "../../../api/types.js";
+
+export const wikiPageFileUploadCommand = new Command("upload")
+  .description("위키 페이지 첨부파일 업로드 (multipart type 순서 강제, ADR-029)")
+  .argument("[arg1]", "프로젝트 코드, Dooray Wiki URL, 또는 (`--id`/`--url` 모드일 때) 파일 경로")
+  .argument("[arg2]", "page-id 또는 (`--id`/`--url` 모드일 때) 파일 경로")
+  .argument("[arg3]", "파일 경로 (positional 3개 모드)")
+  .option("--id <pageId>", "위키 페이지 ID")
+  .option("--url <url>", "Dooray Wiki URL")
+  .option("--project <code>", "프로젝트 코드 (--id 모드에서 wikiId 해석용)")
+  .option("--file <path>", "업로드할 파일 경로 (positional 대체)")
+  .option("--type <type>", "파일 타입: general | inline_image (기본 general)", "general")
+  .action(async (arg1, arg2, arg3, opts) => {
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+
+    const fileType = opts.type as WikiPageFileType;
+    if (fileType !== "general" && fileType !== "inline_image") {
+      throw new DoorayCliError(
+        `--type 은 general 또는 inline_image 여야 합니다 (입력: ${opts.type})`,
+        EXIT_PARAM_ERROR,
+      );
+    }
+
+    let projectArg: string | undefined;
+    let pageIdArg: string | undefined;
+    let filePath: string | undefined = opts.file;
+
+    if (opts.id || opts.url) {
+      if (arg2 || arg3) {
+        throw new DoorayCliError(
+          "--id/--url 모드에서는 파일 경로 외 positional 인자를 받지 않습니다. --file 옵션 사용을 권장합니다.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+      filePath = filePath ?? arg1;
+    } else if (arg3) {
+      projectArg = arg1;
+      pageIdArg = arg2;
+      filePath = filePath ?? arg3;
+    } else if (arg1 && !arg2) {
+      projectArg = arg1;
+      if (!filePath) {
+        throw new DoorayCliError(
+          "URL/--id 모드 외에서는 <project> <page-id> 둘 다 또는 --file 옵션이 필요합니다.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+    } else {
+      projectArg = arg1;
+      pageIdArg = arg2;
+      if (!filePath) {
+        throw new DoorayCliError(
+          "<file> 이 필요합니다. positional 3번째 또는 --file 옵션을 사용하세요.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+    }
+
+    if (!filePath) {
+      throw new DoorayCliError("파일 경로가 필요합니다.", EXIT_PARAM_ERROR);
+    }
+
+    // resolveWikiPageInput 을 startSpinner 보다 먼저 호출 (1-1 회피)
+    const { wikiId, pageId } = await resolveWikiPageInput(client, {
+      projectArg,
+      pageIdArg,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+      project: opts.project,
+    });
+
+    startSpinner(`파일 업로드 중... (${fileType})`);
+    try {
+      const res = await client.uploadWikiPageFile(wikiId, pageId, filePath, fileType);
+      stopSpinner(true, "업로드 완료");
+
+      process.stdout.write(`attachFileId: ${res.result.attachFileId}\n`);
+      process.stdout.write(`name:         ${res.result.name}\n`);
+      process.stdout.write(`size:         ${res.result.size}\n`);
+      process.stdout.write(`type:         ${res.result.type}\n`);
+
+      if (fileType === "inline_image") {
+        process.stdout.write("\n본문 삽입용 markdown snippet (직접 wiki page edit 으로 본문에 박으세요):\n");
+        process.stdout.write(`  ![${res.result.name}](/wikis/${wikiId}/files/${res.result.attachFileId})\n`);
+      }
+    } catch (e) {
+      stopSpinner(false);
+      throw e;
+    }
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import { wikiPagesCommand } from "./commands/wiki/pages.js";
 import { wikiPageGetCommand } from "./commands/wiki/page-get.js";
 import { wikiPageCreateCommand } from "./commands/wiki/page-create.js";
 import { wikiPageEditCommand } from "./commands/wiki/page-edit.js";
+import { wikiPageFileCommand } from "./commands/wiki/page-file/index.js";
 import { memberCommand } from "./commands/member/index.js";
 import { mailListCommand } from "./commands/mail/list.js";
 import { mailGetCommand } from "./commands/mail/get.js";
@@ -116,6 +117,7 @@ const wikiPageCommand = new Command("page").description("위키 페이지 관련
 wikiPageCommand.addCommand(wikiPageGetCommand);
 wikiPageCommand.addCommand(wikiPageCreateCommand);
 wikiPageCommand.addCommand(wikiPageEditCommand);
+wikiPageCommand.addCommand(wikiPageFileCommand);
 wikiCommand.addCommand(wikiPageCommand);
 
 // mail 커맨드 그룹

--- a/src/resolvers/wiki-page-input.test.ts
+++ b/src/resolvers/wiki-page-input.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from "vitest";
+import { resolveWikiPageInput } from "./wiki-page-input.js";
+import { DoorayCliError } from "../utils/errors.js";
+
+vi.mock("./wiki.js");
+
+import { resolveWiki } from "./wiki.js";
+
+const mockResolveWiki = vi.mocked(resolveWiki);
+
+function makeClient() {
+  return {} as any;
+}
+
+describe("resolveWikiPageInput", () => {
+  it("positional 2개 → resolveWiki + pageId 반환", async () => {
+    mockResolveWiki.mockResolvedValue("wiki-100");
+    const out = await resolveWikiPageInput(makeClient(), {
+      projectArg: "my-project",
+      pageIdArg: "456",
+    });
+    expect(out).toEqual({ wikiId: "wiki-100", pageId: "456" });
+    expect(mockResolveWiki).toHaveBeenCalledWith(expect.anything(), "my-project");
+  });
+
+  it("--url 단독 → URL parser 결과 그대로", async () => {
+    const out = await resolveWikiPageInput(makeClient(), {
+      urlOpt: "https://x.dooray.com/wiki/123/456",
+    });
+    expect(out).toEqual({ wikiId: "123", pageId: "456" });
+  });
+
+  it("positional URL → URL parser 결과 그대로", async () => {
+    const out = await resolveWikiPageInput(makeClient(), {
+      projectArg: "https://x.dooray.com/wiki/123/456",
+    });
+    expect(out).toEqual({ wikiId: "123", pageId: "456" });
+  });
+
+  it("--id + --project → resolveWiki + pageId", async () => {
+    mockResolveWiki.mockResolvedValue("wiki-200");
+    const out = await resolveWikiPageInput(makeClient(), {
+      idOpt: "789",
+      project: "other-project",
+    });
+    expect(out).toEqual({ wikiId: "wiki-200", pageId: "789" });
+    expect(mockResolveWiki).toHaveBeenCalledWith(expect.anything(), "other-project");
+  });
+
+  it("--id + --url 충돌 → throw", async () => {
+    await expect(
+      resolveWikiPageInput(makeClient(), {
+        idOpt: "1",
+        urlOpt: "https://x.dooray.com/wiki/123/456",
+      }),
+    ).rejects.toBeInstanceOf(DoorayCliError);
+  });
+
+  it("positional 0개 → INPUT_HELP throw", async () => {
+    await expect(
+      resolveWikiPageInput(makeClient(), {}),
+    ).rejects.toBeInstanceOf(DoorayCliError);
+  });
+});

--- a/src/resolvers/wiki-page-input.ts
+++ b/src/resolvers/wiki-page-input.ts
@@ -1,0 +1,87 @@
+import { DoorayApiClient } from "../api/client.js";
+import { resolveWiki } from "./wiki.js";
+import { parseDoorayWikiUrl, isLikelyDoorayUrl } from "../utils/dooray-url.js";
+import { DoorayCliError } from "../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../utils/exit-codes.js";
+
+export interface WikiPageInputArgs {
+  projectArg?: string;
+  pageIdArg?: string;
+  idOpt?: string;
+  urlOpt?: string;
+  project?: string;
+}
+
+export interface ResolvedWikiPageInput {
+  wikiId: string;
+  pageId: string;
+}
+
+const INPUT_HELP =
+  "위키 페이지를 식별할 정보가 부족합니다. 다음 중 하나를 입력하세요:\n" +
+  "  - <project> <page-id>                    예: my-project 4071828729722696495\n" +
+  "  - --id <page-id> --project <project>      (또는 --url)\n" +
+  "  - <Dooray URL>                            예: https://x.dooray.com/wiki/<wikiId>/<pageId>";
+
+export async function resolveWikiPageInput(
+  client: DoorayApiClient,
+  args: WikiPageInputArgs,
+): Promise<ResolvedWikiPageInput> {
+  const { projectArg, pageIdArg, idOpt, urlOpt, project } = args;
+  const hasPositional = !!projectArg || !!pageIdArg;
+
+  if (idOpt && urlOpt) {
+    throw new DoorayCliError("--id와 --url은 동시에 사용할 수 없습니다.", EXIT_PARAM_ERROR);
+  }
+  if ((idOpt || urlOpt) && hasPositional) {
+    throw new DoorayCliError(
+      "--id/--url과 positional 인자(<project> <page-id>)는 동시에 사용할 수 없습니다.",
+      EXIT_PARAM_ERROR,
+    );
+  }
+
+  // 1. --url — wikiId/pageId 둘 다 URL 에서 추출 (project 불요)
+  if (urlOpt) {
+    const parsed = parseDoorayWikiUrl(urlOpt);
+    if (!parsed) {
+      throw new DoorayCliError(
+        `--url 형식이 올바르지 않습니다: "${urlOpt}"\n예: https://x.dooray.com/wiki/<wikiId>/<pageId>`,
+        EXIT_PARAM_ERROR,
+      );
+    }
+    return parsed;
+  }
+
+  // 2. positional 1개 & URL 형태 — wikiId/pageId 둘 다 URL 에서 추출
+  if (projectArg && !pageIdArg && isLikelyDoorayUrl(projectArg)) {
+    const parsed = parseDoorayWikiUrl(projectArg);
+    if (!parsed) {
+      throw new DoorayCliError(
+        `Dooray Wiki URL 형식이 올바르지 않습니다: "${projectArg}"\n예: https://x.dooray.com/wiki/<wikiId>/<pageId>`,
+        EXIT_PARAM_ERROR,
+      );
+    }
+    return parsed;
+  }
+
+  // 3. --id 단독 — project 필요 (wikiId 해석에 project 필요)
+  if (idOpt) {
+    const projectCode = project ?? projectArg;
+    if (!projectCode) {
+      throw new DoorayCliError(
+        "--id 모드는 --project <code> 가 필요합니다 (또는 첫 positional 에 project code).",
+        EXIT_PARAM_ERROR,
+      );
+    }
+    const wikiId = await resolveWiki(client, projectCode);
+    return { wikiId, pageId: idOpt };
+  }
+
+  // 4. positional 2개 (기본 경로)
+  if (projectArg && pageIdArg) {
+    const wikiId = await resolveWiki(client, projectArg);
+    return { wikiId, pageId: pageIdArg };
+  }
+
+  throw new DoorayCliError(INPUT_HELP, EXIT_PARAM_ERROR);
+}

--- a/src/utils/dooray-url.test.ts
+++ b/src/utils/dooray-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseDoorayTaskUrl, isLikelyDoorayUrl } from "./dooray-url.js";
+import { parseDoorayTaskUrl, parseDoorayWikiUrl, isLikelyDoorayUrl } from "./dooray-url.js";
 
 describe("parseDoorayTaskUrl", () => {
   it("정상 URL에서 postId 추출", () => {
@@ -40,6 +40,20 @@ describe("parseDoorayTaskUrl", () => {
   });
   it("/task/<projectId>/<postId> 형도 dooray.com 도메인 외 reject", () => {
     expect(parseDoorayTaskUrl("https://other.com/task/123/456")).toBeNull();
+  });
+});
+
+describe("parseDoorayWikiUrl", () => {
+  it("표준 wiki URL → {wikiId, pageId}", () => {
+    expect(parseDoorayWikiUrl("https://x.dooray.com/wiki/123/456"))
+      .toEqual({ wikiId: "123", pageId: "456" });
+  });
+  it("쿼리 파라미터 무시", () => {
+    expect(parseDoorayWikiUrl("https://my-org.dooray.com/wiki/123/456?foo=bar"))
+      .toEqual({ wikiId: "123", pageId: "456" });
+  });
+  it("task URL 은 wiki parser 에서 null", () => {
+    expect(parseDoorayWikiUrl("https://x.dooray.com/task/123/456")).toBeNull();
   });
 });
 

--- a/src/utils/dooray-url.ts
+++ b/src/utils/dooray-url.ts
@@ -4,12 +4,25 @@ const TASK_URL_RE = /^https?:\/\/[\w.-]+\.dooray\.com\/task\/to\/(\d+)(?:[/?#].*
 // postId 가 캡처 1 이 되어 short form (`m1[1]`) 과 인덱스 일관.
 const TASK_URL_ALT_RE = /^https?:\/\/[\w.-]+\.dooray\.com\/task\/(?:\d+)\/(\d+)(?:[/?#].*)?$/;
 
+const WIKI_URL_RE = /^https?:\/\/[\w.-]+\.dooray\.com\/wiki\/(\d+)\/(\d+)(?:[/?#].*)?$/;
+
 export function parseDoorayTaskUrl(input: string): string | null {
   const m1 = TASK_URL_RE.exec(input);
   if (m1) return m1[1];
   const m2 = TASK_URL_ALT_RE.exec(input);
   if (m2) return m2[1];
   return null;
+}
+
+export interface ParsedWikiPageUrl {
+  wikiId: string;
+  pageId: string;
+}
+
+export function parseDoorayWikiUrl(input: string): ParsedWikiPageUrl | null {
+  const m = WIKI_URL_RE.exec(input);
+  if (!m) return null;
+  return { wikiId: m[1], pageId: m[2] };
 }
 
 export function isLikelyDoorayUrl(input: string): boolean {

--- a/tasks/035-feat-wiki-page-file-commands/index.json
+++ b/tasks/035-feat-wiki-page-file-commands/index.json
@@ -2,8 +2,8 @@
   "name": "035-feat-wiki-page-file-commands",
   "description": "GitHub Issue #70 — `dooray wiki page file <list|upload|download|download-all|delete>` 5 명령 추가. post file 명령군 mirror. Page 입력 분기 (`<project> <page-id>` + `--id` + `--url` + positional URL) 신규 resolver `resolveWikiPageInput` + wiki URL parser. upload 는 `--type general|inline_image` flag + multipart 필드 순서 (type → file) 강제 (신규 ADR-029). 307 redirect 는 ADR-015 패턴 재사용. list 는 `getWikiPage` 의 files[] + images[] 합성 (별도 endpoint 부재). inline_image upload 시 본문 markdown 자동 삽입 안 함 — stdout 에 attachFileId + snippet 안내. delete 는 confirm 없이 즉시 (post file delete mirror).",
   "created_at": "2026-05-21T00:00:00Z",
-  "status": "pending",
-  "current_phase": 1,
+  "status": "completed",
+  "current_phase": 3,
   "total_phases": 3,
   "error_message": null,
   "blocked_reason": null,
@@ -12,23 +12,23 @@
       "number": 1,
       "title": "api/client (3 method) + types + utils/dooray-url (wiki URL parser) + resolvers/wiki-page-input + 단위 테스트",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 2,
       "title": "commands/wiki/page-file/ 5 명령 (list/upload/download/download-all/delete) + index.ts 등록",
       "file": "phase-02.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 3,
       "title": "README + skills/dooray-cli/SKILL.md + 빌드/실증 검증 + 완료 마킹",
       "file": "phase-03.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],
-  "updated_at": "2026-05-21T00:00:00Z"
+  "updated_at": "2026-05-21T11:16:00Z"
 }


### PR DESCRIPTION
## Summary

GitHub Issue #70 — `dooray wiki page file <list|upload|download|download-all|delete>` 5 명령 추가. `post file` 명령군 mirror 패턴.

- **list**: `getWikiPage` 의 `files[]` + `images[]` 합성 (별도 endpoint 부재), `type` 컬럼 추가
- **upload**: `--type general|inline_image` (기본 `general`), multipart `type` → `file` 필드 순서 강제 (ADR-029), inline_image 일 때 stdout 에 본문 삽입용 markdown snippet 안내
- **download / download-all**: 307 redirect 처리 (ADR-015 재사용), 부분 실패 시 non-zero exit
- **delete**: confirm 없이 즉시 (post file delete mirror)
- Page 입력 분기: `<project> <page-id>` + `--id <pageId> --project <code>` + `--url <url>` + positional URL (신규 resolver `resolveWikiPageInput` + `parseDoorayWikiUrl`)

## Commits

- `00f75fd` phase 1/3 — api/client (3 method) + types + utils/dooray-url (wiki URL parser) + resolvers/wiki-page-input + 단위 테스트 9 케이스
- `7f69dde` phase 2/3 — commands/wiki/page-file/ 5 명령 + index.ts 등록
- `6493856` phase 3/3 — README + skills/dooray-cli/SKILL.md + 완료 마킹

## ADR

- **ADR-029** (신규): multipart `type` 필드 순서 의존 — Dooray 서버가 `file` 보다 먼저 `type` 을 받아야 정상 동작
- **ADR-015** (재사용): 307 redirect + Auth 헤더 재첨부
- **ADR-020** (확장): URL parser — wiki URL 패턴 추가

## Test plan

- [x] `pnpm tsc --noEmit` — 에러 0건
- [x] `pnpm run build` — 단일 번들 생성 (221.54 KB)
- [x] `pnpm test` — 140 케이스 통과 (신규 wiki-page-input 6 + dooray-url wiki 3)
- [x] `node dist/index.js wiki page file --help` — 5 명령 노출
- [x] critic APPROVE / code-reviewer PASS / docs-verifier PASS
- [ ] 사용자 환경 실증: 실제 wiki page 에 general 업로드 / list / inline_image 업로드 + snippet URL 형식 확인 / download / download-all / delete
- [ ] inline_image snippet URL 패턴 (`/wikis/<wikiId>/files/<attachFileId>`) — Dooray 실제 형식과 다르면 `upload.ts` snippet 문자열만 수정

closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)