### PR TITLE
fix(resolvers): unwrap nested member-group response + id direct input fallback (Issue #76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,22 @@ interactive ($EDITOR) 모드에서는 위 6개 옵션이 무시되고 stderr 경
 `post edit --dry-run --json` 사용 시 출력에 `users: { to, cc }` 가 포함되어 API 호출 없이 변경 결과 미리보기 가능.
 `post create --dry-run` 은 본문만 출력하며 `users` 는 포함하지 않음.
 
+**그룹 cc / mention 사용 예 (Issue #76 fix)**:
+
+```bash
+# code 부분일치
+dooray post create <project> ... --cc-group "개발"
+
+# code 정확 일치
+dooray post create <project> ... --mention-group "all"
+
+# 19자리 id 직접 입력 (response shape robustness 또는 code 누락 그룹 회피)
+dooray post create <project> ... --cc-group "<19자리 group id>"
+
+# 후보 탐색
+dooray project groups <project>
+```
+
 ```bash
 dooray post edit <project> <post-number> --cc-group dev-team --dry-run --json | jq '.users.cc'
 # 출력 예: [{ "type": "group", "group": { "projectMemberGroupId": "...", "members": [] } }, ...]

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -111,6 +111,7 @@ dooray doctor                                 # 설정 검증
 | 참조자(cc) 멤버/그룹 추가 | `dooray post edit <project> <number> --cc-group <code>` — 기존 참조자 유지 + 그룹 추가 (dedupe, ADR-025) |
 | 참조자 전체 교체 | `dooray post edit <project> <number> --cc-clear --cc <name>` — 기존 참조자 비우고 신규 멤버만 |
 | 신규 업무 + 그룹 cc | `dooray post create <project> --title "..." --cc-group <code>` — 생성 시 그룹 참조자 포함 |
+| `--cc-group <code\|id>` / `--mention-group <code\|id>` | 그룹 매칭 — 15+자리 numeric → id 직접 / 그 외 → code matchByName (부분일치, ADR-028) |
 | 상위 업무 설정/변경 | `dooray post edit <project> <number> --title "<원제목>" --parent <ref>` (`<ref>`: `<project>/<number>` 또는 raw postId. `--title` 필수, unset 미지원) |
 | `dooray post edit --id <postId> --tag <name>` | 태그 추가 (반복, dedupe) |
 | `dooray post edit --id <postId> --tag-clear --tag <name>` | 태그 전체 교체 |
@@ -450,6 +451,35 @@ dooray post comment latest <project> <number>
 ```
 
 ---
+
+## 그룹 멘션 / cc 시 AI agent 동선 (Issue #76, ADR-028)
+
+자연어 그룹명을 사용자가 지칭했을 때 AI agent 의 의사결정 순서:
+
+1. **사용자가 명확한 code 를 줬으면 바로 시도**
+   ```bash
+   dooray post create <project> --mention-group "<code>"
+   ```
+   부분일치 가능 (예: "AI-Data" → "AI-Data파트" 매칭).
+
+2. **부분일치 모호 / 매칭 실패 시 후보 탐색**
+   ```bash
+   dooray project groups <project>
+   ```
+   ID + Code 표 출력.
+   AI agent 가 자연어 의도와 가장 가까운 code 선택 후 재시도.
+
+3. **모든 컬럼이 빈값일 때 (response shape 이상) 회피**
+   - ADR-028 fix 이후 거의 발생 안 함 (`fetchAllMemberGroups` 가 nested array 정규화)
+   - 만약 발생 시: 사용자에게 그룹 id (UI 의 그룹 URL 에서 19자리 numeric) 확인 요청
+   - `--cc-group <id>` / `--mention-group <id>` 직접 입력
+   - 또는 그룹 멤버를 개별 `--cc <member>` / `--mention <member>` 로 지정
+
+4. **모호한 자연어 매핑은 사용자에게 확인**
+   - 후보가 여러 개일 때 임의 선택 금지 — 사용자에게 선택지 제시
+   - 예: "AI-Data파트 / AI-Data실험팀 — 어느 그룹인가요?"
+
+순서 고정 — 멤버 먼저, 그룹 다음 (기존 정책 유지).
 
 ## 멘션·링크 자동 삽입 (first-class)
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -433,7 +433,7 @@ export interface ProjectMemberListResponse {
 
 export interface MemberGroup {
   id: string;
-  code?: string;  // optional — 실제 API 응답에서 누락 케이스 존재 (ADR-026)
+  code?: string;  // optional — 실제 API 응답에서 누락 케이스 존재 (ADR-028)
   project: ProjectInfo;
   createdAt: string;
   updatedAt: string;
@@ -441,7 +441,10 @@ export interface MemberGroup {
 
 export interface MemberGroupListResponse {
   header: DoorayApiHeader;
-  result: MemberGroup[];
+  // Dooray API 가 nested array (`[[g1, g2]]`) 로 반환 — 평면 / 중첩 둘 다 허용 (ADR-028).
+  // 호출자 (`fetchAllMemberGroups`) 가 `.flat()` 로 정규화 — `.flat()` 시그니처가 union 의
+  // 양쪽 case 를 흡수하므로 추가 단언 불필요.
+  result: MemberGroup[] | MemberGroup[][];
   totalCount: number;
 }
 

--- a/src/resolvers/member-group.test.ts
+++ b/src/resolvers/member-group.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { resolveMemberGroup, fetchAllMemberGroups } from "./member-group.js";
+import type { DoorayApiClient } from "../api/client.js";
+import { DoorayCliError } from "../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../utils/exit-codes.js";
+
+vi.mock("../cache/store.js", () => ({
+  getMemberGroups: vi.fn().mockResolvedValue(null),
+  setMemberGroups: vi.fn().mockResolvedValue(undefined),
+  isExpired: vi.fn().mockReturnValue(true),
+}));
+
+function mockClient(result: unknown): DoorayApiClient {
+  return {
+    getProjectMemberGroups: vi.fn().mockResolvedValue({ result, totalCount: (result as unknown[]).flat().length }),
+  } as unknown as DoorayApiClient;
+}
+
+// fixture — 정규화 후 평면 (cache 거친 상태)
+const fixtureFlat = [
+  { id: "1111222233334444555", code: "all" },
+  { id: "2222333344445555666", code: "개발" },
+  { id: "3333444455556666777", code: undefined },
+  { id: "4444555566667777888", code: "" },
+];
+
+beforeEach(() => vi.clearAllMocks());
+
+// ─── fetchAllMemberGroups — flatten 멱등성 ───────────────
+
+describe("fetchAllMemberGroups response shape normalization", () => {
+  it("nested array 응답을 flatten 해서 처리", async () => {
+    const nestedResult = [
+      [
+        { id: "1111222233334444555", code: "all", project: {}, createdAt: "", updatedAt: "" },
+        { id: "2222333344445555666", code: "개발", project: {}, createdAt: "", updatedAt: "" },
+      ],
+    ];
+    const client = {
+      getProjectMemberGroups: vi.fn().mockResolvedValue({ result: nestedResult, totalCount: 2 }),
+    } as unknown as DoorayApiClient;
+
+    const result = await fetchAllMemberGroups(client, "proj");
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ id: "1111222233334444555", code: "all" });
+    expect(result[1]).toEqual({ id: "2222333344445555666", code: "개발" });
+  });
+
+  it("평면 배열 응답도 정상 처리 (멱등성)", async () => {
+    const flatResult = [
+      { id: "1111222233334444555", code: "all", project: {}, createdAt: "", updatedAt: "" },
+      { id: "2222333344445555666", code: "개발", project: {}, createdAt: "", updatedAt: "" },
+    ];
+    const client = {
+      getProjectMemberGroups: vi.fn().mockResolvedValue({ result: flatResult, totalCount: 2 }),
+    } as unknown as DoorayApiClient;
+
+    const result = await fetchAllMemberGroups(client, "proj");
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ id: "1111222233334444555", code: "all" });
+    expect(result[1]).toEqual({ id: "2222333344445555666", code: "개발" });
+  });
+});
+
+// ─── resolveMemberGroup ───────────────────────────────────
+
+describe("resolveMemberGroup", () => {
+  it("code 부분일치 — 한글 code", async () => {
+    const client = mockClient(fixtureFlat);
+    const result = await resolveMemberGroup(client, "p1", "개발");
+    expect(result).toEqual({ id: "2222333344445555666", code: "개발" });
+  });
+
+  it("id 직접 입력 — 정상 그룹", async () => {
+    const client = mockClient(fixtureFlat);
+    const result = await resolveMemberGroup(client, "p1", "1111222233334444555");
+    expect(result).toEqual({ id: "1111222233334444555", code: "all" });
+  });
+
+  it("id 직접 입력 — code 누락 그룹도 매칭 (response shape robustness)", async () => {
+    const client = mockClient(fixtureFlat);
+    const result = await resolveMemberGroup(client, "p1", "3333444455556666777");
+    expect(result.id).toBe("3333444455556666777");
+    expect(result.code).toBe("");
+  });
+
+  it("id 매칭 실패 — 친절한 안내 + EXIT_PARAM_ERROR", async () => {
+    const client = mockClient(fixtureFlat);
+    await expect(resolveMemberGroup(client, "p1", "9999999999999999999")).rejects.toSatisfy(
+      (err: unknown) =>
+        err instanceof DoorayCliError &&
+        err.exitCode === EXIT_PARAM_ERROR &&
+        /그룹 id 를 찾을 수 없습니다.*dooray project groups/s.test(err.message),
+    );
+  });
+
+  it("code 매칭 실패 시 helpHint 에 id 입력 안내 포함", async () => {
+    const client = mockClient(fixtureFlat);
+    await expect(resolveMemberGroup(client, "p1", "존재하지않는code")).rejects.toThrow(
+      /dooray project groups|id 직접 입력/,
+    );
+  });
+});

--- a/src/resolvers/member-group.ts
+++ b/src/resolvers/member-group.ts
@@ -17,8 +17,10 @@ export async function fetchAllMemberGroups(client: DoorayApiClient, projectId: s
   while (true) {
     const res = await client.getProjectMemberGroups(projectId, { page, size });
     // ADR-028: Dooray API 가 nested array (`result: [[g1, g2]]`) 로 반환 — flatten 필수
-    // 1 레벨만 평면화. 평면 응답에도 안전 (이미 평면이면 flat() 무동작 — 멱등)
-    const groups = (res.result as unknown as MemberGroup[][] | MemberGroup[]).flat() as MemberGroup[];
+    // 1 레벨만 평면화. 평면 응답에도 안전 (이미 평면이면 flat() 무동작 — 멱등).
+    // `MemberGroupListResponse.result` 가 union (`MemberGroup[] | MemberGroup[][]`) 이라
+    // `.flat()` 시그니처가 양쪽 case 자동 흡수 — 단언 불요.
+    const groups: MemberGroup[] = res.result.flat();
     for (const g of groups) {
       all.push({ id: g.id, code: g.code });
     }

--- a/src/resolvers/member-group.ts
+++ b/src/resolvers/member-group.ts
@@ -1,16 +1,25 @@
 import { DoorayApiClient } from "../api/client.js";
+import type { MemberGroup } from "../api/types.js";
 import type { CachedMemberGroup } from "../cache/types.js";
 import { getMemberGroups, setMemberGroups, isExpired } from "../cache/store.js";
 import { MEMBER_GROUPS_TTL_MS, RESOLVER_FETCH_PAGE_SIZE } from "../cache/types.js";
 import { matchByName } from "./match.js";
+import { DoorayCliError } from "../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../utils/exit-codes.js";
 
-async function fetchAllMemberGroups(client: DoorayApiClient, projectId: string): Promise<CachedMemberGroup[]> {
+// resolveMember 의 MEMBER_ID_RE 와 동일 패턴
+const GROUP_ID_RE = /^\d{15,}$/;
+
+export async function fetchAllMemberGroups(client: DoorayApiClient, projectId: string): Promise<CachedMemberGroup[]> {
   const all: CachedMemberGroup[] = [];
   let page = 0;
   const size = RESOLVER_FETCH_PAGE_SIZE;
   while (true) {
     const res = await client.getProjectMemberGroups(projectId, { page, size });
-    for (const g of res.result) {
+    // ADR-028: Dooray API 가 nested array (`result: [[g1, g2]]`) 로 반환 — flatten 필수
+    // 1 레벨만 평면화. 평면 응답에도 안전 (이미 평면이면 flat() 무동작 — 멱등)
+    const groups = (res.result as unknown as MemberGroup[][] | MemberGroup[]).flat() as MemberGroup[];
+    for (const g of groups) {
       all.push({ id: g.id, code: g.code });
     }
     const total = res.totalCount ?? all.length;
@@ -43,19 +52,38 @@ export async function resolveMemberGroup(
   input: string,
 ): Promise<{ id: string; code: string }> {
   const groups = await ensureMemberGroups(client, projectId);
-  // code 가 없는 그룹은 매칭 불가 — 사전 필터 (Dooray API 응답 mismatch, ADR-026)
+
+  // 1. id 직접 입력 (numeric 15+자리) — code 누락 그룹도 매칭, response shape robustness
+  if (GROUP_ID_RE.test(input)) {
+    const found = groups.find((g) => g.id === input);
+    if (found) {
+      return { id: found.id, code: found.code ?? "" };
+    }
+    throw new DoorayCliError(
+      `그룹 id 를 찾을 수 없습니다: "${input}"\n` +
+      `전체 목록은 \`dooray project groups <project>\` 로 확인하세요.`,
+      EXIT_PARAM_ERROR,
+    );
+  }
+
+  // 2. code 매칭 흐름 (기존)
+  // code 가 없는 그룹은 매칭 불가 — 사전 필터 (Dooray API 응답 mismatch, ADR-028)
   const valid = groups.filter(hasValidCode);
   const skipped = groups.length - valid.length;
   if (skipped > 0) {
     process.stderr.write(
-      `⚠  ${skipped}개 그룹에 code 가 없어 매칭에서 제외했습니다 (Dooray API 응답 mismatch — ADR-026).\n`,
+      // ADR 번호 정정: ADR-026 → ADR-028
+      `⚠  ${skipped}개 그룹에 code 가 없어 매칭에서 제외했습니다 (ADR-028).\n` +
+      `   id 직접 입력 (15+자리 numeric) 또는 UI 수동 cc / \`--cc <member>\` 우회 가능.\n`,
     );
   }
   // CachedMemberGroup은 { id, code } — name 필드 없음. matchByName은 name 필드 사용
   // → 어댑터: code를 name처럼 사용 (predicate 로 code 가 string 임이 좁혀짐)
   const adapter = valid.map((g) => ({ name: g.code, id: g.id, code: g.code }));
   const match = matchByName(adapter, input, "그룹", (g) => `${g.code} (${g.id})`, {
-    helpHint: "dooray project groups <project>",
+    helpHint:
+      "전체 목록: `dooray project groups <project>` / " +
+      "id 직접 입력도 가능 (15+자리 numeric — code 누락 그룹도 매칭, ADR-028)",
   });
   return { id: match.id, code: match.code };
 }

--- a/tasks/038-fix-member-group-response-shape/index.json
+++ b/tasks/038-fix-member-group-response-shape/index.json
@@ -2,7 +2,7 @@
   "name": "038-fix-member-group-response-shape",
   "description": "GitHub Issue #76 — member-group 응답 shape mismatch root cause fix. 실측 결과 (2026-05-22) Dooray API `GET /project/v1/projects/{id}/member-groups` 응답이 nested array (`result: [[g1, g2]]`) 로 반환되는데 dooray-cli `fetchAllMemberGroups` 가 평면 배열 가정으로 처리해 모든 그룹이 빈 객체로 cache 되는 사고. ADR-028 의 'code 누락 사전 필터' 가정은 root cause 가 아닌 증상만 본 진단으로 무효화 — 본 task 에서 ADR-028 전면 개정. 3종 fix 동시 적용: (C) fetchAllMemberGroups 에 `res.result.flat()` 정규화, (A) stderr 메시지의 ADR 번호 오기 정정 (ADR-026 → ADR-028) + AI 친화 helpHint, (B2) resolveMemberGroup 의 numeric 15+자리 입력 시 id 직접 매칭 fallback (response shape robustness). 5 호출자 (post create/edit cc-group + mention-group + comment add/edit + post-users) 시그니처 불변 → 자동 혜택.",
   "created_at": "2026-05-22T00:00:00Z",
-  "status": "pending",
+  "status": "completed",
   "current_phase": 1,
   "total_phases": 1,
   "error_message": null,
@@ -12,9 +12,9 @@
       "number": 1,
       "title": "fetchAllMemberGroups flatten + resolveMemberGroup id 분기 + 메시지 정정 + AI agent 동선 docs + 단위 테스트",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],
-  "updated_at": "2026-05-22T00:00:00Z"
+  "updated_at": "2026-05-22T15:38:00Z"
 }


### PR DESCRIPTION
## Summary

GitHub Issue #76 — `--cc-group` / `--mention-group` 매칭 전면 실패 fix.

**진짜 root cause** (2026-05-22 실측): Dooray API `GET .../member-groups` 가 nested array (`result: [[g1, g2]]`) 로 반환되는데 `fetchAllMemberGroups` 가 평면 가정으로 처리 → 모든 그룹이 빈 객체로 cache.

구 ADR-028 의 "code 누락 사전 필터" 진단은 증상만 본 것 — 본 PR 에서 전면 개정.

## 3종 fix 동시 적용

- **C. fetchAllMemberGroups 응답 정규화** — `res.result.flat()` 추가 (root cause fix, 멱등성)
- **A. stderr 경고 ADR 번호 정정** — `ADR-026` → `ADR-028` + AI 친화 helpHint
- **B2. resolveMemberGroup id 직접 입력 fallback** — numeric 15+자리 → id 직접 매칭 (response shape robustness)

## Commits

```
33681f6 fix(resolvers): unwrap nested member-group response + id direct input fallback (Issue #76, ADR-028)
```

## Test plan

- [x] `pnpm tsc --noEmit` — 0건
- [x] `pnpm run build` — OK (239.15 KB)
- [x] `pnpm test` — 156/156 PASS (member-group.test.ts 7 케이스 신규)
- [x] 5 호출자 시그니처 불변 → 자동 혜택 (post-users / create / edit / comment-add / comment-edit)
- [ ] 실 API 실증 — `dooray project groups <project>` ID + Code 컬럼 모두 표시 (머지 후 검증)

closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)