### PR TITLE
feat(wiki): add wiki page comment 6 commands (task 036, Issue #71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,42 @@ dooray wiki page file upload --id <pageId> --project <project> --file ./README.m
   upload stdout 의 snippet 을 복사해서 `dooray wiki page edit` 으로 본문에 직접 추가
 - `delete` 는 confirm 없이 즉시 삭제 (실수 방지 책임은 호출자)
 
+#### 위키 페이지 댓글
+
+post 의 `post comment` 명령군과 동일 패턴 — `<project> <page-id>` 외에도 `--id`/`--url`/positional URL 지원.
+
+```bash
+# 목록 (최신순)
+dooray wiki page comment list <project> <page-id>
+dooray wiki page comment list <project> <page-id> --latest 5
+
+# 최신 1건 shortcut
+dooray wiki page comment latest <project> <page-id>
+
+# 단일 조회
+dooray wiki page comment get <project> <page-id> <comment-id>
+
+# 추가 — interactive ($EDITOR) 또는 옵션
+dooray wiki page comment add <project> <page-id>                          # $EDITOR
+dooray wiki page comment add <project> <page-id> --body "회의 결정 사항"
+dooray wiki page comment add <project> <page-id> --body-file ./note.md
+echo "댓글" | dooray wiki page comment add <project> <page-id> --body -
+
+# 수정 — interactive ($EDITOR, 기존 본문 prefill) 또는 옵션
+dooray wiki page comment edit <project> <page-id> <comment-id> --body "..."
+
+# 삭제 (confirm 없이 즉시)
+dooray wiki page comment delete <project> <page-id> <comment-id>
+
+# URL 모드
+dooray wiki page comment list "https://<tenant>.dooray.com/wiki/<wikiId>/<pageId>"
+```
+
+**post comment 와의 차이**:
+- mention / cc / 받는 사람 미지원 — wiki API 부재
+- 첨부 파일 미지원 — wiki comment 전용 endpoint 부재 (페이지 본문 파일은 `wiki page file` 사용)
+- 본문은 markdown 그대로 전송 (mimeType 자동)
+
 ### 메일
 
 IMAP을 통해 Dooray 메일을 조회할 수 있습니다. 메일 설정은 `dooray setup`에서 한 번에 진행하거나, 수동으로 설정할 수 있습니다.

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -87,6 +87,12 @@ dooray doctor                                 # 설정 검증
 | 위키 페이지 첨부 다운로드 | `dooray wiki page file download <project> <page-id> --file-id <id> -o <dir>` |
 | 위키 페이지 첨부 일괄 다운로드 | `dooray wiki page file download-all <project> <page-id> -o <dir>` (files + images 전부) |
 | 위키 페이지 첨부 삭제 | `dooray wiki page file delete <project> <page-id> --file-id <id>` (confirm 없음) |
+| 위키 페이지 댓글 목록 | `dooray wiki page comment list <project> <page-id> [--latest N]` (최신순) |
+| 위키 페이지 최신 댓글 | `dooray wiki page comment latest <project> <page-id>` |
+| 위키 페이지 댓글 조회 | `dooray wiki page comment get <project> <page-id> <comment-id>` |
+| 위키 페이지 댓글 추가 | `dooray wiki page comment add <project> <page-id> --body "..."` ($EDITOR fallback) |
+| 위키 페이지 댓글 수정 | `dooray wiki page comment edit <project> <page-id> <comment-id> --body "..."` |
+| 위키 페이지 댓글 삭제 | `dooray wiki page comment delete <project> <page-id> <comment-id>` (confirm 없음) |
 | 메일 목록 조회 | `dooray mail list` |
 | 안읽은 메일 | `dooray mail list --unread` |
 | 메일 제목 검색 | `dooray mail list --search "<keyword>"` |
@@ -213,6 +219,21 @@ dooray wiki page file download-all <project> <page-id> -o ~/.claude/skills/my-sk
 
 # 첨부 목록 확인 (type 컬럼: general / inline_image)
 dooray wiki page file list <project> <page-id>
+```
+
+### 위키 페이지 댓글 — 회의록 결정사항 자동 누적
+
+**회의록 결정사항 자동 누적**: 회의록 위키 페이지에 자동화 봇이 `wiki page comment add` 로 결정사항을 댓글로 누적, `wiki page comment list --latest 20` 으로 최근 토론 흐름 추적.
+
+```bash
+# 결정사항 댓글 추가
+dooray wiki page comment add <project> <page-id> --body "결정: 배포일 2026-06-01 확정"
+
+# 최근 20개 토론 흐름 조회
+dooray wiki page comment list <project> <page-id> --latest 20
+
+# 최신 댓글 1건 shortcut
+dooray wiki page comment latest <project> <page-id>
 ```
 
 ## 단일 댓글 본문 fetch

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -40,6 +40,11 @@ import type {
   UpdateWikiPageContentRequest,
   WikiPageFileType,
   UploadWikiPageFileResponse,
+  WikiCommentListResponse,
+  WikiCommentDetailResponse,
+  CreateWikiCommentRequest,
+  UpdateWikiCommentRequest,
+  CreateWikiCommentApiResponse,
   DoorayApiUnitResponse,
   DoorayErrorResponse,
   PostFileListResponse,
@@ -784,6 +789,84 @@ export class DoorayApiClient {
     try {
       return await this.api
         .delete(`wiki/v1/wikis/${wikiId}/pages/${pageId}/files/${fileId}`)
+        .json<DoorayApiUnitResponse>();
+    } catch (e) {
+      throw await toDoorayCliError(e);
+    }
+  }
+
+  // ─── Wiki Page Comments ─────────────────────────────
+
+  async getWikiPageComments(
+    wikiId: string,
+    pageId: string,
+    params?: { page?: number; size?: number },
+  ): Promise<WikiCommentListResponse> {
+    try {
+      return await this.api
+        .get(`wiki/v1/wikis/${wikiId}/pages/${pageId}/comments`, {
+          searchParams: {
+            ...(params?.page !== undefined && { page: params.page }),
+            ...(params?.size !== undefined && { size: params.size }),
+          },
+        })
+        .json<WikiCommentListResponse>();
+    } catch (e) {
+      throw await toDoorayCliError(e);
+    }
+  }
+
+  async getWikiPageComment(
+    wikiId: string,
+    pageId: string,
+    commentId: string,
+  ): Promise<WikiCommentDetailResponse> {
+    try {
+      return await this.api
+        .get(`wiki/v1/wikis/${wikiId}/pages/${pageId}/comments/${commentId}`)
+        .json<WikiCommentDetailResponse>();
+    } catch (e) {
+      throw await toDoorayCliError(e);
+    }
+  }
+
+  async addWikiPageComment(
+    wikiId: string,
+    pageId: string,
+    body: CreateWikiCommentRequest,
+  ): Promise<CreateWikiCommentApiResponse> {
+    try {
+      return await this.api
+        .post(`wiki/v1/wikis/${wikiId}/pages/${pageId}/comments`, { json: body })
+        .json<CreateWikiCommentApiResponse>();
+    } catch (e) {
+      throw await toDoorayCliError(e);
+    }
+  }
+
+  async updateWikiPageComment(
+    wikiId: string,
+    pageId: string,
+    commentId: string,
+    body: UpdateWikiCommentRequest,
+  ): Promise<DoorayApiUnitResponse> {
+    try {
+      return await this.api
+        .put(`wiki/v1/wikis/${wikiId}/pages/${pageId}/comments/${commentId}`, { json: body })
+        .json<DoorayApiUnitResponse>();
+    } catch (e) {
+      throw await toDoorayCliError(e);
+    }
+  }
+
+  async deleteWikiPageComment(
+    wikiId: string,
+    pageId: string,
+    commentId: string,
+  ): Promise<DoorayApiUnitResponse> {
+    try {
+      return await this.api
+        .delete(`wiki/v1/wikis/${wikiId}/pages/${pageId}/comments/${commentId}`)
         .json<DoorayApiUnitResponse>();
     } catch (e) {
       throw await toDoorayCliError(e);

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -337,6 +337,56 @@ export type UpdateCommentResponse = DoorayApiUnitResponse;
 
 export type DeleteCommentResponse = DoorayApiUnitResponse;
 
+// ─── Wiki Comment ────────────────────────────────────────
+
+export interface WikiCommentPage {
+  id: string;
+}
+
+export interface WikiCommentCreator {
+  type: string;
+  member: {
+    organizationMemberId: string;
+    name: string;
+  };
+}
+
+export interface WikiCommentBody {
+  mimeType: string;
+  content: string;
+}
+
+export interface WikiComment {
+  id: string;
+  page: WikiCommentPage;
+  createdAt: string;
+  modifiedAt?: string;
+  creator: WikiCommentCreator;
+  body: WikiCommentBody;
+}
+
+export interface CreateWikiCommentRequest {
+  body: { content: string };
+}
+
+export interface UpdateWikiCommentRequest {
+  body: { content: string };
+}
+
+export interface WikiCommentListResponse {
+  header: DoorayApiHeader;
+  result: WikiComment[];
+  totalCount: number;
+}
+
+export type WikiCommentDetailResponse = DoorayApiResponse<WikiComment>;
+
+export interface CreateWikiCommentResult {
+  id: string;
+}
+
+export type CreateWikiCommentApiResponse = DoorayApiResponse<CreateWikiCommentResult>;
+
 // ─── Project Member ─────────────────────────────────────
 
 export interface ProjectMember {

--- a/src/commands/wiki/page-comment/add.ts
+++ b/src/commands/wiki/page-comment/add.ts
@@ -1,0 +1,59 @@
+import { Command } from "commander";
+import { getConfigOrThrow } from "../../../config/store.js";
+import { DoorayApiClient } from "../../../api/client.js";
+import { resolveWikiPageInput } from "../../../resolvers/wiki-page-input.js";
+import { openInEditor } from "../../../editor/index.js";
+import { readBodyInputOrNull } from "../../../utils/body-input.js";
+import type { OutputOptions } from "../../../formatters/table.js";
+import { printJson, printQuiet } from "../../../formatters/table.js";
+import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
+
+export const wikiPageCommentAddCommand = new Command("add")
+  .description("위키 페이지 댓글 추가 (--body 없으면 $EDITOR)")
+  .argument("[project]", "프로젝트 코드 (또는 첫 인자에 Dooray Wiki URL)")
+  .argument("[page-id]", "위키 페이지 ID")
+  .option("--id <pageId>", "위키 페이지 ID (--project 동반)")
+  .option("--url <url>", "Dooray Wiki URL")
+  .option("--project <code>", "프로젝트 코드 (--id 모드용)")
+  .option("--body <text>", "댓글 본문 (- 입력 시 stdin에서 읽기)")
+  .option("--body-file <path>", "본문 파일 경로 (- 입력 시 stdin에서 읽기)")
+  .action(async (project, pageIdArg, opts) => {
+    const globalOpts = wikiPageCommentAddCommand.optsWithGlobals() as OutputOptions;
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+
+    let bodyContent = await readBodyInputOrNull(opts);
+    if (bodyContent == null) {
+      bodyContent = await openInEditor("");
+      if (!bodyContent.trim()) {
+        process.stdout.write("빈 댓글은 작성할 수 없습니다.\n");
+        return;
+      }
+    }
+
+    const { wikiId, pageId } = await resolveWikiPageInput(client, {
+      projectArg: project,
+      pageIdArg,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+      project: opts.project,
+    });
+
+    startSpinner("댓글 추가 중...");
+    try {
+      const res = await client.addWikiPageComment(wikiId, pageId, {
+        body: { content: bodyContent },
+      });
+      stopSpinner(true, `댓글 추가 완료 (id: ${res.result.id})`);
+      if (globalOpts.json) {
+        printJson({ id: res.result.id });
+      } else if (globalOpts.quiet) {
+        printQuiet([res.result.id]);
+      } else {
+        process.stdout.write(`댓글이 추가되었습니다: ${res.result.id}\n`);
+      }
+    } catch (e) {
+      stopSpinner(false);
+      throw e;
+    }
+  });

--- a/src/commands/wiki/page-comment/add.ts
+++ b/src/commands/wiki/page-comment/add.ts
@@ -7,6 +7,8 @@ import { readBodyInputOrNull } from "../../../utils/body-input.js";
 import type { OutputOptions } from "../../../formatters/table.js";
 import { printJson, printQuiet } from "../../../formatters/table.js";
 import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
+import { DoorayCliError } from "../../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
 
 export const wikiPageCommentAddCommand = new Command("add")
   .description("위키 페이지 댓글 추가 (--body 없으면 $EDITOR)")
@@ -18,9 +20,24 @@ export const wikiPageCommentAddCommand = new Command("add")
   .option("--body <text>", "댓글 본문 (- 입력 시 stdin에서 읽기)")
   .option("--body-file <path>", "본문 파일 경로 (- 입력 시 stdin에서 읽기)")
   .action(async (project, pageIdArg, opts) => {
+    if ((opts.id || opts.url) && (project || pageIdArg)) {
+      throw new DoorayCliError(
+        "positional 인자와 --id/--url 옵션은 동시에 사용할 수 없습니다.",
+        EXIT_PARAM_ERROR,
+      );
+    }
+
     const globalOpts = wikiPageCommentAddCommand.optsWithGlobals() as OutputOptions;
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+
+    const { wikiId, pageId } = await resolveWikiPageInput(client, {
+      projectArg: project,
+      pageIdArg,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+      project: opts.project,
+    });
 
     let bodyContent = await readBodyInputOrNull(opts);
     if (bodyContent == null) {
@@ -30,14 +47,6 @@ export const wikiPageCommentAddCommand = new Command("add")
         return;
       }
     }
-
-    const { wikiId, pageId } = await resolveWikiPageInput(client, {
-      projectArg: project,
-      pageIdArg,
-      idOpt: opts.id,
-      urlOpt: opts.url,
-      project: opts.project,
-    });
 
     startSpinner("댓글 추가 중...");
     try {

--- a/src/commands/wiki/page-comment/delete.ts
+++ b/src/commands/wiki/page-comment/delete.ts
@@ -3,8 +3,7 @@ import { getConfigOrThrow } from "../../../config/store.js";
 import { DoorayApiClient } from "../../../api/client.js";
 import { resolveWikiPageInput } from "../../../resolvers/wiki-page-input.js";
 import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
-import { DoorayCliError } from "../../../utils/errors.js";
-import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
+import { parseWikiCommentArgs } from "./parse-args.js";
 
 export const wikiPageCommentDeleteCommand = new Command("delete")
   .description("위키 페이지 댓글 삭제 (confirm 없이 즉시)")
@@ -16,58 +15,24 @@ export const wikiPageCommentDeleteCommand = new Command("delete")
   .option("--project <code>", "프로젝트 코드 (--id 모드용)")
   .option("--comment-id <commentId>", "댓글 ID (positional 대체)")
   .action(async (arg1, arg2, arg3, opts) => {
+    const parsed = parseWikiCommentArgs(arg1, arg2, arg3, opts);
+
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
-    let projectArg: string | undefined;
-    let pageIdArg: string | undefined;
-    let commentId: string | undefined = opts.commentId;
-    let idOpt: string | undefined;
-    let urlOpt: string | undefined;
-    let projectOpt: string | undefined;
-
-    if (opts.id || opts.url) {
-      if (arg2 || arg3) {
-        throw new DoorayCliError(
-          "--id/--url 모드에서는 댓글 ID 외 추가 positional 인자를 받지 않습니다. --comment-id 옵션 사용을 권장합니다.",
-          EXIT_PARAM_ERROR,
-        );
-      }
-      commentId = commentId ?? arg1;
-      idOpt = opts.id;
-      urlOpt = opts.url;
-      projectOpt = opts.project;
-    } else if (arg3) {
-      projectArg = arg1;
-      pageIdArg = arg2;
-      commentId = commentId ?? arg3;
-    } else if (arg1 && arg2 && opts.commentId) {
-      projectArg = arg1;
-      pageIdArg = arg2;
-    } else {
-      throw new DoorayCliError(
-        "<comment-id>가 필요합니다. positional 3번째 또는 --comment-id 옵션을 사용하세요.",
-        EXIT_PARAM_ERROR,
-      );
-    }
-
-    if (!commentId) {
-      throw new DoorayCliError("<comment-id>가 필요합니다.", EXIT_PARAM_ERROR);
-    }
-
     const { wikiId, pageId } = await resolveWikiPageInput(client, {
-      projectArg,
-      pageIdArg,
-      idOpt,
-      urlOpt,
-      project: projectOpt,
+      projectArg: parsed.projectArg,
+      pageIdArg: parsed.pageIdArg,
+      idOpt: parsed.idOpt,
+      urlOpt: parsed.urlOpt,
+      project: parsed.projectOpt,
     });
 
     startSpinner("댓글 삭제 중...");
     try {
-      await client.deleteWikiPageComment(wikiId, pageId, commentId);
+      await client.deleteWikiPageComment(wikiId, pageId, parsed.commentId);
       stopSpinner(true, "삭제 완료");
-      process.stdout.write(`댓글(${commentId})이 삭제되었습니다.\n`);
+      process.stdout.write(`댓글(${parsed.commentId})이 삭제되었습니다.\n`);
     } catch (e) {
       stopSpinner(false);
       throw e;

--- a/src/commands/wiki/page-comment/delete.ts
+++ b/src/commands/wiki/page-comment/delete.ts
@@ -1,0 +1,75 @@
+import { Command } from "commander";
+import { getConfigOrThrow } from "../../../config/store.js";
+import { DoorayApiClient } from "../../../api/client.js";
+import { resolveWikiPageInput } from "../../../resolvers/wiki-page-input.js";
+import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
+import { DoorayCliError } from "../../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
+
+export const wikiPageCommentDeleteCommand = new Command("delete")
+  .description("위키 페이지 댓글 삭제 (confirm 없이 즉시)")
+  .argument("[arg1]", "프로젝트 코드 / Dooray Wiki URL (모드별)")
+  .argument("[arg2]", "위키 페이지 ID (모드별)")
+  .argument("[arg3]", "댓글 ID (positional 3개 모드)")
+  .option("--id <pageId>", "위키 페이지 ID (positional 대신)")
+  .option("--url <url>", "Dooray Wiki URL (positional 대신)")
+  .option("--project <code>", "프로젝트 코드 (--id 모드용)")
+  .option("--comment-id <commentId>", "댓글 ID (positional 대체)")
+  .action(async (arg1, arg2, arg3, opts) => {
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+
+    let projectArg: string | undefined;
+    let pageIdArg: string | undefined;
+    let commentId: string | undefined = opts.commentId;
+    let idOpt: string | undefined;
+    let urlOpt: string | undefined;
+    let projectOpt: string | undefined;
+
+    if (opts.id || opts.url) {
+      if (arg2 || arg3) {
+        throw new DoorayCliError(
+          "--id/--url 모드에서는 댓글 ID 외 추가 positional 인자를 받지 않습니다. --comment-id 옵션 사용을 권장합니다.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+      commentId = commentId ?? arg1;
+      idOpt = opts.id;
+      urlOpt = opts.url;
+      projectOpt = opts.project;
+    } else if (arg3) {
+      projectArg = arg1;
+      pageIdArg = arg2;
+      commentId = commentId ?? arg3;
+    } else if (arg1 && arg2 && opts.commentId) {
+      projectArg = arg1;
+      pageIdArg = arg2;
+    } else {
+      throw new DoorayCliError(
+        "<comment-id>가 필요합니다. positional 3번째 또는 --comment-id 옵션을 사용하세요.",
+        EXIT_PARAM_ERROR,
+      );
+    }
+
+    if (!commentId) {
+      throw new DoorayCliError("<comment-id>가 필요합니다.", EXIT_PARAM_ERROR);
+    }
+
+    const { wikiId, pageId } = await resolveWikiPageInput(client, {
+      projectArg,
+      pageIdArg,
+      idOpt,
+      urlOpt,
+      project: projectOpt,
+    });
+
+    startSpinner("댓글 삭제 중...");
+    try {
+      await client.deleteWikiPageComment(wikiId, pageId, commentId);
+      stopSpinner(true, "삭제 완료");
+      process.stdout.write(`댓글(${commentId})이 삭제되었습니다.\n`);
+    } catch (e) {
+      stopSpinner(false);
+      throw e;
+    }
+  });

--- a/src/commands/wiki/page-comment/edit.ts
+++ b/src/commands/wiki/page-comment/edit.ts
@@ -1,0 +1,101 @@
+import { Command } from "commander";
+import { getConfigOrThrow } from "../../../config/store.js";
+import { DoorayApiClient } from "../../../api/client.js";
+import { resolveWikiPageInput } from "../../../resolvers/wiki-page-input.js";
+import { openInEditor } from "../../../editor/index.js";
+import { readBodyInputOrNull } from "../../../utils/body-input.js";
+import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
+import { DoorayCliError } from "../../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
+
+export const wikiPageCommentEditCommand = new Command("edit")
+  .description("위키 페이지 댓글 수정 ($EDITOR 또는 --body 옵션)")
+  .argument("[arg1]", "프로젝트 코드 / Dooray Wiki URL (모드별)")
+  .argument("[arg2]", "위키 페이지 ID (모드별)")
+  .argument("[arg3]", "댓글 ID (positional 3개 모드)")
+  .option("--id <pageId>", "위키 페이지 ID (positional 대신)")
+  .option("--url <url>", "Dooray Wiki URL (positional 대신)")
+  .option("--project <code>", "프로젝트 코드 (--id 모드용)")
+  .option("--comment-id <commentId>", "댓글 ID (positional 대체)")
+  .option("--body <text>", "댓글 본문 변경 (- 입력 시 stdin, non-interactive)")
+  .option("--body-file <path>", "본문 파일 경로 (- 입력 시 stdin, non-interactive)")
+  .action(async (arg1, arg2, arg3, opts) => {
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+
+    let projectArg: string | undefined;
+    let pageIdArg: string | undefined;
+    let commentId: string | undefined = opts.commentId;
+    let idOpt: string | undefined;
+    let urlOpt: string | undefined;
+    let projectOpt: string | undefined;
+
+    if (opts.id || opts.url) {
+      if (arg2 || arg3) {
+        throw new DoorayCliError(
+          "--id/--url 모드에서는 댓글 ID 외 추가 positional 인자를 받지 않습니다. --comment-id 옵션 사용을 권장합니다.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+      commentId = commentId ?? arg1;
+      idOpt = opts.id;
+      urlOpt = opts.url;
+      projectOpt = opts.project;
+    } else if (arg3) {
+      projectArg = arg1;
+      pageIdArg = arg2;
+      commentId = commentId ?? arg3;
+    } else if (arg1 && arg2 && opts.commentId) {
+      projectArg = arg1;
+      pageIdArg = arg2;
+    } else {
+      throw new DoorayCliError(
+        "<comment-id>가 필요합니다. positional 3번째 또는 --comment-id 옵션을 사용하세요.",
+        EXIT_PARAM_ERROR,
+      );
+    }
+
+    if (!commentId) {
+      throw new DoorayCliError("<comment-id>가 필요합니다.", EXIT_PARAM_ERROR);
+    }
+
+    const { wikiId, pageId } = await resolveWikiPageInput(client, {
+      projectArg,
+      pageIdArg,
+      idOpt,
+      urlOpt,
+      project: projectOpt,
+    });
+
+    startSpinner("댓글 조회 중...");
+    let existing;
+    try {
+      const detail = await client.getWikiPageComment(wikiId, pageId, commentId);
+      existing = detail.result;
+      stopSpinner(true, "댓글 조회 완료");
+    } catch (e) {
+      stopSpinner(false);
+      throw e;
+    }
+
+    let newBody = await readBodyInputOrNull(opts);
+    if (newBody == null) {
+      newBody = await openInEditor(existing.body.content);
+      if (!newBody.trim() || newBody === existing.body.content) {
+        process.stdout.write("변경 사항이 없습니다.\n");
+        return;
+      }
+    }
+
+    startSpinner("댓글 수정 중...");
+    try {
+      await client.updateWikiPageComment(wikiId, pageId, commentId, {
+        body: { content: newBody },
+      });
+      stopSpinner(true, "댓글 수정 완료");
+      process.stdout.write(`댓글이 수정되었습니다: ${commentId}\n`);
+    } catch (e) {
+      stopSpinner(false);
+      throw e;
+    }
+  });

--- a/src/commands/wiki/page-comment/edit.ts
+++ b/src/commands/wiki/page-comment/edit.ts
@@ -5,8 +5,7 @@ import { resolveWikiPageInput } from "../../../resolvers/wiki-page-input.js";
 import { openInEditor } from "../../../editor/index.js";
 import { readBodyInputOrNull } from "../../../utils/body-input.js";
 import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
-import { DoorayCliError } from "../../../utils/errors.js";
-import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
+import { parseWikiCommentArgs } from "./parse-args.js";
 
 export const wikiPageCommentEditCommand = new Command("edit")
   .description("위키 페이지 댓글 수정 ($EDITOR 또는 --body 옵션)")
@@ -20,57 +19,23 @@ export const wikiPageCommentEditCommand = new Command("edit")
   .option("--body <text>", "댓글 본문 변경 (- 입력 시 stdin, non-interactive)")
   .option("--body-file <path>", "본문 파일 경로 (- 입력 시 stdin, non-interactive)")
   .action(async (arg1, arg2, arg3, opts) => {
+    const parsed = parseWikiCommentArgs(arg1, arg2, arg3, opts);
+
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
-    let projectArg: string | undefined;
-    let pageIdArg: string | undefined;
-    let commentId: string | undefined = opts.commentId;
-    let idOpt: string | undefined;
-    let urlOpt: string | undefined;
-    let projectOpt: string | undefined;
-
-    if (opts.id || opts.url) {
-      if (arg2 || arg3) {
-        throw new DoorayCliError(
-          "--id/--url 모드에서는 댓글 ID 외 추가 positional 인자를 받지 않습니다. --comment-id 옵션 사용을 권장합니다.",
-          EXIT_PARAM_ERROR,
-        );
-      }
-      commentId = commentId ?? arg1;
-      idOpt = opts.id;
-      urlOpt = opts.url;
-      projectOpt = opts.project;
-    } else if (arg3) {
-      projectArg = arg1;
-      pageIdArg = arg2;
-      commentId = commentId ?? arg3;
-    } else if (arg1 && arg2 && opts.commentId) {
-      projectArg = arg1;
-      pageIdArg = arg2;
-    } else {
-      throw new DoorayCliError(
-        "<comment-id>가 필요합니다. positional 3번째 또는 --comment-id 옵션을 사용하세요.",
-        EXIT_PARAM_ERROR,
-      );
-    }
-
-    if (!commentId) {
-      throw new DoorayCliError("<comment-id>가 필요합니다.", EXIT_PARAM_ERROR);
-    }
-
     const { wikiId, pageId } = await resolveWikiPageInput(client, {
-      projectArg,
-      pageIdArg,
-      idOpt,
-      urlOpt,
-      project: projectOpt,
+      projectArg: parsed.projectArg,
+      pageIdArg: parsed.pageIdArg,
+      idOpt: parsed.idOpt,
+      urlOpt: parsed.urlOpt,
+      project: parsed.projectOpt,
     });
 
     startSpinner("댓글 조회 중...");
     let existing;
     try {
-      const detail = await client.getWikiPageComment(wikiId, pageId, commentId);
+      const detail = await client.getWikiPageComment(wikiId, pageId, parsed.commentId);
       existing = detail.result;
       stopSpinner(true, "댓글 조회 완료");
     } catch (e) {
@@ -89,11 +54,11 @@ export const wikiPageCommentEditCommand = new Command("edit")
 
     startSpinner("댓글 수정 중...");
     try {
-      await client.updateWikiPageComment(wikiId, pageId, commentId, {
+      await client.updateWikiPageComment(wikiId, pageId, parsed.commentId, {
         body: { content: newBody },
       });
       stopSpinner(true, "댓글 수정 완료");
-      process.stdout.write(`댓글이 수정되었습니다: ${commentId}\n`);
+      process.stdout.write(`댓글이 수정되었습니다: ${parsed.commentId}\n`);
     } catch (e) {
       stopSpinner(false);
       throw e;

--- a/src/commands/wiki/page-comment/get.test.ts
+++ b/src/commands/wiki/page-comment/get.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { parseGetArgs } from "./get.js";
+import { DoorayCliError } from "../../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
+
+describe("parseGetArgs (wiki page comment)", () => {
+  it("positional 3개 → projectArg / pageIdArg / commentId", () => {
+    const result = parseGetArgs("myproject", "4071828729722696495", "comment-123", {});
+    expect(result.projectArg).toBe("myproject");
+    expect(result.pageIdArg).toBe("4071828729722696495");
+    expect(result.commentId).toBe("comment-123");
+    expect(result.idOpt).toBeUndefined();
+    expect(result.urlOpt).toBeUndefined();
+  });
+
+  it("--url + --comment-id → urlOpt + commentId (projectArg 없음)", () => {
+    const result = parseGetArgs(undefined, undefined, undefined, {
+      url: "https://example.dooray.com/wiki/123/456",
+      commentId: "comment-789",
+    });
+    expect(result.urlOpt).toBe("https://example.dooray.com/wiki/123/456");
+    expect(result.commentId).toBe("comment-789");
+    expect(result.projectArg).toBeUndefined();
+    expect(result.pageIdArg).toBeUndefined();
+  });
+
+  it("--id + --project + --comment-id → idOpt + projectOpt + commentId", () => {
+    const result = parseGetArgs(undefined, undefined, undefined, {
+      id: "4071828729722696495",
+      project: "myproject",
+      commentId: "comment-123",
+    });
+    expect(result.idOpt).toBe("4071828729722696495");
+    expect(result.projectOpt).toBe("myproject");
+    expect(result.commentId).toBe("comment-123");
+    expect(result.projectArg).toBeUndefined();
+  });
+
+  it("positional + --url 동시 → DoorayCliError (EXIT_PARAM_ERROR)", () => {
+    const err = (() => {
+      try {
+        parseGetArgs("myproject", "4071828729722696495", "comment-123", {
+          url: "https://example.dooray.com/wiki/123/456",
+        });
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect(err).toBeInstanceOf(DoorayCliError);
+    expect((err as DoorayCliError).exitCode).toBe(EXIT_PARAM_ERROR);
+  });
+
+  it("--url 만 있고 --comment-id 누락 → DoorayCliError (EXIT_PARAM_ERROR)", () => {
+    const err = (() => {
+      try {
+        parseGetArgs(undefined, undefined, undefined, {
+          url: "https://example.dooray.com/wiki/123/456",
+        });
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect(err).toBeInstanceOf(DoorayCliError);
+    expect((err as DoorayCliError).exitCode).toBe(EXIT_PARAM_ERROR);
+  });
+
+  it("positional 3개 + --comment-id 동시 → DoorayCliError (EXIT_PARAM_ERROR)", () => {
+    const err = (() => {
+      try {
+        parseGetArgs("myproject", "4071828729722696495", "comment-A", {
+          commentId: "comment-B",
+        });
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect(err).toBeInstanceOf(DoorayCliError);
+    expect((err as DoorayCliError).exitCode).toBe(EXIT_PARAM_ERROR);
+  });
+});

--- a/src/commands/wiki/page-comment/get.ts
+++ b/src/commands/wiki/page-comment/get.ts
@@ -1,0 +1,112 @@
+import { Command } from "commander";
+import { getConfigOrThrow } from "../../../config/store.js";
+import { DoorayApiClient } from "../../../api/client.js";
+import { resolveWikiPageInput } from "../../../resolvers/wiki-page-input.js";
+import { formatWikiCommentDetail } from "../../../formatters/wiki-comment.js";
+import type { OutputOptions } from "../../../formatters/table.js";
+import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
+import { DoorayCliError } from "../../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
+
+export interface GetWikiCommentArgs {
+  projectArg?: string;
+  pageIdArg?: string;
+  commentId: string;
+  idOpt?: string;
+  urlOpt?: string;
+  projectOpt?: string;
+}
+
+export function parseGetArgs(
+  arg1: string | undefined,
+  arg2: string | undefined,
+  arg3: string | undefined,
+  opts: { id?: string; url?: string; commentId?: string; project?: string },
+): GetWikiCommentArgs {
+  const hasPositional = arg1 !== undefined || arg2 !== undefined || arg3 !== undefined;
+  const hasIdUrl = !!(opts.id || opts.url);
+
+  if (hasPositional && hasIdUrl) {
+    throw new DoorayCliError(
+      "positional 인자와 --id/--url 옵션은 동시에 사용할 수 없습니다.",
+      EXIT_PARAM_ERROR,
+    );
+  }
+
+  if (hasIdUrl) {
+    if (!opts.commentId) {
+      throw new DoorayCliError(
+        "--id/--url 모드에서는 --comment-id 옵션이 필요합니다.",
+        EXIT_PARAM_ERROR,
+      );
+    }
+    return {
+      commentId: opts.commentId,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+      projectOpt: opts.project,
+    };
+  }
+
+  if (arg3) {
+    if (opts.commentId) {
+      throw new DoorayCliError(
+        "positional 댓글 ID 와 --comment-id 옵션은 동시에 사용할 수 없습니다.",
+        EXIT_PARAM_ERROR,
+      );
+    }
+    return {
+      projectArg: arg1,
+      pageIdArg: arg2,
+      commentId: arg3,
+    };
+  }
+
+  if (arg1 && arg2 && opts.commentId) {
+    return {
+      projectArg: arg1,
+      pageIdArg: arg2,
+      commentId: opts.commentId,
+    };
+  }
+
+  throw new DoorayCliError(
+    "<comment-id>가 필요합니다. positional 3번째 또는 --comment-id 옵션을 사용하세요.",
+    EXIT_PARAM_ERROR,
+  );
+}
+
+export const wikiPageCommentGetCommand = new Command("get")
+  .description("단일 댓글 조회")
+  .argument("[arg1]", "프로젝트 코드 / Dooray Wiki URL (모드별)")
+  .argument("[arg2]", "위키 페이지 ID (모드별)")
+  .argument("[arg3]", "댓글 ID (positional 3개 모드)")
+  .option("--id <pageId>", "위키 페이지 ID (positional 대신)")
+  .option("--url <url>", "Dooray Wiki URL (positional 대신)")
+  .option("--project <code>", "프로젝트 코드 (--id 모드용)")
+  .option("--comment-id <id>", "댓글 ID (arg3 대신)")
+  .action(async (arg1, arg2, arg3, opts) => {
+    const parsed = parseGetArgs(arg1, arg2, arg3, opts);
+
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+    const globalOpts = wikiPageCommentGetCommand.optsWithGlobals() as OutputOptions;
+
+    const { wikiId, pageId } = await resolveWikiPageInput(client, {
+      projectArg: parsed.projectArg,
+      pageIdArg: parsed.pageIdArg,
+      idOpt: parsed.idOpt,
+      urlOpt: parsed.urlOpt,
+      project: parsed.projectOpt,
+    });
+
+    startSpinner("댓글 조회 중...");
+    try {
+      const detail = await client.getWikiPageComment(wikiId, pageId, parsed.commentId);
+      stopSpinner(true, "댓글 조회 완료");
+      formatWikiCommentDetail(detail.result, globalOpts);
+    } catch (e) {
+      stopSpinner(false);
+      throw e;
+    }
+  });

--- a/src/commands/wiki/page-comment/get.ts
+++ b/src/commands/wiki/page-comment/get.ts
@@ -5,76 +5,7 @@ import { resolveWikiPageInput } from "../../../resolvers/wiki-page-input.js";
 import { formatWikiCommentDetail } from "../../../formatters/wiki-comment.js";
 import type { OutputOptions } from "../../../formatters/table.js";
 import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
-import { DoorayCliError } from "../../../utils/errors.js";
-import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
-
-export interface GetWikiCommentArgs {
-  projectArg?: string;
-  pageIdArg?: string;
-  commentId: string;
-  idOpt?: string;
-  urlOpt?: string;
-  projectOpt?: string;
-}
-
-export function parseGetArgs(
-  arg1: string | undefined,
-  arg2: string | undefined,
-  arg3: string | undefined,
-  opts: { id?: string; url?: string; commentId?: string; project?: string },
-): GetWikiCommentArgs {
-  const hasPositional = arg1 !== undefined || arg2 !== undefined || arg3 !== undefined;
-  const hasIdUrl = !!(opts.id || opts.url);
-
-  if (hasPositional && hasIdUrl) {
-    throw new DoorayCliError(
-      "positional 인자와 --id/--url 옵션은 동시에 사용할 수 없습니다.",
-      EXIT_PARAM_ERROR,
-    );
-  }
-
-  if (hasIdUrl) {
-    if (!opts.commentId) {
-      throw new DoorayCliError(
-        "--id/--url 모드에서는 --comment-id 옵션이 필요합니다.",
-        EXIT_PARAM_ERROR,
-      );
-    }
-    return {
-      commentId: opts.commentId,
-      idOpt: opts.id,
-      urlOpt: opts.url,
-      projectOpt: opts.project,
-    };
-  }
-
-  if (arg3) {
-    if (opts.commentId) {
-      throw new DoorayCliError(
-        "positional 댓글 ID 와 --comment-id 옵션은 동시에 사용할 수 없습니다.",
-        EXIT_PARAM_ERROR,
-      );
-    }
-    return {
-      projectArg: arg1,
-      pageIdArg: arg2,
-      commentId: arg3,
-    };
-  }
-
-  if (arg1 && arg2 && opts.commentId) {
-    return {
-      projectArg: arg1,
-      pageIdArg: arg2,
-      commentId: opts.commentId,
-    };
-  }
-
-  throw new DoorayCliError(
-    "<comment-id>가 필요합니다. positional 3번째 또는 --comment-id 옵션을 사용하세요.",
-    EXIT_PARAM_ERROR,
-  );
-}
+import { parseWikiCommentArgs } from "./parse-args.js";
 
 export const wikiPageCommentGetCommand = new Command("get")
   .description("단일 댓글 조회")
@@ -86,7 +17,7 @@ export const wikiPageCommentGetCommand = new Command("get")
   .option("--project <code>", "프로젝트 코드 (--id 모드용)")
   .option("--comment-id <id>", "댓글 ID (arg3 대신)")
   .action(async (arg1, arg2, arg3, opts) => {
-    const parsed = parseGetArgs(arg1, arg2, arg3, opts);
+    const parsed = parseWikiCommentArgs(arg1, arg2, arg3, opts);
 
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);

--- a/src/commands/wiki/page-comment/index.ts
+++ b/src/commands/wiki/page-comment/index.ts
@@ -1,0 +1,17 @@
+import { Command } from "commander";
+import { wikiPageCommentListCommand } from "./list.js";
+import { wikiPageCommentLatestCommand } from "./latest.js";
+import { wikiPageCommentGetCommand } from "./get.js";
+import { wikiPageCommentAddCommand } from "./add.js";
+import { wikiPageCommentEditCommand } from "./edit.js";
+import { wikiPageCommentDeleteCommand } from "./delete.js";
+
+export const wikiPageCommentCommand = new Command("comment")
+  .description("위키 페이지 댓글 관련 명령");
+
+wikiPageCommentCommand.addCommand(wikiPageCommentListCommand);
+wikiPageCommentCommand.addCommand(wikiPageCommentLatestCommand);
+wikiPageCommentCommand.addCommand(wikiPageCommentGetCommand);
+wikiPageCommentCommand.addCommand(wikiPageCommentAddCommand);
+wikiPageCommentCommand.addCommand(wikiPageCommentEditCommand);
+wikiPageCommentCommand.addCommand(wikiPageCommentDeleteCommand);

--- a/src/commands/wiki/page-comment/latest.ts
+++ b/src/commands/wiki/page-comment/latest.ts
@@ -1,0 +1,42 @@
+import { Command } from "commander";
+import { getConfigOrThrow } from "../../../config/store.js";
+import { DoorayApiClient } from "../../../api/client.js";
+import { resolveWikiPageInput } from "../../../resolvers/wiki-page-input.js";
+import { formatWikiCommentDetail } from "../../../formatters/wiki-comment.js";
+import type { OutputOptions } from "../../../formatters/table.js";
+import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
+
+export const wikiPageCommentLatestCommand = new Command("latest")
+  .description("최신 댓글 1건 조회 (= comment list --latest 1)")
+  .argument("[project]", "프로젝트 코드 (또는 첫 인자에 Dooray Wiki URL)")
+  .argument("[page-id]", "위키 페이지 ID")
+  .option("--id <pageId>", "위키 페이지 ID (--project 동반)")
+  .option("--url <url>", "Dooray Wiki URL")
+  .option("--project <code>", "프로젝트 코드 (--id 모드용)")
+  .action(async (project, pageIdArg, opts) => {
+    const globalOpts = wikiPageCommentLatestCommand.optsWithGlobals() as OutputOptions;
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+
+    const { wikiId, pageId } = await resolveWikiPageInput(client, {
+      projectArg: project,
+      pageIdArg,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+      project: opts.project,
+    });
+
+    startSpinner("최신 댓글 조회 중...");
+    try {
+      const res = await client.getWikiPageComments(wikiId, pageId, { size: 1, page: 0 });
+      stopSpinner(true, res.result.length > 0 ? "최신 댓글" : "댓글 없음");
+      if (res.result.length === 0) {
+        process.stdout.write("댓글이 없습니다.\n");
+        return;
+      }
+      formatWikiCommentDetail(res.result[0]!, globalOpts);
+    } catch (e) {
+      stopSpinner(false);
+      throw e;
+    }
+  });

--- a/src/commands/wiki/page-comment/list.ts
+++ b/src/commands/wiki/page-comment/list.ts
@@ -1,0 +1,44 @@
+import { Command } from "commander";
+import { getConfigOrThrow } from "../../../config/store.js";
+import { DoorayApiClient } from "../../../api/client.js";
+import { resolveWikiPageInput } from "../../../resolvers/wiki-page-input.js";
+import { formatWikiCommentList } from "../../../formatters/wiki-comment.js";
+import type { OutputOptions } from "../../../formatters/table.js";
+import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
+
+export const wikiPageCommentListCommand = new Command("list")
+  .description("위키 페이지 댓글 목록 조회 (최신순)")
+  .argument("[project]", "프로젝트 코드 (또는 첫 인자에 Dooray Wiki URL)")
+  .argument("[page-id]", "위키 페이지 ID")
+  .option("--id <pageId>", "위키 페이지 ID (--project 동반)")
+  .option("--url <url>", "Dooray Wiki URL")
+  .option("--project <code>", "프로젝트 코드 (--id 모드용)")
+  .option("--size <n>", "페이지 크기 (기본 20, 최대 100)", (v) => parseInt(v, 10))
+  .option("--page <n>", "페이지 번호 (0부터)", (v) => parseInt(v, 10))
+  .option("--latest <n>", "최신 N개만 (size 대신 사용)", (v) => parseInt(v, 10))
+  .action(async (project, pageIdArg, opts) => {
+    const globalOpts = wikiPageCommentListCommand.optsWithGlobals() as OutputOptions;
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+
+    const { wikiId, pageId } = await resolveWikiPageInput(client, {
+      projectArg: project,
+      pageIdArg,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+      project: opts.project,
+    });
+
+    const size = opts.latest ?? opts.size ?? 20;
+    const page = opts.page ?? 0;
+
+    startSpinner("댓글 목록 조회 중...");
+    try {
+      const res = await client.getWikiPageComments(wikiId, pageId, { size, page });
+      stopSpinner(true, `댓글 ${res.result.length}건 (총 ${res.totalCount})`);
+      formatWikiCommentList(res.result, { globalOpts, totalCount: res.totalCount });
+    } catch (e) {
+      stopSpinner(false);
+      throw e;
+    }
+  });

--- a/src/commands/wiki/page-comment/parse-args.test.ts
+++ b/src/commands/wiki/page-comment/parse-args.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { parseGetArgs } from "./get.js";
+import { parseWikiCommentArgs } from "./parse-args.js";
 import { DoorayCliError } from "../../../utils/errors.js";
 import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
 
-describe("parseGetArgs (wiki page comment)", () => {
+describe("parseWikiCommentArgs (wiki page comment)", () => {
   it("positional 3개 → projectArg / pageIdArg / commentId", () => {
-    const result = parseGetArgs("myproject", "4071828729722696495", "comment-123", {});
+    const result = parseWikiCommentArgs("myproject", "4071828729722696495", "comment-123", {});
     expect(result.projectArg).toBe("myproject");
     expect(result.pageIdArg).toBe("4071828729722696495");
     expect(result.commentId).toBe("comment-123");
@@ -14,7 +14,7 @@ describe("parseGetArgs (wiki page comment)", () => {
   });
 
   it("--url + --comment-id → urlOpt + commentId (projectArg 없음)", () => {
-    const result = parseGetArgs(undefined, undefined, undefined, {
+    const result = parseWikiCommentArgs(undefined, undefined, undefined, {
       url: "https://example.dooray.com/wiki/123/456",
       commentId: "comment-789",
     });
@@ -25,7 +25,7 @@ describe("parseGetArgs (wiki page comment)", () => {
   });
 
   it("--id + --project + --comment-id → idOpt + projectOpt + commentId", () => {
-    const result = parseGetArgs(undefined, undefined, undefined, {
+    const result = parseWikiCommentArgs(undefined, undefined, undefined, {
       id: "4071828729722696495",
       project: "myproject",
       commentId: "comment-123",
@@ -39,7 +39,7 @@ describe("parseGetArgs (wiki page comment)", () => {
   it("positional + --url 동시 → DoorayCliError (EXIT_PARAM_ERROR)", () => {
     const err = (() => {
       try {
-        parseGetArgs("myproject", "4071828729722696495", "comment-123", {
+        parseWikiCommentArgs("myproject", "4071828729722696495", "comment-123", {
           url: "https://example.dooray.com/wiki/123/456",
         });
       } catch (e) {
@@ -53,7 +53,7 @@ describe("parseGetArgs (wiki page comment)", () => {
   it("--url 만 있고 --comment-id 누락 → DoorayCliError (EXIT_PARAM_ERROR)", () => {
     const err = (() => {
       try {
-        parseGetArgs(undefined, undefined, undefined, {
+        parseWikiCommentArgs(undefined, undefined, undefined, {
           url: "https://example.dooray.com/wiki/123/456",
         });
       } catch (e) {
@@ -67,7 +67,7 @@ describe("parseGetArgs (wiki page comment)", () => {
   it("positional 3개 + --comment-id 동시 → DoorayCliError (EXIT_PARAM_ERROR)", () => {
     const err = (() => {
       try {
-        parseGetArgs("myproject", "4071828729722696495", "comment-A", {
+        parseWikiCommentArgs("myproject", "4071828729722696495", "comment-A", {
           commentId: "comment-B",
         });
       } catch (e) {

--- a/src/commands/wiki/page-comment/parse-args.ts
+++ b/src/commands/wiki/page-comment/parse-args.ts
@@ -1,0 +1,70 @@
+import { DoorayCliError } from "../../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
+
+export interface WikiCommentArgs {
+  projectArg?: string;
+  pageIdArg?: string;
+  commentId: string;
+  idOpt?: string;
+  urlOpt?: string;
+  projectOpt?: string;
+}
+
+export function parseWikiCommentArgs(
+  arg1: string | undefined,
+  arg2: string | undefined,
+  arg3: string | undefined,
+  opts: { id?: string; url?: string; commentId?: string; project?: string },
+): WikiCommentArgs {
+  const hasPositional = arg1 !== undefined || arg2 !== undefined || arg3 !== undefined;
+  const hasIdUrl = !!(opts.id || opts.url);
+
+  if (hasPositional && hasIdUrl) {
+    throw new DoorayCliError(
+      "positional 인자와 --id/--url 옵션은 동시에 사용할 수 없습니다.",
+      EXIT_PARAM_ERROR,
+    );
+  }
+
+  if (hasIdUrl) {
+    if (!opts.commentId) {
+      throw new DoorayCliError(
+        "--id/--url 모드에서는 --comment-id 옵션이 필요합니다.",
+        EXIT_PARAM_ERROR,
+      );
+    }
+    return {
+      commentId: opts.commentId,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+      projectOpt: opts.project,
+    };
+  }
+
+  if (arg3) {
+    if (opts.commentId) {
+      throw new DoorayCliError(
+        "positional 댓글 ID 와 --comment-id 옵션은 동시에 사용할 수 없습니다.",
+        EXIT_PARAM_ERROR,
+      );
+    }
+    return {
+      projectArg: arg1,
+      pageIdArg: arg2,
+      commentId: arg3,
+    };
+  }
+
+  if (arg1 && arg2 && opts.commentId) {
+    return {
+      projectArg: arg1,
+      pageIdArg: arg2,
+      commentId: opts.commentId,
+    };
+  }
+
+  throw new DoorayCliError(
+    "<comment-id>가 필요합니다. positional 3번째 또는 --comment-id 옵션을 사용하세요.",
+    EXIT_PARAM_ERROR,
+  );
+}

--- a/src/formatters/wiki-comment.test.ts
+++ b/src/formatters/wiki-comment.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { WikiComment } from "../api/types.js";
+import { formatWikiCommentDetail, formatWikiCommentList } from "./wiki-comment.js";
+
+const fixture: WikiComment = {
+  id: "3950295078642684620",
+  page: { id: "3521165468947041024" },
+  createdAt: "2024-12-03T17:51:10+09:00",
+  modifiedAt: "2024-12-03T17:51:10+09:00",
+  creator: { type: "member", member: { organizationMemberId: "u1", name: "홍길동" } },
+  body: { mimeType: "text/x-markdown", content: "테스트 댓글 본문" },
+};
+
+describe("formatWikiCommentDetail", () => {
+  let writes: string[];
+  beforeEach(() => {
+    writes = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((s: any) => {
+      writes.push(String(s));
+      return true;
+    });
+  });
+
+  it("table 모드 — 핵심 필드 모두 표시", () => {
+    formatWikiCommentDetail(fixture, {});
+    const joined = writes.join("");
+    expect(joined).toContain("ID:");
+    expect(joined).toContain("홍길동");
+    expect(joined).toContain("테스트 댓글 본문");
+  });
+
+  it("--json 모드 — raw 객체 JSON 출력", () => {
+    formatWikiCommentDetail(fixture, { json: true });
+    const parsed = JSON.parse(writes.join(""));
+    expect(parsed.id).toBe(fixture.id);
+  });
+
+  it("--quiet 모드 — ID 만 출력", () => {
+    formatWikiCommentDetail(fixture, { quiet: true });
+    expect(writes.join("").trim()).toBe(fixture.id);
+  });
+});

--- a/src/formatters/wiki-comment.ts
+++ b/src/formatters/wiki-comment.ts
@@ -1,0 +1,52 @@
+import type { WikiComment } from "../api/types.js";
+import type { OutputOptions } from "./table.js";
+import { output, printJson, printQuiet } from "./table.js";
+
+export interface FormatWikiCommentOptions {
+  globalOpts: OutputOptions;
+  totalCount?: number;
+}
+
+export function formatWikiCommentList(
+  comments: WikiComment[],
+  opts: FormatWikiCommentOptions,
+): void {
+  output(opts.globalOpts, {
+    headers: ["ID", "작성자", "생성일", "본문 (요약)"],
+    rows: comments.map((c) => [
+      c.id,
+      c.creator.member.name,
+      c.createdAt,
+      truncate(c.body.content, 60),
+    ]),
+    raw: comments,
+    ids: comments.map((c) => c.id),
+  });
+}
+
+export function formatWikiCommentDetail(
+  comment: WikiComment,
+  globalOpts: OutputOptions,
+): void {
+  if (globalOpts.json) {
+    printJson(comment);
+    return;
+  }
+  if (globalOpts.quiet) {
+    printQuiet([comment.id]);
+    return;
+  }
+  process.stdout.write(`ID:       ${comment.id}\n`);
+  process.stdout.write(`Page ID:  ${comment.page.id}\n`);
+  process.stdout.write(`작성자:   ${comment.creator.member.name}\n`);
+  process.stdout.write(`생성일:   ${comment.createdAt}\n`);
+  if (comment.modifiedAt && comment.modifiedAt !== comment.createdAt) {
+    process.stdout.write(`수정일:   ${comment.modifiedAt}\n`);
+  }
+  process.stdout.write(`\n${comment.body.content}\n`);
+}
+
+function truncate(s: string, n: number): string {
+  const oneLine = s.replace(/\s+/g, " ").trim();
+  return oneLine.length <= n ? oneLine : oneLine.slice(0, n - 1) + "…";
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import { wikiPageGetCommand } from "./commands/wiki/page-get.js";
 import { wikiPageCreateCommand } from "./commands/wiki/page-create.js";
 import { wikiPageEditCommand } from "./commands/wiki/page-edit.js";
 import { wikiPageFileCommand } from "./commands/wiki/page-file/index.js";
+import { wikiPageCommentCommand } from "./commands/wiki/page-comment/index.js";
 import { memberCommand } from "./commands/member/index.js";
 import { mailListCommand } from "./commands/mail/list.js";
 import { mailGetCommand } from "./commands/mail/get.js";
@@ -118,6 +119,7 @@ wikiPageCommand.addCommand(wikiPageGetCommand);
 wikiPageCommand.addCommand(wikiPageCreateCommand);
 wikiPageCommand.addCommand(wikiPageEditCommand);
 wikiPageCommand.addCommand(wikiPageFileCommand);
+wikiPageCommand.addCommand(wikiPageCommentCommand);
 wikiCommand.addCommand(wikiPageCommand);
 
 // mail 커맨드 그룹

--- a/tasks/036-feat-wiki-page-comment-commands/index.json
+++ b/tasks/036-feat-wiki-page-comment-commands/index.json
@@ -3,8 +3,8 @@
   "description": "wiki 페이지 댓글 CLI 6 명령 추가 (list/latest/get/add/edit/delete). post comment 패턴 mirror. 단 wiki comment API 는 mention / cc / 첨부 파일 미지원이므로 시그니처 축소. WikiComment 타입 신설 (page.id + creator.member) + formatters/wiki-comment.ts 전용 포맷. resolveWikiPageInput 재사용 — task 035 phase-01 산출물 의존. 신규 ADR 불요 (API 단순, 함정 없음). cmux-browser 로 공식 API 스펙 재확인 완료 (2026-05-21).",
   "depends_on": "035-feat-wiki-page-file-commands (phase-01 의 resolveWikiPageInput 필요)",
   "created_at": "2026-05-21T00:00:00Z",
-  "status": "in_progress",
-  "current_phase": 1,
+  "status": "completed",
+  "current_phase": 3,
   "total_phases": 3,
   "error_message": null,
   "blocked_reason": null,
@@ -13,23 +13,23 @@
       "number": 1,
       "title": "api/client (5 method) + types (WikiComment + WikiCommentBody 등) + formatters/wiki-comment.ts + 단위 테스트",
       "file": "phase-01.md",
-      "status": "in_progress",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 2,
       "title": "commands/wiki/page-comment/ 6 명령 (list/latest/get/add/edit/delete) + index.ts 등록",
       "file": "phase-02.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 3,
       "title": "README + skills/dooray-cli/SKILL.md + 빌드/실증 검증 + 완료 마킹",
       "file": "phase-03.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],
-  "updated_at": "2026-05-21T00:00:00Z"
+  "updated_at": "2026-05-21T09:00:00Z"
 }

--- a/tasks/036-feat-wiki-page-comment-commands/index.json
+++ b/tasks/036-feat-wiki-page-comment-commands/index.json
@@ -3,17 +3,17 @@
   "description": "wiki 페이지 댓글 CLI 6 명령 추가 (list/latest/get/add/edit/delete). post comment 패턴 mirror. 단 wiki comment API 는 mention / cc / 첨부 파일 미지원이므로 시그니처 축소. WikiComment 타입 신설 (page.id + creator.member) + formatters/wiki-comment.ts 전용 포맷. resolveWikiPageInput 재사용 — task 035 phase-01 산출물 의존. 신규 ADR 불요 (API 단순, 함정 없음). cmux-browser 로 공식 API 스펙 재확인 완료 (2026-05-21).",
   "depends_on": "035-feat-wiki-page-file-commands (phase-01 의 resolveWikiPageInput 필요)",
   "created_at": "2026-05-21T00:00:00Z",
-  "status": "pending",
+  "status": "in_progress",
   "current_phase": 1,
   "total_phases": 3,
   "error_message": null,
-  "blocked_reason": "task 035 머지 후 시작",
+  "blocked_reason": null,
   "phases": [
     {
       "number": 1,
       "title": "api/client (5 method) + types (WikiComment + WikiCommentBody 등) + formatters/wiki-comment.ts + 단위 테스트",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "in_progress",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {


### PR DESCRIPTION
## Summary

Wiki 페이지 댓글 CLI 6 명령 추가 — `dooray wiki page comment {list,latest,get,add,edit,delete}`.
post comment 패턴 mirror 하되 wiki comment API 제약 (mention / cc / 첨부 파일 미지원) 으로 시그니처 축소.

## Commits

- 7bf9ed1 feat(api,formatters): add wiki page comment types/methods + WikiComment formatter (phase 1/3)
- 6f49c40 feat(commands): add wiki page comment 6 commands (list/latest/get/add/edit/delete, phase 2/3)
- 01a3d2d docs(readme,skill): document wiki page comment 6 commands + complete task 036

## 변경 사항

- `src/api/types.ts` — WikiComment / WikiCommentBody / Page / Creator / Create·Update Request / List·Detail·Create Response 8 타입 신설
- `src/api/client.ts` — getWikiPageComments / getWikiPageComment / addWikiPageComment / updateWikiPageComment / deleteWikiPageComment 5 메소드
- `src/formatters/wiki-comment.ts` — formatWikiCommentList / formatWikiCommentDetail (page.id + creator.member 시그니처)
- `src/commands/wiki/page-comment/` — list / latest / get / add / edit / delete 6 명령 + index.ts
- `src/index.ts` — wikiPageCommand 에 comment 그룹 등록
- README.md / skills/dooray-cli/SKILL.md — 6 명령 사용 예 + 빠른 참조 표

## post comment 대비 축소 (wiki API 미지원)

- mention / mention-group / link-task / dry-run 미지원
- cc / 받는 사람 / 첨부 파일 미지원
- request body 에 `mimeType` 미전송

## Test plan

- [x] `pnpm tsc --noEmit` — 에러 0건
- [x] `pnpm build && pnpm test` — 21 파일 149 케이스 통과 (신규 9 케이스 포함: formatter 3 + parseGetArgs 6)
- [x] `node dist/index.js wiki page comment --help` — 6 명령 노출 확인
- [x] critic APPROVE / code-reviewer PASS / docs-verifier PASS (1-shot)
- [ ] 실제 Dooray 환경에서 6 명령 smoke test (list/latest/get/add/edit/delete)

🤖 Generated with build-with-teams (plan036)