### PR TITLE
feat(commands): unify --json/--quiet output schema across file commands (Issue #73, ADR-031)

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,22 @@ dooray wiki page file list "https://<tenant>.dooray.com/wiki/<wikiId>/<pageId>"
 dooray wiki page file upload --id <pageId> --project <project> --file ./README.md
 ```
 
+`--json` 옵션으로 자동화 파이프라인에서 동일 parse 코드를 사용할 수 있습니다 (ADR-031):
+
+```bash
+# download — { outputPath, fileName, size }
+dooray wiki page file download <project> <page-id> --file-id <id> -o ./ --json
+
+# download-all — { count, succeeded, failed } (부분 실패 시 exit 1)
+dooray wiki page file download-all <project> <page-id> -o ./ --json | jq '.failed'
+
+# delete — { fileId, status: "deleted" }
+dooray wiki page file delete <project> <page-id> --file-id <id> --json
+
+# upload — res.result raw (--quiet 는 id 만)
+dooray wiki page file upload <project> <page-id> --file ./report.pdf --json
+```
+
 **주의**:
 - `upload` 시 multipart 필드 순서 (`type` → `file`) 가 중요.
   클라이언트가 자동으로 강제 (ADR-029 참조)
@@ -472,6 +488,25 @@ dooray post file upload <project> <number> ./report.pdf
 
 # 파일 삭제
 dooray post file delete <project> <number> <file-id>
+```
+
+자동화 스크립트에서 `--json` 옵션으로 구조화된 출력을 파이프로 가공할 수 있습니다 (ADR-031):
+
+```bash
+# download — { outputPath, fileName, size }
+dooray post file download <project> <number> --file-id <id> -o ./ --json
+# 출력: {"outputPath": "./<fileName>", "fileName": "...", "size": 12345}
+
+# download-all — { count, succeeded, failed } (부분 실패 시 exit 1)
+dooray post file download-all <project> <number> -o ./ --json | jq '.failed'
+# 출력: [] 또는 [{"fileId": "...", "error": "..."}]
+
+# delete — { fileId, status: "deleted" }
+dooray post file delete <project> <number> --file-id <id> --json
+# 출력: {"fileId": "...", "status": "deleted"}
+
+# upload — res.result raw (--quiet 는 id 만)
+dooray post file upload <project> <number> ./report.pdf --json
 ```
 
 URL/`--id`/`--url` 모드에서는 sub-id를 옵션으로 전달:

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -68,6 +68,7 @@ src/
     member.ts               # Member 상세/목록 포맷 (ADR-021)
     comment.ts              # PostComment 상세 포맷 (table/JSON/quiet, Issue #45)
     wiki-comment.ts         # WikiComment 전용 포맷 — page.id + creator.member 시그니처 차이 (post comment 와 mailUsers/files/mention 부재)
+    file-output.ts          # file 명령군 emit 헬퍼 (ADR-031) — download/download-all/delete 3종
 
   utils/
     errors.ts               # DoorayCliError (message + exitCode)

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -104,6 +104,7 @@ dooray doctor                                 # 설정 검증
 | 전체 첨부파일 다운로드 | `dooray post file download-all <project> <number>` |
 | 첨부파일 업로드 | `dooray post file upload <project> <number> <file-path>` |
 | 첨부파일 삭제 | `dooray post file delete <project> <number> <file-id>` |
+| file 명령군 자동화 파싱 | `dooray post file <verb> ... --json` — `download` = `{outputPath,fileName,size}`, `download-all` = `{count,succeeded,failed}` (부분 실패 시 exit 1), `delete` = `{fileId,status}`, `upload` = `res.result` raw (ADR-031) |
 | 댓글 첨부 목록 | `dooray post comment file list <project> <number> <comment-id>` |
 | 댓글 파일 업로드 | `dooray post comment file upload <project> <number> <comment-id> <path>` |
 | 댓글 파일 다운로드 | `dooray post comment file download <project> <number> <comment-id> <file-id>` |
@@ -205,6 +206,16 @@ dooray wiki pages <project> --json
 
 # 2. 페이지 내용 조회
 dooray wiki page get <project> <pageId> --json
+```
+
+### 첨부파일 일괄 다운로드 후 실패 분리 (ADR-031)
+
+```bash
+# --json 으로 구조화 출력 → jq 로 성공/실패 분리
+RESULT=$(dooray post file download-all <project> <number> -o ./ --json)
+echo "$RESULT" | jq -r '.failed[] | "\(.fileId): \(.error)"' >&2
+echo "$RESULT" | jq -r '.succeeded[].path'
+# exit code 1 이 설정되어 있으면 실패 있는 상태
 ```
 
 ### 위키 페이지 첨부파일 — 스킬 파일 팀 공유 (Issue #70)

--- a/src/commands/post/file/delete.ts
+++ b/src/commands/post/file/delete.ts
@@ -5,6 +5,8 @@ import { resolvePostInput } from "../../../resolvers/post-input.js";
 import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
 import { DoorayCliError } from "../../../utils/errors.js";
 import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
+import type { OutputOptions } from "../../../formatters/table.js";
+import { emitDeleteResult } from "../../../formatters/file-output.js";
 
 export const fileDeleteCommand = new Command("delete")
   .description("첨부파일 삭제")
@@ -15,6 +17,7 @@ export const fileDeleteCommand = new Command("delete")
   .option("--url <url>", "Dooray 업무 URL (project/post-number 대신)")
   .option("--file-id <fileId>", "파일 ID (positional 대체)")
   .action(async (arg1, arg2, arg3, opts) => {
+    const globalOpts = fileDeleteCommand.optsWithGlobals() as OutputOptions;
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
@@ -67,5 +70,6 @@ export const fileDeleteCommand = new Command("delete")
     await client.deletePostFile(projectId, postId, fileId);
     stopSpinner(true, "삭제 완료");
 
-    process.stdout.write(`파일(${fileId})이 삭제되었습니다.\n`);
+    // ADR-031: --json / --quiet / plain 3 모드 분기
+    emitDeleteResult(globalOpts, { fileId });
   });

--- a/src/commands/post/file/download-all.ts
+++ b/src/commands/post/file/download-all.ts
@@ -32,10 +32,9 @@ export const fileDownloadAllCommand = new Command("download-all")
 
     if (res.result.length === 0) {
       stopSpinner(true, "첨부파일 없음");
-      // ADR-031: --json 모드에서는 빈 스키마 반환
       if (globalOpts.json) {
         printJson({ count: 0, succeeded: [], failed: [] });
-      } else {
+      } else if (!globalOpts.quiet) {
         process.stdout.write("첨부파일이 없습니다.\n");
       }
       return;

--- a/src/commands/post/file/download-all.ts
+++ b/src/commands/post/file/download-all.ts
@@ -1,10 +1,13 @@
 import { Command } from "commander";
 import { writeFile, mkdir } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { getConfigOrThrow } from "../../../config/store.js";
 import { DoorayApiClient } from "../../../api/client.js";
 import { resolvePostInput } from "../../../resolvers/post-input.js";
 import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
+import type { OutputOptions } from "../../../formatters/table.js";
+import { printJson } from "../../../formatters/table.js";
+import { emitDownloadAllResult } from "../../../formatters/file-output.js";
 
 export const fileDownloadAllCommand = new Command("download-all")
   .description("업무의 모든 첨부파일 다운로드")
@@ -14,10 +17,11 @@ export const fileDownloadAllCommand = new Command("download-all")
   .option("--url <url>", "Dooray 업무 URL (project/post-number 대신)")
   .option("-o, --output <dir>", "저장 디렉토리", ".")
   .action(async (project, postNumberStr, opts) => {
+    const globalOpts = fileDownloadAllCommand.optsWithGlobals() as OutputOptions;
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
-    const spinner = startSpinner("첨부파일 목록 조회 중...");
+    startSpinner("첨부파일 목록 조회 중...");
     const { projectId, postId } = await resolvePostInput(client, {
       projectArg: project,
       postNumberArg: postNumberStr,
@@ -28,23 +32,44 @@ export const fileDownloadAllCommand = new Command("download-all")
 
     if (res.result.length === 0) {
       stopSpinner(true, "첨부파일 없음");
-      process.stdout.write("첨부파일이 없습니다.\n");
+      // ADR-031: --json 모드에서는 빈 스키마 반환
+      if (globalOpts.json) {
+        printJson({ count: 0, succeeded: [], failed: [] });
+      } else {
+        process.stdout.write("첨부파일이 없습니다.\n");
+      }
       return;
     }
 
+    stopSpinner(true, `${res.result.length}개 파일 다운로드 시작`);
     await mkdir(opts.output, { recursive: true });
 
-    const downloaded: string[] = [];
-    for (const file of res.result) {
-      spinner.text = `다운로드 중: ${file.name} (${downloaded.length + 1}/${res.result.length})`;
-      const { buffer, fileName } = await client.downloadPostFile(projectId, postId, file.id);
-      const outputPath = join(opts.output, fileName);
-      await writeFile(outputPath, Buffer.from(buffer));
-      downloaded.push(outputPath);
-    }
-    stopSpinner(true, `${downloaded.length}개 파일 다운로드 완료`);
+    const succeeded: { path: string; fileName: string }[] = [];
+    const failed: { fileId: string; error: string }[] = [];
 
-    for (const path of downloaded) {
-      process.stdout.write(`${path}\n`);
+    for (const file of res.result) {
+      try {
+        const { buffer, fileName } = await client.downloadPostFile(projectId, postId, file.id);
+        // CLI7: path-traversal 방지 — basename + decodeURIComponent
+        const safeName = basename(decodeURIComponent(fileName));
+        const outputPath = join(opts.output, safeName);
+        await writeFile(outputPath, Buffer.from(buffer));
+        succeeded.push({ path: outputPath, fileName: safeName });
+        // plain 모드만 ✓ 진행 출력 (json/quiet 는 마지막에 일괄)
+        if (!globalOpts.json && !globalOpts.quiet) {
+          process.stdout.write(`✓ ${safeName}\n`);
+        }
+      } catch (e) {
+        failed.push({ fileId: file.id, error: e instanceof Error ? e.message : String(e) });
+        if (!globalOpts.json) {
+          process.stderr.write(`✗ ${file.name} (${file.id}): ${e instanceof Error ? e.message : String(e)}\n`);
+        }
+      }
     }
+
+    // ADR-031: --json / --quiet / plain 최종 출력
+    emitDownloadAllResult(globalOpts, { count: res.result.length, succeeded, failed });
+
+    // 부분 실패 시 exit 1 (process.exit 대신 exitCode — 비동기 flush 보장)
+    if (failed.length > 0) process.exitCode = 1;
   });

--- a/src/commands/post/file/download.ts
+++ b/src/commands/post/file/download.ts
@@ -1,12 +1,14 @@
 import { Command } from "commander";
 import { writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { getConfigOrThrow } from "../../../config/store.js";
 import { DoorayApiClient } from "../../../api/client.js";
 import { resolvePostInput } from "../../../resolvers/post-input.js";
 import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
 import { DoorayCliError } from "../../../utils/errors.js";
 import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
+import type { OutputOptions } from "../../../formatters/table.js";
+import { emitDownloadResult } from "../../../formatters/file-output.js";
 
 export const fileDownloadCommand = new Command("download")
   .description("첨부파일 다운로드")
@@ -18,6 +20,7 @@ export const fileDownloadCommand = new Command("download")
   .option("--file-id <fileId>", "파일 ID (positional 대체)")
   .option("-o, --output <dir>", "저장 디렉토리", ".")
   .action(async (arg1, arg2, arg3, opts) => {
+    const globalOpts = fileDownloadCommand.optsWithGlobals() as OutputOptions;
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
@@ -69,9 +72,12 @@ export const fileDownloadCommand = new Command("download")
     });
     const { buffer, fileName } = await client.downloadPostFile(projectId, postId, fileId);
 
-    const outputPath = join(opts.output, fileName);
+    // CLI7: path-traversal 방지 — basename + decodeURIComponent
+    const safeName = basename(decodeURIComponent(fileName));
+    const outputPath = join(opts.output, safeName);
     await writeFile(outputPath, Buffer.from(buffer));
     stopSpinner(true, "다운로드 완료");
 
-    process.stdout.write(`${outputPath}\n`);
+    // ADR-031: --json / --quiet / plain 3 모드 분기
+    emitDownloadResult(globalOpts, { outputPath, fileName: safeName, size: buffer.byteLength });
   });

--- a/src/commands/wiki/page-file/delete.ts
+++ b/src/commands/wiki/page-file/delete.ts
@@ -5,6 +5,8 @@ import { resolveWikiPageInput } from "../../../resolvers/wiki-page-input.js";
 import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
 import { DoorayCliError } from "../../../utils/errors.js";
 import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
+import type { OutputOptions } from "../../../formatters/table.js";
+import { emitDeleteResult } from "../../../formatters/file-output.js";
 
 export const wikiPageFileDeleteCommand = new Command("delete")
   .description("위키 페이지 첨부파일 삭제")
@@ -16,6 +18,7 @@ export const wikiPageFileDeleteCommand = new Command("delete")
   .option("--project <code>", "프로젝트 코드 (--id 모드에서 wikiId 해석용)")
   .option("--file-id <fileId>", "파일 ID (positional 대체)")
   .action(async (arg1, arg2, arg3, opts) => {
+    const globalOpts = wikiPageFileDeleteCommand.optsWithGlobals() as OutputOptions;
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
@@ -72,7 +75,8 @@ export const wikiPageFileDeleteCommand = new Command("delete")
       await client.deleteWikiPageFile(wikiId, pageId, fileId);
       stopSpinner(true, "삭제 완료");
 
-      process.stdout.write(`파일(${fileId})이 삭제되었습니다.\n`);
+      // ADR-031: --json / --quiet / plain 3 모드 분기
+      emitDeleteResult(globalOpts, { fileId });
     } catch (e) {
       stopSpinner(false);
       throw e;

--- a/src/commands/wiki/page-file/download-all.ts
+++ b/src/commands/wiki/page-file/download-all.ts
@@ -1,13 +1,14 @@
 import { Command } from "commander";
 import { writeFile, mkdir } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { getConfigOrThrow } from "../../../config/store.js";
 import { DoorayApiClient } from "../../../api/client.js";
 import { resolveWikiPageInput } from "../../../resolvers/wiki-page-input.js";
 import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
-import { DoorayCliError } from "../../../utils/errors.js";
-import { EXIT_API_ERROR } from "../../../utils/exit-codes.js";
 import type { WikiPageFile } from "../../../api/types.js";
+import type { OutputOptions } from "../../../formatters/table.js";
+import { printJson } from "../../../formatters/table.js";
+import { emitDownloadAllResult } from "../../../formatters/file-output.js";
 
 export const wikiPageFileDownloadAllCommand = new Command("download-all")
   .description("위키 페이지의 모든 첨부파일 다운로드 (general + inline image)")
@@ -18,6 +19,7 @@ export const wikiPageFileDownloadAllCommand = new Command("download-all")
   .option("--project <code>", "프로젝트 코드 (--id 모드에서 wikiId 해석용)")
   .option("-o, --output <dir>", "저장 디렉토리", ".")
   .action(async (project, pageIdArg, opts) => {
+    const globalOpts = wikiPageFileDownloadAllCommand.optsWithGlobals() as OutputOptions;
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
@@ -42,7 +44,12 @@ export const wikiPageFileDownloadAllCommand = new Command("download-all")
 
     if (allFiles.length === 0) {
       stopSpinner(true, "첨부파일 없음");
-      process.stdout.write("첨부파일이 없습니다.\n");
+      // ADR-031: --json 모드에서는 빈 스키마 반환
+      if (globalOpts.json) {
+        printJson({ count: 0, succeeded: [], failed: [] });
+      } else {
+        process.stdout.write("첨부파일이 없습니다.\n");
+      }
       return;
     }
 
@@ -50,26 +57,32 @@ export const wikiPageFileDownloadAllCommand = new Command("download-all")
 
     await mkdir(opts.output, { recursive: true });
 
-    let successCount = 0;
-    const failures: { fileId: string; error: string }[] = [];
+    const succeeded: { path: string; fileName: string }[] = [];
+    const failed: { fileId: string; error: string }[] = [];
 
     for (const f of allFiles) {
       try {
         const { buffer, fileName } = await client.downloadWikiPageFile(wikiId, pageId, f.id);
-        await writeFile(join(opts.output, fileName), Buffer.from(buffer));
-        process.stdout.write(`✓ ${fileName}\n`);
-        successCount++;
+        // CLI7: path-traversal 방지 — basename + decodeURIComponent
+        const safeName = basename(decodeURIComponent(fileName));
+        const outputPath = join(opts.output, safeName);
+        await writeFile(outputPath, Buffer.from(buffer));
+        succeeded.push({ path: outputPath, fileName: safeName });
+        // plain 모드만 ✓ 진행 출력 (json/quiet 는 마지막에 일괄)
+        if (!globalOpts.json && !globalOpts.quiet) {
+          process.stdout.write(`✓ ${safeName}\n`);
+        }
       } catch (e) {
-        failures.push({ fileId: f.id, error: e instanceof Error ? e.message : String(e) });
-        process.stderr.write(`✗ ${f.name} (${f.id}): ${e instanceof Error ? e.message : String(e)}\n`);
+        failed.push({ fileId: f.id, error: e instanceof Error ? e.message : String(e) });
+        if (!globalOpts.json) {
+          process.stderr.write(`✗ ${f.name} (${f.id}): ${e instanceof Error ? e.message : String(e)}\n`);
+        }
       }
     }
 
-    process.stdout.write(`\n완료: ${successCount}/${allFiles.length}\n`);
-    if (failures.length > 0) {
-      throw new DoorayCliError(
-        `${failures.length}개 파일 다운로드 실패 (성공: ${successCount}/${allFiles.length})`,
-        EXIT_API_ERROR,
-      );
-    }
+    // ADR-031: --json / --quiet / plain 최종 출력
+    emitDownloadAllResult(globalOpts, { count: allFiles.length, succeeded, failed });
+
+    // 부분 실패 시 exit 1 (process.exit 대신 exitCode — 비동기 flush 보장)
+    if (failed.length > 0) process.exitCode = 1;
   });

--- a/src/commands/wiki/page-file/download-all.ts
+++ b/src/commands/wiki/page-file/download-all.ts
@@ -44,10 +44,9 @@ export const wikiPageFileDownloadAllCommand = new Command("download-all")
 
     if (allFiles.length === 0) {
       stopSpinner(true, "첨부파일 없음");
-      // ADR-031: --json 모드에서는 빈 스키마 반환
       if (globalOpts.json) {
         printJson({ count: 0, succeeded: [], failed: [] });
-      } else {
+      } else if (!globalOpts.quiet) {
         process.stdout.write("첨부파일이 없습니다.\n");
       }
       return;

--- a/src/commands/wiki/page-file/download.ts
+++ b/src/commands/wiki/page-file/download.ts
@@ -7,6 +7,8 @@ import { resolveWikiPageInput } from "../../../resolvers/wiki-page-input.js";
 import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
 import { DoorayCliError } from "../../../utils/errors.js";
 import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
+import type { OutputOptions } from "../../../formatters/table.js";
+import { emitDownloadResult } from "../../../formatters/file-output.js";
 
 export const wikiPageFileDownloadCommand = new Command("download")
   .description("위키 페이지 첨부파일 다운로드")
@@ -19,6 +21,7 @@ export const wikiPageFileDownloadCommand = new Command("download")
   .option("--file-id <fileId>", "파일 ID (positional 대체)")
   .option("-o, --output <dir>", "저장 디렉토리", ".")
   .action(async (arg1, arg2, arg3, opts) => {
+    const globalOpts = wikiPageFileDownloadCommand.optsWithGlobals() as OutputOptions;
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
@@ -73,12 +76,14 @@ export const wikiPageFileDownloadCommand = new Command("download")
     startSpinner("파일 다운로드 중...");
     try {
       const { buffer, fileName } = await client.downloadWikiPageFile(wikiId, pageId, fileId);
-      // 방어적 basename — client 가 이미 sanitize 하지만 출력 경로 조합 전 한 번 더
-      const outputPath = join(opts.output, basename(fileName));
+      // CLI7: path-traversal 방지 — basename + decodeURIComponent
+      const safeName = basename(decodeURIComponent(fileName));
+      const outputPath = join(opts.output, safeName);
       await writeFile(outputPath, Buffer.from(buffer));
       stopSpinner(true, `다운로드 완료: ${outputPath}`);
 
-      process.stdout.write(`${outputPath}\n`);
+      // ADR-031: --json / --quiet / plain 3 모드 분기
+      emitDownloadResult(globalOpts, { outputPath, fileName: safeName, size: buffer.byteLength });
     } catch (e) {
       stopSpinner(false);
       throw e;

--- a/src/commands/wiki/page-file/upload.ts
+++ b/src/commands/wiki/page-file/upload.ts
@@ -6,6 +6,8 @@ import { startSpinner, stopSpinner } from "../../../utils/spinner.js";
 import { DoorayCliError } from "../../../utils/errors.js";
 import { EXIT_PARAM_ERROR } from "../../../utils/exit-codes.js";
 import type { WikiPageFileType } from "../../../api/types.js";
+import type { OutputOptions } from "../../../formatters/table.js";
+import { printJson } from "../../../formatters/table.js";
 
 export const wikiPageFileUploadCommand = new Command("upload")
   .description("위키 페이지 첨부파일 업로드 (multipart type 순서 강제, ADR-029)")
@@ -18,6 +20,7 @@ export const wikiPageFileUploadCommand = new Command("upload")
   .option("--file <path>", "업로드할 파일 경로 (positional 대체)")
   .option("--type <type>", "파일 타입: general | inline_image (기본 general)", "general")
   .action(async (arg1, arg2, arg3, opts) => {
+    const globalOpts = wikiPageFileUploadCommand.optsWithGlobals() as OutputOptions;
     const config = await getConfigOrThrow();
     const client = new DoorayApiClient(config.apiKey, config.baseUrl);
 
@@ -82,14 +85,21 @@ export const wikiPageFileUploadCommand = new Command("upload")
       const res = await client.uploadWikiPageFile(wikiId, pageId, filePath, fileType);
       stopSpinner(true, "업로드 완료");
 
-      process.stdout.write(`attachFileId: ${res.result.attachFileId}\n`);
-      process.stdout.write(`name:         ${res.result.name}\n`);
-      process.stdout.write(`size:         ${res.result.size}\n`);
-      process.stdout.write(`type:         ${res.result.type}\n`);
+      // ADR-031: --json / --quiet / plain 3 모드 분기
+      if (globalOpts.json) {
+        printJson(res.result);
+      } else if (globalOpts.quiet) {
+        process.stdout.write(`${res.result.id}\n`);
+      } else {
+        process.stdout.write(`attachFileId: ${res.result.attachFileId}\n`);
+        process.stdout.write(`name:         ${res.result.name}\n`);
+        process.stdout.write(`size:         ${res.result.size}\n`);
+        process.stdout.write(`type:         ${res.result.type}\n`);
 
-      if (fileType === "inline_image") {
-        process.stdout.write("\n본문 삽입용 markdown snippet (직접 wiki page edit 으로 본문에 박으세요):\n");
-        process.stdout.write(`  ![${res.result.name}](/wikis/${wikiId}/files/${res.result.attachFileId})\n`);
+        if (fileType === "inline_image") {
+          process.stdout.write("\n본문 삽입용 markdown snippet (직접 wiki page edit 으로 본문에 박으세요):\n");
+          process.stdout.write(`  ![${res.result.name}](/wikis/${wikiId}/files/${res.result.attachFileId})\n`);
+        }
       }
     } catch (e) {
       stopSpinner(false);

--- a/src/formatters/file-output.test.ts
+++ b/src/formatters/file-output.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  emitDownloadResult,
+  emitDownloadAllResult,
+  emitDeleteResult,
+  type DownloadResult,
+  type DownloadAllResult,
+  type DeleteResult,
+} from "./file-output.js";
+
+// --- helpers ---
+
+function captureStdout(): { writes: string[]; restore: () => void } {
+  const writes: string[] = [];
+  const spy = vi.spyOn(process.stdout, "write").mockImplementation((s: any) => {
+    writes.push(String(s));
+    return true;
+  });
+  return {
+    writes,
+    restore: () => spy.mockRestore(),
+  };
+}
+
+// --- emitDownloadResult ---
+
+const downloadFixture: DownloadResult = {
+  outputPath: "/tmp/report.pdf",
+  fileName: "report.pdf",
+  size: 12345,
+};
+
+describe("emitDownloadResult", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("--json 모드 — { outputPath, fileName, size } JSON 출력", () => {
+    const { writes, restore } = captureStdout();
+    emitDownloadResult({ json: true }, downloadFixture);
+    restore();
+    const parsed = JSON.parse(writes.join(""));
+    expect(parsed.outputPath).toBe("/tmp/report.pdf");
+    expect(parsed.fileName).toBe("report.pdf");
+    expect(parsed.size).toBe(12345);
+  });
+
+  it("--quiet 모드 — outputPath 한 줄 출력", () => {
+    const { writes, restore } = captureStdout();
+    emitDownloadResult({ quiet: true }, downloadFixture);
+    restore();
+    expect(writes.join("").trim()).toBe("/tmp/report.pdf");
+  });
+
+  it("plain 모드 — outputPath 한 줄 출력", () => {
+    const { writes, restore } = captureStdout();
+    emitDownloadResult({}, downloadFixture);
+    restore();
+    expect(writes.join("").trim()).toBe("/tmp/report.pdf");
+  });
+});
+
+// --- emitDownloadAllResult ---
+
+const downloadAllFixture: DownloadAllResult = {
+  count: 3,
+  succeeded: [
+    { path: "/tmp/a.pdf", fileName: "a.pdf" },
+    { path: "/tmp/b.png", fileName: "b.png" },
+  ],
+  failed: [{ fileId: "f001", error: "timeout" }],
+};
+
+describe("emitDownloadAllResult", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("--json 모드 — { count, succeeded, failed } JSON 출력", () => {
+    const { writes, restore } = captureStdout();
+    emitDownloadAllResult({ json: true }, downloadAllFixture);
+    restore();
+    const parsed = JSON.parse(writes.join(""));
+    expect(parsed.count).toBe(3);
+    expect(parsed.succeeded).toHaveLength(2);
+    expect(parsed.failed).toHaveLength(1);
+    expect(parsed.failed[0].fileId).toBe("f001");
+  });
+
+  it("--quiet 모드 — succeeded 경로 한 줄씩 출력", () => {
+    const { writes, restore } = captureStdout();
+    emitDownloadAllResult({ quiet: true }, downloadAllFixture);
+    restore();
+    const lines = writes.join("").split("\n").filter(Boolean);
+    expect(lines).toEqual(["/tmp/a.pdf", "/tmp/b.png"]);
+  });
+
+  it("plain 모드 — 완료 요약 출력", () => {
+    const { writes, restore } = captureStdout();
+    emitDownloadAllResult({}, downloadAllFixture);
+    restore();
+    expect(writes.join("")).toContain("완료: 2/3");
+  });
+
+  it("--json 모드, 빈 결과 — { count: 0, succeeded: [], failed: [] }", () => {
+    const { writes, restore } = captureStdout();
+    emitDownloadAllResult({ json: true }, { count: 0, succeeded: [], failed: [] });
+    restore();
+    const parsed = JSON.parse(writes.join(""));
+    expect(parsed.count).toBe(0);
+    expect(parsed.succeeded).toHaveLength(0);
+    expect(parsed.failed).toHaveLength(0);
+  });
+});
+
+// --- emitDeleteResult ---
+
+const deleteFixture: DeleteResult = { fileId: "abc123" };
+
+describe("emitDeleteResult", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("--json 모드 — { fileId, status: 'deleted' } JSON 출력", () => {
+    const { writes, restore } = captureStdout();
+    emitDeleteResult({ json: true }, deleteFixture);
+    restore();
+    const parsed = JSON.parse(writes.join(""));
+    expect(parsed.fileId).toBe("abc123");
+    expect(parsed.status).toBe("deleted");
+  });
+
+  it("--quiet 모드 — fileId 한 줄 출력", () => {
+    const { writes, restore } = captureStdout();
+    emitDeleteResult({ quiet: true }, deleteFixture);
+    restore();
+    expect(writes.join("").trim()).toBe("abc123");
+  });
+
+  it("plain 모드 — 삭제 확인 메시지 출력", () => {
+    const { writes, restore } = captureStdout();
+    emitDeleteResult({}, deleteFixture);
+    restore();
+    expect(writes.join("")).toContain("abc123");
+    expect(writes.join("")).toContain("삭제");
+  });
+});

--- a/src/formatters/file-output.test.ts
+++ b/src/formatters/file-output.test.ts
@@ -12,7 +12,7 @@ import {
 
 function captureStdout(): { writes: string[]; restore: () => void } {
   const writes: string[] = [];
-  const spy = vi.spyOn(process.stdout, "write").mockImplementation((s: any) => {
+  const spy = vi.spyOn(process.stdout, "write").mockImplementation((s: string | Uint8Array) => {
     writes.push(String(s));
     return true;
   });

--- a/src/formatters/file-output.ts
+++ b/src/formatters/file-output.ts
@@ -34,6 +34,8 @@ export function emitDownloadResult(
 ): void {
   if (globalOpts.json) {
     printJson(result);
+  } else if (globalOpts.quiet) {
+    process.stdout.write(`${result.outputPath}\n`);
   } else {
     process.stdout.write(`${result.outputPath}\n`);
   }

--- a/src/formatters/file-output.ts
+++ b/src/formatters/file-output.ts
@@ -34,8 +34,6 @@ export function emitDownloadResult(
 ): void {
   if (globalOpts.json) {
     printJson(result);
-  } else if (globalOpts.quiet) {
-    process.stdout.write(`${result.outputPath}\n`);
   } else {
     process.stdout.write(`${result.outputPath}\n`);
   }
@@ -50,6 +48,9 @@ export function emitDownloadAllResult(
   } else if (globalOpts.quiet) {
     for (const s of data.succeeded) {
       process.stdout.write(`${s.path}\n`);
+    }
+    if (data.failed.length > 0) {
+      process.stderr.write(`${data.failed.length} failed\n`);
     }
   } else {
     process.stdout.write(`\n완료: ${data.succeeded.length}/${data.count}\n`);

--- a/src/formatters/file-output.ts
+++ b/src/formatters/file-output.ts
@@ -27,11 +27,7 @@ export interface DeleteResult {
   fileId: string;
 }
 
-/**
- * download 명령 출력 (ADR-031)
- * --json: { outputPath, fileName, size }
- * --quiet / plain: outputPath 한 줄
- */
+// ADR-031 file 명령 출력 헬퍼
 export function emitDownloadResult(
   globalOpts: OutputOptions,
   result: DownloadResult,
@@ -39,19 +35,10 @@ export function emitDownloadResult(
   if (globalOpts.json) {
     printJson(result);
   } else {
-    // quiet 와 plain 모두 outputPath 한 줄 — 의미 일관성 위해 분기는 동일
     process.stdout.write(`${result.outputPath}\n`);
   }
 }
 
-/**
- * download-all 명령 최종 출력 (ADR-031)
- * --json: { count, succeeded, failed }
- * --quiet: succeeded 경로 한 줄씩
- * plain: 완료 요약 한 줄
- *
- * 루프 중 ✓/✗ 진행 출력은 각 명령 파일에서 직접 처리.
- */
 export function emitDownloadAllResult(
   globalOpts: OutputOptions,
   data: DownloadAllResult,
@@ -67,12 +54,6 @@ export function emitDownloadAllResult(
   }
 }
 
-/**
- * delete 명령 출력 (ADR-031)
- * --json: { fileId, status: "deleted" }
- * --quiet: fileId 한 줄
- * plain: 삭제 확인 메시지
- */
 export function emitDeleteResult(
   globalOpts: OutputOptions,
   result: DeleteResult,

--- a/src/formatters/file-output.ts
+++ b/src/formatters/file-output.ts
@@ -1,0 +1,87 @@
+import { printJson } from "./table.js";
+import type { OutputOptions } from "./table.js";
+
+export interface DownloadResult {
+  outputPath: string;
+  fileName: string;
+  size: number;
+}
+
+export interface DownloadAllSucceeded {
+  path: string;
+  fileName: string;
+}
+
+export interface DownloadAllFailed {
+  fileId: string;
+  error: string;
+}
+
+export interface DownloadAllResult {
+  count: number;
+  succeeded: DownloadAllSucceeded[];
+  failed: DownloadAllFailed[];
+}
+
+export interface DeleteResult {
+  fileId: string;
+}
+
+/**
+ * download 명령 출력 (ADR-031)
+ * --json: { outputPath, fileName, size }
+ * --quiet / plain: outputPath 한 줄
+ */
+export function emitDownloadResult(
+  globalOpts: OutputOptions,
+  result: DownloadResult,
+): void {
+  if (globalOpts.json) {
+    printJson(result);
+  } else {
+    // quiet 와 plain 모두 outputPath 한 줄 — 의미 일관성 위해 분기는 동일
+    process.stdout.write(`${result.outputPath}\n`);
+  }
+}
+
+/**
+ * download-all 명령 최종 출력 (ADR-031)
+ * --json: { count, succeeded, failed }
+ * --quiet: succeeded 경로 한 줄씩
+ * plain: 완료 요약 한 줄
+ *
+ * 루프 중 ✓/✗ 진행 출력은 각 명령 파일에서 직접 처리.
+ */
+export function emitDownloadAllResult(
+  globalOpts: OutputOptions,
+  data: DownloadAllResult,
+): void {
+  if (globalOpts.json) {
+    printJson(data);
+  } else if (globalOpts.quiet) {
+    for (const s of data.succeeded) {
+      process.stdout.write(`${s.path}\n`);
+    }
+  } else {
+    process.stdout.write(`\n완료: ${data.succeeded.length}/${data.count}\n`);
+  }
+}
+
+/**
+ * delete 명령 출력 (ADR-031)
+ * --json: { fileId, status: "deleted" }
+ * --quiet: fileId 한 줄
+ * plain: 삭제 확인 메시지
+ */
+export function emitDeleteResult(
+  globalOpts: OutputOptions,
+  result: DeleteResult,
+): void {
+  if (globalOpts.json) {
+    printJson({ fileId: result.fileId, status: "deleted" });
+  } else if (globalOpts.quiet) {
+    process.stdout.write(`${result.fileId}\n`);
+  } else {
+    process.stdout.write(`파일(${result.fileId})이 삭제되었습니다.\n`);
+  }
+}

--- a/tasks/040-feat-file-commands-json-output/index.json
+++ b/tasks/040-feat-file-commands-json-output/index.json
@@ -2,8 +2,8 @@
   "name": "040-feat-file-commands-json-output",
   "description": "GitHub Issue #73 — file 명령군 8 명령 (`post file` + `wiki page file` 각 4종: upload/download/download-all/delete) 의 `--json` 출력 스키마 통일. 현재 list 만 양쪽 다 동작, upload 는 post file 만 동작, 나머지는 plain text 만. 자동화 스크립트의 parse 일관성 부재 해결. ADR-031 신설 — 스키마 통일 + 부분 실패 표현 + quiet 모드 의미 명시. download = `{outputPath, fileName, size}` / download-all = `{count, succeeded, failed}` (부분 실패 시 exit 1) / delete = `{fileId, status: 'deleted'}`. quiet 모드는 id / outputPath / fileId 만. 두 명령군 mirror — 자동화가 동일 코드로 parse.",
   "created_at": "2026-05-26T00:00:00Z",
-  "status": "pending",
-  "current_phase": 1,
+  "status": "completed",
+  "current_phase": 2,
   "total_phases": 1,
   "error_message": null,
   "blocked_reason": null,
@@ -12,7 +12,7 @@
       "number": 1,
       "title": "8 명령 --json/--quiet 분기 추가 + 단위 테스트 + README/SKILL 갱신",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],

--- a/tasks/040-feat-file-commands-json-output/phase-01.md
+++ b/tasks/040-feat-file-commands-json-output/phase-01.md
@@ -77,9 +77,12 @@ if (globalOpts.json) {
 - quiet vs plain 동작 동일성: 현재 `download` 의 plain text 출력이 이미 `outputPath\n` 한 줄이라 quiet 와 동일.
   plain 그대로 유지 + json 모드만 추가.
   `--quiet` 명시 시 동일 결과지만 의미 일관성 위해 분기는 유지.
-- **CLI7 basename 필수**: `post/file/download.ts` 와 `wiki/page-file/download-all.ts` 에 `basename(decodeURIComponent(fileName))` 미적용 상태.
-  본 phase 에서 수정 시 반드시 적용.
-  `wiki/page-file/download.ts` 는 이미 적용되어 있으므로 skip.
+- **CLI7 basename 필수**: 아래 3 파일에 `basename(decodeURIComponent(fileName))` 미적용 상태.
+  본 phase 에서 반드시 적용.
+  - `post/file/download.ts`
+  - `post/file/download-all.ts`
+  - `wiki/page-file/download-all.ts`
+  - `wiki/page-file/download.ts` 는 이미 적용 → skip
 
 ### 2. `download-all` 양 명령군 — 2 파일
 
@@ -91,9 +94,10 @@ const failed: { fileId: string; error: string }[] = [];
 for (const f of allFiles) {
   try {
     const { buffer, fileName } = await client.downloadPostFile(projectId, postId, f.id);
-    const outputPath = path.join(outDir, fileName);
+    const safeName = path.basename(decodeURIComponent(fileName));  // CLI7: path-traversal 방지
+    const outputPath = path.join(outDir, safeName);
     await writeFile(outputPath, Buffer.from(buffer));
-    succeeded.push({ path: outputPath, fileName });
+    succeeded.push({ path: outputPath, fileName: safeName });
     // plain 모드만 ✓ 마크 출력 (json/quiet 는 마지막에 일괄)
     if (!globalOpts.json && !globalOpts.quiet) {
       process.stdout.write(`✓ ${fileName}\n`);

--- a/tasks/040-feat-file-commands-json-output/phase-01.md
+++ b/tasks/040-feat-file-commands-json-output/phase-01.md
@@ -58,13 +58,14 @@ const globalOpts = fileDownloadCommand.optsWithGlobals() as OutputOptions;
 
 // ...기존 download 호출...
 const { buffer, fileName } = await client.downloadPostFile(...);
-const outputPath = path.join(opts.output ?? ".", fileName);
+const safeName = path.basename(decodeURIComponent(fileName));  // CLI7: path-traversal 방지
+const outputPath = path.join(opts.output ?? ".", safeName);
 await writeFile(outputPath, Buffer.from(buffer));
 stopSpinner(true, "다운로드 완료");
 
 // ADR-031: --json / --quiet / plain 3 모드 분기
 if (globalOpts.json) {
-  printJson({ outputPath, fileName, size: buffer.byteLength });
+  printJson({ outputPath, fileName: safeName, size: buffer.byteLength });
 } else if (globalOpts.quiet) {
   process.stdout.write(`${outputPath}\n`);
 } else {
@@ -72,9 +73,13 @@ if (globalOpts.json) {
 }
 ```
 
-**주의 — quiet vs plain 동작 동일성**: 현재 `download` 의 plain text 출력이 이미 `outputPath\n` 한 줄이라 quiet 와 동일.
-plain 그대로 유지 + json 모드만 추가.
-`--quiet` 명시 시 동일 결과지만 의미 일관성 위해 분기는 유지.
+**주의 사항**:
+- quiet vs plain 동작 동일성: 현재 `download` 의 plain text 출력이 이미 `outputPath\n` 한 줄이라 quiet 와 동일.
+  plain 그대로 유지 + json 모드만 추가.
+  `--quiet` 명시 시 동일 결과지만 의미 일관성 위해 분기는 유지.
+- **CLI7 basename 필수**: `post/file/download.ts` 와 `wiki/page-file/download-all.ts` 에 `basename(decodeURIComponent(fileName))` 미적용 상태.
+  본 phase 에서 수정 시 반드시 적용.
+  `wiki/page-file/download.ts` 는 이미 적용되어 있으므로 skip.
 
 ### 2. `download-all` 양 명령군 — 2 파일
 
@@ -114,7 +119,13 @@ if (globalOpts.json) {
 if (failed.length > 0) process.exitCode = 1;
 ```
 
-**주의**: `process.exit(1)` 대신 `process.exitCode = 1` — Node 의 비동기 flush 보장 (기존 패턴).
+**주의 사항**:
+- `process.exit(1)` 대신 `process.exitCode = 1` — Node 의 비동기 flush 보장 (기존 패턴)
+- **빈 파일 조기 반환**: 양 명령군 모두 파일 0개 시 기존 plain "첨부파일이 없습니다" early return 존재.
+  `--json` 모드에서는 `{ count: 0, succeeded: [], failed: [] }` 로 반환해야 ADR-031 스키마 일관.
+  early return 분기에 `globalOpts.json` 체크 추가
+- **wiki/download-all.ts orphan import 제거**: 기존 `EXIT_API_ERROR` import 가 `process.exitCode = 1` 전환 후 미사용.
+  orphan import 정리
 
 ### 3. `delete` 양 명령군 — 2 파일
 
@@ -270,6 +281,13 @@ grep -nE "process\.exitCode = 1" src/commands/{post/file,wiki/page-file}/downloa
 grep -c "file.*--json" README.md
 # 기대: 4 이상 (양 명령군 × 사용 예 2 이상)
 ```
+
+### index.json 완료 마킹 (마지막 phase 의무)
+
+`tasks/040-feat-file-commands-json-output/index.json` 의 다음 필드를 갱신:
+- `status`: `"completed"`
+- `current_phase`: `2` (total_phases + 1)
+- `phases[0].status`: `"completed"`
 
 ## 작업 외 금지
 


### PR DESCRIPTION
## Summary

- file 명령군 8 명령 (post file + wiki page file 각 upload/download/download-all/delete) 의 `--json`/`--quiet` 출력 스키마 통일 (ADR-031)
- 자동화 스크립트가 두 명령군을 동일 parse 코드로 처리 가능
- CLI7 basename 보안 수정 3 파일 포함

## Changes

- `src/formatters/file-output.ts` — 공통 emit 헬퍼 3종 (emitDownloadResult/emitDownloadAllResult/emitDeleteResult)
- `src/formatters/file-output.test.ts` — 10 단위 테스트
- `src/commands/post/file/{download,download-all,delete}.ts` — json/quiet 분기 + CLI7 basename
- `src/commands/wiki/page-file/{upload,download,download-all,delete}.ts` — json/quiet 분기 + CLI7 basename + orphan import 정리
- `docs/code-architecture.md` — file-output.ts 등재
- `README.md` — --json 사용 예 (양 명령군)
- `skills/dooray-cli/SKILL.md` — 빠른 참조 표 + 자동화 시나리오

## ADR-031 스키마

| 명령 | --json | --quiet |
|---|---|---|
| upload | res.result raw | id |
| download | {outputPath, fileName, size} | outputPath |
| download-all | {count, succeeded, failed} | succeeded paths |
| delete | {fileId, status: 'deleted'} | fileId |

## Test plan

- [x] `pnpm tsc --noEmit` — 0 errors
- [x] `pnpm run build` — exit 0
- [x] `pnpm test` — 166/166 passed (10 신규)
- [x] 8 파일 모두 json/quiet 분기 존재
- [x] download-all 부분 실패 exit 1 (양 명령군)
- [x] CLI7 basename 3 파일 적용

closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)
