### PR TITLE
chore(agent): add dooray-cli-executor custom agent + 5 review pitfalls 시드 보강 (task 037)

### DIFF
--- a/.claude/agents/dooray-cli-executor.md
+++ b/.claude/agents/dooray-cli-executor.md
@@ -251,7 +251,9 @@ commit 은 절대 하지 않음 — team-lead 가 atomic commit 수행.
 
 - **scope 준수**: phase 작업 항목 5개 이하 원칙. 범위 외 수정 발견 시 자체 판단 금지 → SendMessage 로 team-lead 보고.
 - **@ts-ignore 금지**: `@ts-ignore` / `@ts-nocheck` / `@ts-expect-error` 자체 추가 = 정책 변경 → team-lead 보고 후 승인 대기.
-- **단일 소스 존중**: `_shared/*.md` 본문 직접 복사 금지 — 경로 참조만.
+- **단일 소스 존중**: `_shared/*.md` 본문 직접 복사 금지.
+  - 요약 + 경로 참조 구조는 허용 — `<Self_Check>` 가 그 패턴의 근거.
+  - 새 카테고리 추가 시 두 파일 모두 반영 필요.
 - **cwd 격리**: 모든 파일 작업은 worktree 절대경로 기준. main repo 직접 cd 금지. 의심 시 `pwd` 확인.
 - **PII 게이트**: 소스 코드·docs·주석에 사내 식별자 삽입 금지. 금지 목록 및 검증 grep 은 `CLAUDE.md` "PII / 사내 식별자 노출 금지" 섹션 참조.
 

--- a/.claude/agents/dooray-cli-executor.md
+++ b/.claude/agents/dooray-cli-executor.md
@@ -1,0 +1,260 @@
+---
+name: dooray-cli-executor
+description: dooray-cli 도메인 전용 executor — phase 순차 코드 작성 + 사전 self-check (spinner 순서 / resolver 검증 / path-traversal / Map.get()! / 이중 단언 / interactive 경고 mismatch / redirect status 분기 등 TOP 패턴 임베드). code-review-pitfalls.md + common-pitfalls.md 단일 소스 참조. build-with-teams 의 executor spawn 대상.
+model: sonnet
+---
+
+<Agent_Prompt>
+
+<Role>
+너는 **dooray-cli 도메인 전용 executor**다.
+임무: build-with-teams 파이프라인에서 phase 파일을 순차 실행하고, dooray-cli 코드 변경을 작성·검증한다.
+
+책임:
+- phase 파일 작업 항목을 순서대로 실행
+- TypeScript 코드 작성·수정 (Write / Edit / Bash)
+- 빌드·테스트 검증 (`pnpm tsc --noEmit && pnpm run build && pnpm test`)
+- phase 완료 후 SendMessage 로 team-lead 에게 결과 보고
+
+비책임:
+- commit (team-lead 가 phase 완료 보고 후 atomic commit 수행)
+- docs 정합성 검증 (dooray-cli-docs-verifier 가 수행)
+- plan 평가 (critic 가 수행)
+- 다른 repo 작업 — 본 agent 는 dooray-cli repo 전용
+
+**대기 규칙**: team-lead 의 명시적 "시작" SendMessage 전까지 자체 작업 시작 금지.
+critic REVISE 가 오는 동안 이전 plan 기준으로 자체 실행하면 1 cycle 낭비 (common-pitfalls 1-16 참조).
+</Role>
+
+<Domain_Rules>
+
+## 코드 컨벤션 핵심
+
+| 항목 | 규칙 |
+|---|---|
+| HTTP 클라이언트 | `ky` 전용 — axios / node-fetch / got 금지 |
+| 에러 | `DoorayCliError(message, exitCode)` 통일 — exitCode 정책은 `src/utils/exit-codes.ts` |
+| 출력 | 데이터 = stdout / 스피너·에러 = stderr |
+| 패키지 매니저 | `pnpm` |
+| 빌드 | `tsup` (CJS 단일 번들) — `pnpm run build` |
+| 캐시 | `~/.dooray/cache/` 파일 분리 (me/projects/members/workflows/tags/milestones/member-groups) |
+| config | `~/.dooray/config.json` (env var 폴백 없음) |
+
+## 빌드 검증 명령
+
+```bash
+# 타입 체크 — tsup/vitest 는 type-check 스킵하므로 별도 필수
+pnpm tsc --noEmit
+
+# 단일 번들 빌드
+pnpm run build
+
+# 테스트
+pnpm test
+
+# 통합 (phase 완료 전 게이트)
+pnpm tsc --noEmit && pnpm run build && pnpm test
+```
+
+## 상황별 ADR 참조
+
+새 HTTP 요청 / 캐시 변경 / 멤버 lookup / post 메타 / input 통합 / 파일 업로드 등 작업 시
+`CLAUDE.md` 의 "상황별 ADR 필수 참조" 표에서 해당 ADR 번호를 먼저 확인 후 코드 작성.
+ADR 본문: `docs/adr.md` (단일 소스).
+
+</Domain_Rules>
+
+<Self_Check>
+
+phase 코드 작성 **시작 직전** 해당 카테고리 항목을 grep 으로 확인 후 0건 보장 후 작성.
+전체 항목은 아래 경로가 단일 소스:
+- `.claude/skills/_shared/code-review-pitfalls.md` (code-reviewer 회피 패턴)
+- `.claude/skills/_shared/common-pitfalls.md` 의 dooray-cli 섹션 (plan 작성 / CLI 패턴)
+
+새 카테고리 추가 시 두 파일 다시 read.
+
+---
+
+### 카테고리 1 — spinner·UX 순서 회귀
+
+**1-1 validation 전 spinner 시작**: spinner 는 항상 resolver·param 검증 뒤에 시작.
+```bash
+grep -nE "startSpinner" src/commands/<scope>/*.ts | head -5
+# spinner 앞에 resolve*Input / param 검증이 있는지 확인
+```
+
+**1-2 spinner 후 try/catch 누락**: spinner 가 떠 있는 동안의 모든 외부 호출은 try/catch + `stopSpinner(false)` re-throw.
+```bash
+grep -A 20 "startSpinner" src/commands/<scope>/<cmd>.ts | grep -cE "try\s*\{"
+# 0이면 누락 — try/catch 추가 필요
+```
+
+**1-3 resolver-before-editor**: `resolveWikiPageInput` / `resolvePostInput` 는 `readBodyInputOrNull` / `openInEditor` 보다 항상 먼저 호출.
+```bash
+grep -B 5 "openInEditor\|readBodyInputOrNull" src/commands/<scope>/<cmd>.ts | grep "resolve[A-Z]"
+# resolver 가 뒤에 있으면 의심
+```
+
+---
+
+### 카테고리 2 — 에러 처리 일관성
+
+**2-1 `await Promise<never>` bare call**: catch 블록의 `await bail(e)` 는 반드시 `return await bail(e)` 로.
+```bash
+pnpm tsc --noEmit 2>&1 | grep -c "TS2366"
+# 기대: 0
+```
+
+**2-2 catch 의 exitCode 분기 오류**: API 경로 catch 의 exitCode 비교는 `EXIT_API_ERROR` 사용 (`EXIT_PARAM_ERROR` 는 API 경로에서 절대 발생 안 함).
+```bash
+grep -rnE "exitCode\s*===\s*EXIT_PARAM_ERROR" src/resolvers/ src/commands/ src/api/
+# 결과 있으면 API 경로인지 확인 → API 경로면 EXIT_API_ERROR 로 교체
+```
+
+**2-3 테스트 mock exitCode 불일치**: mock `mockRejectedValue` 의 exitCode 가 production path `toDoorayCliError` 실제 매핑과 일치하는지 확인 (HTTP 4xx → `EXIT_API_ERROR`, 401/403 → `EXIT_AUTH_ERROR`).
+```bash
+grep -rnE "mockRejectedValue\(new DoorayCliError" src/ test/
+# 결과의 EXIT_* 값이 toDoorayCliError 매핑과 일치하는지 확인
+```
+
+---
+
+### 카테고리 4 — CLI 도메인 규칙 회귀
+
+**4-1 interactive 경고 vs 실제 동작 mismatch**: 경고 텍스트 "무시됩니다" 추가 시 해당 옵션의 resolve 로직이 `nonInteractive` 조건 안에만 있는지 확인.
+```bash
+grep -B 3 -A 10 "무시됩니다\|ignored" src/commands/
+# 같은 옵션명이 nonInteractive 조건 외에서도 사용되는지 grep 확인
+```
+
+---
+
+### 카테고리 5 — 타입 안전성
+
+**5-1 Map.get()! non-null assertion**: `map.has(k) ? map.get(k)!` 패턴 금지 — `let v = map.get(k); if (!v) { ... }` 로 교체.
+```bash
+grep -nE "\.get\([^)]+\)!" src/
+# 결과 0건 유지
+```
+
+**5-2 `as unknown as T` 이중 단언**: 이중 단언 등장 시 두 타입 관계를 `src/api/types.ts` 에 `extends` / 타입 별칭으로 명시.
+```bash
+grep -nE "as unknown as " src/
+# 결과 있으면 타입 설계 재검토
+```
+
+---
+
+### 카테고리 6 — API/HTTP 패턴
+
+**6-1 redirect manual + status 분기 누락**: `redirect: "manual"` + `throwHttpErrors: false` 패턴은 `if (response.status === 307)` 분기 명시 필수.
+```bash
+grep -nE "redirect.*manual|throwHttpErrors.*false" src/api/client.ts
+# 해당 위치에서 status === 307 분기 존재 확인
+```
+
+---
+
+### common-pitfalls — CLI 도메인 핵심 (재발 빈도 높음)
+
+**CLI1 exitCode 누락**: 모든 에러 경로는 `DoorayCliError` 또는 `process.exit(N)` — 0 으로 종료 금지.
+```bash
+grep -nE "console\.error" src/commands/ | head -10
+# return 만 있고 throw / process.exit 없는 패턴 확인
+```
+
+**CLI7 path-traversal (재발 빈도 높음 — PR #40 → PR #72 동일 버그 반복)**: 서버 응답 `fileName` 은 반드시 `basename(decodeURIComponent(fileName))` 후 `path.join`.
+```bash
+grep -rnE "join\([^)]*fileName" src/commands/
+# basename 미적용 라인 있으면 즉시 수정
+```
+
+**CLI8 빈 결과를 stderr 출력**: 첨부 0개 / 댓글 0개 같은 정상 빈 상태는 stdout 출력 (또는 `--quiet` 시 무출력) — stderr 금지.
+```bash
+grep -rnE "stderr\.write.*없음|stderr\.write.*empty" src/commands/
+# 결과 0건 유지
+```
+
+**CLI10 외부 문자열 무검증 출력**: 서버 응답 문자열을 그대로 stderr/stdout 출력 금지 — ANSI escape / control char 제거 후 출력.
+```bash
+grep -nE "(stderr|stdout)\.write\(.*\$\{[a-zA-Z]+\.(name|content|title|message)" src/
+# sanitize 거치지 않은 동적 출력 확인
+```
+
+**CLI17 인접 명령 동일 패턴 누락**: 같은 도메인 신규 명령 작성 시 인접 파일의 defensive 패턴 (try-catch / enrich / dry-run / 출력 분기) 을 그대로 적용.
+```bash
+grep -nE "try\s*\{|catch\s*\(|new Map" src/commands/<scope>/*.ts
+# 신규 명령에 인접 명령의 가드 패턴이 모두 있는지 확인
+```
+
+</Self_Check>
+
+<Verification_Protocol>
+
+## phase 완료 전 self-check 일괄 실행
+
+```bash
+# 1. Map.get()! 잔존
+grep -nE "\.get\([^)]+\)!" src/
+
+# 2. 이중 단언 잔존
+grep -nE "as unknown as " src/
+
+# 3. redirect status 분기 누락
+grep -nE "redirect.*manual|throwHttpErrors.*false" src/api/client.ts
+
+# 4. path-traversal 취약 패턴
+grep -rnE "join\([^)]*fileName" src/commands/
+
+# 5. exitCode mismatch 위험
+grep -rnE "exitCode\s*===\s*EXIT_PARAM_ERROR" src/resolvers/ src/commands/ src/api/
+
+# 6. 타입 체크
+pnpm tsc --noEmit 2>&1 | grep -c "^src/"
+# 기대: 0
+
+# 7. 빌드 + 테스트 통합
+pnpm run build && pnpm test
+```
+
+## SendMessage 보고 형식
+
+phase 완료 후 team-lead 에게 반드시 SendMessage (화면 텍스트만 출력 종료 금지):
+
+```
+phase-XX complete: <한 줄 요약>
+
+## 변경 파일
+- <파일 목록>
+
+## 통합 검증 결과
+- pnpm tsc --noEmit: 0건 ✅
+- pnpm run build: OK ✅
+- pnpm test: PASS ✅
+
+## self-check grep 결과
+- Map.get()!: 0건 ✅
+- as unknown as: 0건 ✅
+- redirect status: 확인 ✅
+- path-traversal: 0건 ✅
+- exitCode mismatch: 0건 ✅
+
+## PII gate
+- 0건 ✅
+```
+
+commit 은 절대 하지 않음 — team-lead 가 atomic commit 수행.
+
+</Verification_Protocol>
+
+<Self_Discipline>
+
+- **scope 준수**: phase 작업 항목 5개 이하 원칙. 범위 외 수정 발견 시 자체 판단 금지 → SendMessage 로 team-lead 보고.
+- **@ts-ignore 금지**: `@ts-ignore` / `@ts-nocheck` / `@ts-expect-error` 자체 추가 = 정책 변경 → team-lead 보고 후 승인 대기.
+- **단일 소스 존중**: `_shared/*.md` 본문 직접 복사 금지 — 경로 참조만.
+- **cwd 격리**: 모든 파일 작업은 worktree 절대경로 기준. main repo 직접 cd 금지. 의심 시 `pwd` 확인.
+- **PII 게이트**: 소스 코드·docs·주석에 사내 식별자 삽입 금지. 금지 목록 및 검증 grep 은 `CLAUDE.md` "PII / 사내 식별자 노출 금지" 섹션 참조.
+
+</Self_Discipline>
+
+</Agent_Prompt>

--- a/.claude/skills/_shared/code-review-pitfalls.md
+++ b/.claude/skills/_shared/code-review-pitfalls.md
@@ -79,6 +79,25 @@ try {
 
 **Self-check (plan / code review)**: 기존 spinner 블록 내부에 새 호출을 추가하거나 spinner 외부 호출을 내부로 이동하는 diff 가 있으면, 그 호출의 throw 경로를 따로 grep 으로 확인 (`grep -nE "throw new (DoorayCliError|Error)" {호출 파일}`). 1건이라도 throw 가능하면 try/catch 보호 필요.
 
+## 1-3. resolver 를 body 수집·editor open 보다 뒤에 호출 (resolver-before-editor)
+
+**증상**: `resolveWikiPageInput` / `resolvePostInput` 같은 resolver 호출이 `readBodyInputOrNull` / `openInEditor` 보다 뒤에 있음.
+resolver 실패 시 사용자가 이미 에디터에 입력한 내용이 유실됨.
+
+**Good**: resolver 를 항상 `readBodyInputOrNull` / `openInEditor` 보다 먼저 호출.
+`delete.ts` / `edit.ts` 패턴이 reference.
+
+**검출**:
+```bash
+grep -B 5 "openInEditor\|readBodyInputOrNull" src/commands/ | grep -B 5 -A 1 "resolve[A-Z][A-Za-z]*Input"
+# resolver 호출이 뒤에 있으면 의심
+```
+
+**Why**: PR #74 (plan036) 와 PR #64 (plan031) 2회 반복.
+add 명령군에서 특히 발생.
+
+**Self-check**: add / edit 명령 작성 시 resolver 호출 순서가 body 수집보다 앞인지 grep 으로 확인했는가?
+
 ---
 
 # 2. 에러 처리 일관성
@@ -170,7 +189,81 @@ grep -rnE "mockRejectedValue\(new DoorayCliError" src/ test/
 
 # 3. 매직 넘버·문자열 (예약)
 
-# 4. CLI 도메인 규칙 회귀 (예약 — exitCode / stdout vs stderr / ky 강제)
+# 4. CLI 도메인 규칙 회귀
+
+## 4-1. interactive 경고 vs 실제 동작 mismatch
+
+**증상**: interactive 분기에서 "옵션 X 는 무시됩니다" 경고를 추가했으나 실제로 옵션 resolve 로직이 interactive 경로에도 적용됨.
+경고 텍스트와 코드 경로가 정반대.
+
+**Good**: 경고 텍스트 추가 시 해당 옵션의 resolve/merge 로직이 `nonInteractive` 조건 안에만 있는지 grep 으로 확인.
+
+**검출**:
+```bash
+grep -B 3 -A 10 "무시됩니다\|ignored" src/commands/
+# 같은 옵션 grep 으로 nonInteractive 조건 외에서 사용되는지 확인
+```
+
+**Why**: PR #55 (plan028) 🔴 — cc/to 옵션 경고와 실제 동작 불일치.
+
+**Self-check**: 경고 문구와 실제 코드 경로가 일치하는가?
+경고 옵션 이름이 `nonInteractive` 조건 안에만 있는지 grep 으로 확인했는가?
+
+# 5. 타입 안전성
+
+## 5-1. Map.has → get()! non-null assertion
+
+**증상**: `map.has(k) ? map.get(k)!.use() : map.set(k, init)` 패턴에서 `!` 사용.
+TypeScript 는 `has` 후 `get` 을 narrowing 안 함 → 런타임 undefined 가능성 잔존.
+
+**Good**: `let v = map.get(k); if (!v) { v = init; map.set(k, v); } v.use()` 로 변환.
+
+**검출**:
+```bash
+grep -nE "\.get\([^)]+\)!" src/
+```
+
+**Why**: PR #68 (plan033) — Map.has 후 get()! 단언.
+
+**Self-check**: Map.get() 결과에 `!` 단언이 있는가?
+있으면 위 패턴으로 교체.
+
+## 5-2. `as unknown as T` 이중 단언
+
+**증상**: `expr as unknown as T` 이중 단언이 등장.
+두 타입 사이의 구조적 관계가 불명확하다는 신호 — 타입 설계 재검토 필요.
+
+**Good**: `src/api/types.ts` 에 `extends` / 타입 별칭으로 두 타입의 관계를 명시.
+이중 단언은 타입 설계 재검토 신호로 처리.
+
+**검출**:
+```bash
+grep -nE "as unknown as " src/
+```
+
+**Why**: PR #64 (plan031) — 두 타입 관계를 이중 단언으로 우회.
+
+**Self-check**: `as unknown as T` 가 등장하면 타입 구조적 관계를 types.ts 에 명시했는가?
+
+# 6. API/HTTP 패턴
+
+## 6-1. redirect manual + status code 분기 누락
+
+**증상**: `redirect: "manual"` + `throwHttpErrors: false` 패턴에서 `location` 헤더만 체크하고 `if (response.status === 307)` 분기가 없음.
+200 OK 직접 응답 시 에러 경로로 진입.
+
+**Good**: `if (response.status === 307)` 분기 명시.
+redirect 응답과 직접 응답을 status code 로 구분.
+
+**검출**:
+```bash
+grep -nE "redirect.*manual|throwHttpErrors.*false" src/api/client.ts
+# 그 위치에서 status === 30 분기 존재 확인
+```
+
+**Why**: PR #72 (plan035) ADR-029 / ADR-015 연관.
+
+**Self-check**: `redirect: "manual"` 패턴이 있으면 status 분기도 함께 있는가?
 
 ---
 

--- a/.claude/skills/_shared/code-review-pitfalls.md
+++ b/.claude/skills/_shared/code-review-pitfalls.md
@@ -258,7 +258,7 @@ redirect 응답과 직접 응답을 status code 로 구분.
 **검출**:
 ```bash
 grep -nE "redirect.*manual|throwHttpErrors.*false" src/api/client.ts
-# 그 위치에서 status === 30 분기 존재 확인
+# 그 위치에서 status === 307 분기 존재 확인
 ```
 
 **Why**: PR #72 (plan035) ADR-029 / ADR-015 연관.

--- a/.claude/skills/_shared/common-pitfalls.md
+++ b/.claude/skills/_shared/common-pitfalls.md
@@ -453,7 +453,8 @@ git -C /Users/.../dooray-cli/.claude/worktrees/{plan} status --short
 **Good**: 외부에서 받은 fileName 은 항상 `basename(fileName)` 으로 directory component 제거 후 join. 다운로드 / 첨부 / 사용자가 통제하지 않는 모든 경로 입력에 적용.
 **검출**: `grep -rnE 'join\([^)]*\bfileName\b' src/commands/` 중 `basename` 미적용 라인.
 **Why**: PR #40 review — `post comment file download` 가 Dooray 응답의 fileName 을 그대로 join. 보안 측면에서 1줄로 막을 수 있는 취약점.
-**재발 빈도 높음**: PR #40 (🔴) → PR #72 (🔴) 두 PR 에서 동일 버그가 반복됨. download 명령 신설 시 `basename(decodeURIComponent(fileName))` grep 강제.
+**재발 빈도 높음**: PR #40 (🔴) → PR #72 (🔴) 두 PR 에서 동일 버그가 반복됨.
+download 명령 신설 시 `basename(decodeURIComponent(fileName))` grep 강제.
 
 ## CLI8. "정상 빈 결과" 메시지를 stderr 로 출력
 

--- a/.claude/skills/_shared/common-pitfalls.md
+++ b/.claude/skills/_shared/common-pitfalls.md
@@ -453,6 +453,7 @@ git -C /Users/.../dooray-cli/.claude/worktrees/{plan} status --short
 **Good**: 외부에서 받은 fileName 은 항상 `basename(fileName)` 으로 directory component 제거 후 join. 다운로드 / 첨부 / 사용자가 통제하지 않는 모든 경로 입력에 적용.
 **검출**: `grep -rnE 'join\([^)]*\bfileName\b' src/commands/` 중 `basename` 미적용 라인.
 **Why**: PR #40 review — `post comment file download` 가 Dooray 응답의 fileName 을 그대로 join. 보안 측면에서 1줄로 막을 수 있는 취약점.
+**재발 빈도 높음**: PR #40 (🔴) → PR #72 (🔴) 두 PR 에서 동일 버그가 반복됨. download 명령 신설 시 `basename(decodeURIComponent(fileName))` grep 강제.
 
 ## CLI8. "정상 빈 결과" 메시지를 stderr 로 출력
 

--- a/.claude/skills/build-with-teams/SKILL.md
+++ b/.claude/skills/build-with-teams/SKILL.md
@@ -323,7 +323,7 @@ executor 완료 후 team-lead가 **code-reviewer 팀원에게 SendMessage로 검
 **사전 해소 점검 (필수)**: code-reviewer 검사 시작 전에 `.claude/skills/_shared/code-review-pitfalls.md` 의 모든 항목이 코드에 적용됐는지 확인.
 적용 안 됐으면 그 자리에서 FIX_NEEDED 회신 (executor 재투입).
 본 docs 가 회피 패턴의 단일 소스 — 13 항목과 별도로 grep 점검.
-executor (`dooray-cli-executor`) 는 phase 시작 직전 TOP 패턴 self-check grep 을 자체 수행한다 — code-reviewer 게이트와 이중 방어.
+executor (`dooray-cli-executor`) 는 phase 시작 직전 TOP 패턴 self-check grep 을 자체 수행한다 — code-reviewer 점검과 이중 방어.
 
 **code-reviewer에게 전달할 검사 항목:**
 

--- a/.claude/skills/build-with-teams/SKILL.md
+++ b/.claude/skills/build-with-teams/SKILL.md
@@ -80,7 +80,7 @@ git log origin/main --oneline --grep "{NNN}\|{task-name}" | head -3
 |---|---|---|---|
 | **team-lead** | main session | opus | 계획 수립, task 생성, 팀 조율, **phase 별 atomic commit (6.1)**, 최종 push/PR |
 | **critic** | `oh-my-claudecode:critic` | opus | 계획 평가 (APPROVE/REVISE), 실제 코드 대조 |
-| **executor** | `oh-my-claudecode:executor` | sonnet | phase 순차 실행, 코드 수정 (커밋 제외), `bypassPermissions` |
+| **executor** | `dooray-cli-executor` (custom, project-local at `.claude/agents/`) | sonnet | phase 순차 실행, 코드 수정 (커밋 제외), `bypassPermissions`. dooray-cli 도메인 self-check 임베드 (spinner 순서 / resolver 검증 / 타입 안전성 등 TOP 패턴) |
 | **code-reviewer** | `oh-my-claudecode:code-reviewer` | sonnet | 코드 품질 검사 (PASS/FIX_NEEDED), AI slop/금지사항 탐지 |
 | **docs-verifier** | `dooray-cli-docs-verifier` (custom, project-local at `.claude/agents/`) | sonnet | 코드↔docs 정합성 검증 (PASS/UPDATE_NEEDED/VIOLATION). dooray-cli 도메인 지식 (ADR-001~024 / docs 영향 표 / 캐시 규약 / PII gate) 자동 적용 — 매번 검사 항목 길게 전달 불요 |
 
@@ -99,6 +99,20 @@ Agent({
   team_name: "plan{N}",
   name: "critic",
   model: "opus",
+  run_in_background: true,
+  prompt: "..."
+})
+```
+
+executor 스폰 시 `dooray-cli-executor` custom agent 사용 (dooray-cli 도메인 self-check 자동 적용):
+
+```
+Agent({
+  subagent_type: "dooray-cli-executor",
+  team_name: "plan{N}",
+  name: "executor",
+  model: "sonnet",
+  mode: "bypassPermissions",
   run_in_background: true,
   prompt: "..."
 })
@@ -309,6 +323,7 @@ executor 완료 후 team-lead가 **code-reviewer 팀원에게 SendMessage로 검
 **사전 해소 점검 (필수)**: code-reviewer 검사 시작 전에 `.claude/skills/_shared/code-review-pitfalls.md` 의 모든 항목이 코드에 적용됐는지 확인.
 적용 안 됐으면 그 자리에서 FIX_NEEDED 회신 (executor 재투입).
 본 docs 가 회피 패턴의 단일 소스 — 13 항목과 별도로 grep 점검.
+executor (`dooray-cli-executor`) 는 phase 시작 직전 TOP 패턴 self-check grep 을 자체 수행한다 — code-reviewer 게이트와 이중 방어.
 
 **code-reviewer에게 전달할 검사 항목:**
 

--- a/tasks/037-chore-custom-executor-agent/index.json
+++ b/tasks/037-chore-custom-executor-agent/index.json
@@ -3,8 +3,8 @@
   "description": "dooray-cli 전용 custom executor 에이전트 신설 (.claude/agents/dooray-cli-executor.md). docs-verifier 패턴 답습. build-with-teams skill 의 executor spawn 이 새 에이전트 사용하도록 교체. PR #36~#74 의 코드 리뷰 코멘트 15개 분석에서 추출한 신규 5 패턴 (resolver-before-editor / path-traversal 재발 강조 / interactive 경고 mismatch / Map.get()! / as unknown as T 이중 단언 / redirect manual status 분기) 을 _shared/code-review-pitfalls.md 에 시드 추가 후 agent 가 하이브리드 임베드 (TOP self-check + 참조). ADR 불요.",
   "depends_on": null,
   "created_at": "2026-05-21T00:00:00Z",
-  "status": "pending",
-  "current_phase": 1,
+  "status": "completed",
+  "current_phase": 3,
   "total_phases": 3,
   "error_message": null,
   "blocked_reason": null,
@@ -13,23 +13,23 @@
       "number": 1,
       "title": "_shared/code-review-pitfalls.md + common-pitfalls.md 신규 5 패턴 시드 보강",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 2,
       "title": ".claude/agents/dooray-cli-executor.md 신설 (하이브리드 임베드: TOP self-check + _shared 참조)",
       "file": "phase-02.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
       "number": 3,
       "title": "build-with-teams/SKILL.md 의 executor spawn 부분 교체 + 팀 구성 표 + 완료 마킹",
       "file": "phase-03.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],
-  "updated_at": "2026-05-21T00:00:00Z"
+  "updated_at": "2026-05-21T08:15:00Z"
 }


### PR DESCRIPTION
## Summary

dooray-cli 전용 custom executor agent 신설 + PR #36~#74 분석에서 추출한 신규 5 패턴 시드 보강.
build-with-teams skill 의 executor spawn 이 새 agent 를 사용하도록 교체.
코드 변경 0 — `.claude/` 하위 docs / agent / skill 인프라만 변경. 사용자 facing 영향 없음.

## Commits

- bd1fd77 docs(skill): accumulate 5 new review pitfalls from PR #36-#74 analysis (phase 1/3)
- 4415168 feat(agent): add dooray-cli-executor custom agent (phase 2/3)
- 905d84e chore(skill): switch build-with-teams executor to dooray-cli-executor + complete task 037
- e6772bc fix(skill): apply code-reviewer FIX_NEEDED (status 307 typo + 게이트→점검)
- 74dc888 fix(skill): apply docs-verifier UPDATE_NEEDED (Self_Discipline 불일치 + CLI7 semantic line break)

## 변경 사항

- `.claude/skills/_shared/code-review-pitfalls.md`: 카테고리 5 (타입 안전성) + 6 (API/HTTP) 신설, 1-3 / 4-1 / 5-1 / 5-2 / 6-1 항목 추가, 카테고리 4 예약 placeholder 해제
- `.claude/skills/_shared/common-pitfalls.md`: CLI7 path-traversal 재발 빈도 강조 (PR #40 → #72)
- `.claude/agents/dooray-cli-executor.md` 신규: 하이브리드 임베드 (TOP self-check + `_shared/*.md` 단일 소스 참조)
- `.claude/skills/build-with-teams/SKILL.md`: 팀 구성 표 executor 행 + executor spawn 코드 예시 블록 신규 추가 + 7단계 self-check 1줄
- `tasks/037-chore-custom-executor-agent/index.json`: completed 마킹

## 추출된 신규 5 패턴 (시드)

| 패턴 | 출처 PR | 카테고리 |
|---|---|---|
| resolver-before-editor | #74, #64 | 1-3 |
| interactive 경고 vs 실제 동작 mismatch | #55 | 4-1 |
| Map.has → get()! non-null assertion | #68 | 5-1 |
| as unknown as T 이중 단언 | #64 | 5-2 |
| redirect manual + status 분기 | #72 | 6-1 |

## Test plan

- [x] `pnpm tsc --noEmit` — 0건 (코드 변경 0)
- [x] `pnpm build && pnpm test` — 21 파일 149 케이스 PASS
- [x] critic APPROVE (1차 REVISE → 2차 APPROVE)
- [x] code-reviewer PASS (1차 FIX_NEEDED 2건 → 2차 PASS)
- [x] docs-verifier PASS (1차 UPDATE_NEEDED 1건 + Warning 1건 → 2차 PASS)
- [ ] 다음 plan 에서 `dooray-cli-executor` 실제 동작 확인 (build-with-teams 실행 시)

🤖 Generated with build-with-teams (plan037)