### PR TITLE
feat(resolvers): post-input 타입 판별기 + URL 형식 확장 (#82, #83)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,8 @@ bash scripts/benchmark.sh [project] [post-number] [wiki-page-id]
   - 대상: `get` / `edit` / `done` / `workflow` + comment 5 + file 5 + comment file 4
   - 입력 형식: `<project> <post-number>` / `--id <postId>` / `--url <url>` / 첫 positional 에 Dooray URL 직접 입력
   - 분기 헬퍼: post / comment / file 13 = `resolvePostInput` / comment file 4 = `resolveCommentFileInput` (`resolvePostInput` 위임 + comment-id 분기)
+  - 입력 토큰 타입 판별 (`classifyPostInputToken`, ADR-020 보강): postId (15+자리) / postNumber / url / project
+    - 진입점이 기대 타입과 불일치하면 타입별 안내 에러 (예: positional 에 postId → `--id` 안내, #82)
 - wiki page file 5 + comment 6 명령 input 통합
   - 분기 헬퍼: `resolveWikiPageInput` (`resolveProject` + URL `/wiki/<wikiId>/<pageId>` parser)
   - `--id <pageId>` 모드는 `--project <code>` 동반 필수 (wiki API 가 page-only fetch 미지원)

--- a/README.md
+++ b/README.md
@@ -83,10 +83,15 @@ dooray post get <project> 42 --json           # JSON 출력
 | 방식 | 예시 |
 |---|---|
 | `<project> <number>` | `dooray post get <project> 42` |
-| Dooray URL positional (`/task/to/<postId>`) | `dooray post get https://x.dooray.com/task/to/<postId>` |
-| Dooray URL positional (브라우저 주소창 복사본) | `dooray post get https://x.dooray.com/task/<projectId>/<postId>` |
+| Dooray URL positional | `dooray post get https://x.dooray.com/task/to/<postId>` |
 | `--id <postId>` | `dooray post get --id <postId>` |
-| `--url <url>` | `dooray post get --url https://x.dooray.com/task/to/...` |
+| `--url <url>` | `dooray post get --url https://x.dooray.com/task/to/<postId>` |
+
+지원 URL 형식 3종 (positional 첫 인자 / `--url` 공통):
+
+- `https://*.dooray.com/task/to/<postId>`
+- `https://*.dooray.com/task/<projectId>/<postId>` — 브라우저 주소창 복사본
+- `https://*.dooray.com/project/tasks/<postId>` — 프로젝트 업무 목록에서 열기 (Issue #83)
 
 대상: `post get`/`edit`/`done`/`workflow`, `post comment list`/`add`/`edit`/`delete`, `post file list`/`upload`/`download`/`download-all`/`delete`.
 AI 에이전트는 사용자 메시지의 Dooray URL을 그대로 첫 인자로 전달하면 가장 빠르다 (ADR-020).
@@ -130,6 +135,17 @@ dooray post create <project> \
 
 > mandatory-tag 정책 프로젝트(예: `<project>`)에서는 mandatory 그룹마다 1개 이상 `--tag`로 지정해야 한다.
 > 누락 시 클라이언트가 사전 검증으로 후보 목록과 함께 에러 출력.
+
+> **`post create` 출력의 `.id` 는 internal postId (19자리 숫자)입니다.**
+> 이 ID 로 후속 조회·수정·댓글 작업을 할 때는 **`--id <postId>`** 를 사용하세요.
+> `<project> <업무번호>` 의 번호 자리에 postId 를 넣으면 안내 에러가 발생합니다.
+>
+> ```bash
+> # 생성 후 바로 조회하는 패턴
+> POST_ID=$(dooray post create <project> --title "..." --json | jq -r '.id')
+> dooray post get --id "$POST_ID"
+> dooray post comment add --id "$POST_ID" --body "첫 댓글"
+> ```
 
 #### 템플릿 기반 정형 task (ADR-027)
 

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -353,6 +353,18 @@ standalone API `GET /project/v1/posts/{postId}` 응답에 `project.{id,code}` �
 분기 규칙·URL 정규식·테스트 케이스는 `src/resolvers/post-input.ts` + `src/utils/dooray-url.ts` 참조.
 후속 (wiki input 통합, CI 통합) 은 별도 task.
 
+**보강 (Issue #82/#83, 2026-06)**: 입력 처리를 '만능 추론' 에서 '명시적 타입 분류' 로 강화한다.
+`classifyPostInputToken` 이 토큰을 postId / postNumber / url / project 로 분류한다.
+진입점 (`--id` / `--url` / positional) 이 기대 타입과 불일치하면 타입별 안내 에러를 던진다.
+
+- positional 2번째가 postId (15+자리 numeric) 면 "`--id` 를 쓰세요" 안내 (#82).
+- URL 형식에 `/project/tasks/{postId}` 추가 (#83 — `/task/{pid}/{id}` 는 기존 처리).
+
+길이 임계 (15+자리) 는 **안내 트리거로만** 쓰고 조회 분기로는 쓰지 않는다.
+따라서 본 ADR 의 'positional numeric → postId 자동 인식 기각' 은 유지된다.
+긴 numeric 을 postId 로 조용히 조회하지 않고 `--id` 명시 경로로 유도한다.
+ID 체계가 바뀌어 분류가 틀려도 `--id` 경로는 영향받지 않는다.
+
 ---
 
 <a id="adr-021"></a>

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -39,7 +39,7 @@ src/
     tag.ts                  # name[] → tagIds + mandatory/selectOne 검증
     milestone.ts            # name → milestoneId
     match.ts                # 공용 매칭: 정확일치 → 부분일치 → 모호 시 에러. helpHint 옵션 + name 가드 (ADR-028)
-    post-input.ts           # --id / --url / positional / Dooray URL → {projectId, postId, ...} 단일 헬퍼 (ADR-020)
+    post-input.ts           # --id / --url / positional / Dooray URL → {projectId, postId, ...} 단일 헬퍼 (ADR-020). 입력 토큰 타입 판별 (classifyPostInputToken) + 진입점별 검증 (ADR-020 보강)
     comment-file-input.ts   # comment file 4개 명령 입력 분기 헬퍼 (parseCommentFilePositional pure + resolveCommentFileInput orchestrator, ADR-020 확장)
     task-link.ts            # --link-task ref[] → TaskLinkInput[] (resolvePostInput + getPost detail 합성, post create/edit 인라인 변환)
     member-group.ts         # projectId → CachedMemberGroup[] (캐시 우선). 응답 nested array 정규화 (`res.result.flat()`) + 입력 자동 분기 (15+자리 numeric → id 직접 / 그 외 → code matchByName) + 개별 code 누락 가드 (ADR-028, Issue #65 #76)
@@ -75,7 +75,7 @@ src/
     spinner.ts              # ora 래퍼 + setQuiet (--json/--quiet 시 noop proxy 반환, Issue #35 item 1)
     exit-codes.ts           # 0 성공 / 1 API오류 / 2 인증실패 / 3 파라미터오류 / 4 설정오류
     body-input.ts           # --body / --body-file → string (stdin "-" + 충돌 가드)
-    dooray-url.ts           # task URL (/task/to/<postId> + /task/<projectId>/<postId>) + wiki URL (/wiki/<wikiId>/<pageId>) parser (ADR-020)
+    dooray-url.ts           # task URL (/task/to/<postId> + /task/<projectId>/<postId> + /project/tasks/<postId>) + wiki URL (/wiki/<wikiId>/<pageId>) parser (ADR-020)
     comment-enrich.ts       # PostComment[] Creator 이름 채우기 (ADR-021, immutable)
     mention.ts              # 멤버·그룹 멘션 마크업 빌더 + prependMentions (Issue #25)
     task-link.ts            # 업무 링크 빌더 (escapeLinkText / buildTaskLink / appendTaskLinks / parseLinkRef, Issue #33)

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -61,8 +61,14 @@ dooray doctor
 dooray project list                         # 1) 프로젝트 목록 (캐시 자동 갱신)
 dooray post list my-project                 # 2) 업무 목록 (postNumber 포함)
 dooray post get my-project 42              # 3) 업무 상세 (#42번)
+dooray post get --id <postId>              # 3-1) internal postId 로 (create 출력값)
+dooray post get https://x.dooray.com/task/to/<postId>        # 3-2) URL 직접 입력 (task/to)
+dooray post get https://x.dooray.com/project/tasks/<postId>  # 3-3) URL 직접 입력 (project/tasks, #83)
 dooray post search my-project "스프린트"   # 4) 제목 검색
 ```
+
+`post create` 출력의 긴 숫자는 internal postId 다 (업무 번호 #N 아님).
+후속 조회·수정은 `--id <postId>` 로 한다 — positional `<project> <number>` 자리에 넣으면 안내 에러로 거부된다 (#82).
 
 ### projectId 직접 입력 (member=me 응답 외 프로젝트, ADR-030, Issue #78)
 

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -47,7 +47,12 @@ dooray doctor                                 # 설정 검증
 
 > **공통 (post 하위 16개 명령)**: 아래 명령은 `<project> <number>` 외에도 `--id <postId>`, `--url <url>`, 또는 첫 인자에 Dooray URL 을 직접 받는다.
 > `post get`/`edit`/`done`/`workflow`, `post comment list`/`add`/`edit`/`delete`, `post file list`/`upload`/`download`/`download-all`/`delete`, `post comment file list`/`upload`/`download`/`delete`.
-> URL 형식: `https://*.dooray.com/task/to/<postId>` 또는 브라우저 주소창 복사본 `https://*.dooray.com/task/<projectId>/<postId>`.
+>
+> 지원 URL 형식 3종 (positional 첫 인자 / `--url` 공통):
+> - `https://*.dooray.com/task/to/<postId>`
+> - `https://*.dooray.com/task/<projectId>/<postId>` — 브라우저 주소창 복사본
+> - `https://*.dooray.com/project/tasks/<postId>` — 프로젝트 업무 목록 → 업무 열기 (Issue #83)
+>
 > **사용자가 URL을 줬으면 그대로 첫 인자로 전달**하는 것이 가장 빠른 경로 (resolve 단계 단축, ADR-020).
 
 | 의도 | 커맨드 |
@@ -63,7 +68,7 @@ dooray doctor                                 # 설정 검증
 | organization 전체 멤버 검색 | `dooray member search <keyword>` (이름 기본), `--email`(이메일 exact), `--user-code`(사번 like), `--user-code-exact`(사번 exact), `--page`/`--size` |
 | 업무 목록 조회 | `dooray post list <project>` |
 | 업무 검색 | `dooray post search <project|projectId> "<keyword>"` — projectId (15+자리 numeric) 직접 입력 시 cache 우회 (ADR-030) |
-| 업무 상세 보기 | `dooray post get <project> <number>` |
+| 업무 상세 보기 | `dooray post get <project> <number>` (번호) / `dooray post get --id <postId>` (internal ID) |
 | 업무 생성 | `dooray post create <project> --title "..." [--body "..." \| --body-file <path>]` (`--tag`/`--parent`/`--workflow`/`--milestone` 지원) |
 | 템플릿 기반 업무 생성 | `dooray post create <project> --template <name\|id>` — body/users/tags 자동 채움 (사용자 옵션 우선 override, ADR-027) |
 | 업무 제목/본문 수정 | `dooray post edit <project> <number> --title "..." --body "..."` 또는 `--body-file <path>` |
@@ -279,18 +284,32 @@ dooray wiki page comment latest <project> <page-id>
 `post get`/`edit`/`done`/`workflow`, `post comment list`/`add`/`edit`/`delete`, `post file list`/`upload`/`download`/`download-all`/`delete`, `post comment file list`/`upload`/`download`/`delete`.
 
 ```bash
-# (1) 기존 positional — 가장 익숙한 형태
+# (1) 기존 positional — 가장 익숙한 형태 (<number> 는 업무 번호 #N)
 dooray post get <project> 42
 
 # (2) Dooray URL을 첫 인자로 — 사용자 메시지에서 URL을 그대로 복사할 때 최적
+#     지원 형식 3종 모두 동일하게 작동
 dooray post get https://x.dooray.com/task/to/<postId>
+dooray post get https://x.dooray.com/task/<projectId>/<postId>
+dooray post get https://x.dooray.com/project/tasks/<postId>
 
-# (3) --id <postId>
+# (3) --id <postId>  — post create 결과의 .id 를 그대로 전달
 dooray post get --id <postId>
 
-# (4) --url <url>
+# (4) --url <url>  — URL 형식 3종 모두 지원
 dooray post get --url https://x.dooray.com/task/to/<postId>
 ```
+
+> ⚠️ **`post create` 결과 `.id` 는 internal postId (19자리 숫자)입니다.**
+> 이 숫자를 `<project> <업무번호>` 의 번호 자리에 넣으면 안내 에러가 발생합니다.
+> 후속 조회·수정·댓글은 반드시 **`--id <postId>`** 를 사용하세요.
+>
+> ```bash
+> POST_ID=$(dooray post create <project> --title "..." --json | jq -r '.id')
+> dooray post get --id "$POST_ID"                          # ✅ --id 사용
+> dooray post comment add --id "$POST_ID" --body "댓글"   # ✅ --id 사용
+> # dooray post get <project> "$POST_ID"                  # ❌ 안내 에러 발생
+> ```
 
 **우선순위 / 충돌 규칙**: `--id`+`--url` 동시 지정 → 에러.
 `--id`/`--url`+positional 동시 지정 → 에러.

--- a/src/resolvers/post-input.test.ts
+++ b/src/resolvers/post-input.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { resolvePostInput } from "./post-input.js";
+import { resolvePostInput, classifyPostInputToken } from "./post-input.js";
 import { DoorayCliError } from "../utils/errors.js";
 
 vi.mock("./project.js");
@@ -56,11 +56,11 @@ describe("resolvePostInput", () => {
 
   it("--id 단독 → standalone 호출", async () => {
     const c = makeClient({
-      standalone: { id: "999", projectId: "p1", projectCode: "tc-ocr", number: 337 },
+      standalone: { id: "4319587406666362045", projectId: "p1", projectCode: "tc-ocr", number: 337 },
     });
-    const out = await resolvePostInput(c, { idOpt: "999" });
-    expect(out.postId).toBe("999");
-    expect(c.getPostStandalone).toHaveBeenCalledWith("999");
+    const out = await resolvePostInput(c, { idOpt: "4319587406666362045" });
+    expect(out.postId).toBe("4319587406666362045");
+    expect(c.getPostStandalone).toHaveBeenCalledWith("4319587406666362045");
   });
 
   it("positional 1개가 URL이면 standalone", async () => {
@@ -103,5 +103,75 @@ describe("resolvePostInput", () => {
     await expect(resolvePostInput(makeClient({}), {})).rejects.toThrow(
       /업무를 식별할 정보가 부족합니다/,
     );
+  });
+
+  // Issue #82 — positional 2번째에 19자리 postId 입력 시 --id 안내
+  it("positional 2번째가 19자리 postId → --id 안내 에러", async () => {
+    await expect(
+      resolvePostInput(makeClient({}), {
+        projectArg: "tc-ocr",
+        postNumberArg: "4319587406666362045",
+      }),
+    ).rejects.toThrow(/--id/);
+  });
+
+  // --id 에 업무 번호(짧은 numeric) → <project> <number> 안내
+  it("--id 에 업무 번호(짧은 numeric) → <project> <number> 안내 에러", async () => {
+    await expect(
+      resolvePostInput(makeClient({}), { idOpt: "337" }),
+    ).rejects.toThrow(/<project>/);
+  });
+
+  // --id 에 URL → --url 안내
+  it("--id 에 URL → --url 안내 에러", async () => {
+    await expect(
+      resolvePostInput(makeClient({}), { idOpt: "https://x.dooray.com/task/to/4319587406666362045" }),
+    ).rejects.toThrow(/--url/);
+  });
+
+  // Issue #83 — /project/tasks/{postId} URL → 정상 standalone 호출
+  it("positional 1개가 /project/tasks/ URL이면 standalone", async () => {
+    const c = makeClient({
+      standalone: { id: "4319587406666362045", projectId: "p1", projectCode: "tc-ocr", number: 337 },
+    });
+    const out = await resolvePostInput(c, {
+      projectArg: "https://x.dooray.com/project/tasks/4319587406666362045",
+    });
+    expect(out.postId).toBe("4319587406666362045");
+    expect(c.getPostStandalone).toHaveBeenCalledWith("4319587406666362045");
+  });
+
+  // 기존 정상 케이스 회귀 — <project> 337
+  it("<project> 337 정상 경로 회귀", async () => {
+    vi.mocked(resolveProject).mockResolvedValue("proj-id-abc");
+    vi.mocked(resolvePost).mockResolvedValue("post-id-123");
+    const c = makeClient({});
+    const out = await resolvePostInput(c, { projectArg: "tc-ocr", postNumberArg: "337" });
+    expect(out.projectCode).toBe("tc-ocr");
+    expect(out.postNumber).toBe(337);
+  });
+});
+
+describe("classifyPostInputToken", () => {
+  it("http(s):// → url", () => {
+    expect(classifyPostInputToken("https://x.dooray.com/task/to/123")).toBe("url");
+    expect(classifyPostInputToken("http://x.dooray.com/project/tasks/123")).toBe("url");
+  });
+
+  it("15자리 이상 numeric → postId", () => {
+    expect(classifyPostInputToken("4319587406666362045")).toBe("postId");
+    expect(classifyPostInputToken("123456789012345")).toBe("postId");
+  });
+
+  it("1~14자리 numeric → postNumber", () => {
+    expect(classifyPostInputToken("337")).toBe("postNumber");
+    expect(classifyPostInputToken("1")).toBe("postNumber");
+    expect(classifyPostInputToken("99999999999999")).toBe("postNumber");
+  });
+
+  it("비숫자 문자열 → project", () => {
+    expect(classifyPostInputToken("tc-ocr")).toBe("project");
+    expect(classifyPostInputToken("abc")).toBe("project");
+    expect(classifyPostInputToken("my-project-code")).toBe("project");
   });
 });

--- a/src/resolvers/post-input.test.ts
+++ b/src/resolvers/post-input.test.ts
@@ -33,39 +33,39 @@ describe("resolvePostInput", () => {
 
   it("--id + positional 동시 → 에러", async () => {
     await expect(
-      resolvePostInput(makeClient({}), { idOpt: "1", projectArg: "tc-ocr" }),
+      resolvePostInput(makeClient({}), { idOpt: "1", projectArg: "my-project" }),
     ).rejects.toBeInstanceOf(DoorayCliError);
   });
 
   it("--url + positional 동시 → 에러", async () => {
     await expect(
-      resolvePostInput(makeClient({}), { urlOpt: "https://x.dooray.com/task/to/1", projectArg: "tc-ocr" }),
+      resolvePostInput(makeClient({}), { urlOpt: "https://x.dooray.com/task/to/1", projectArg: "my-project" }),
     ).rejects.toBeInstanceOf(DoorayCliError);
   });
 
   it("--url 단독 → standalone 호출", async () => {
     const c = makeClient({
-      standalone: { id: "999", projectId: "p1", projectCode: "tc-ocr", number: 337 },
+      standalone: { id: "999", projectId: "p1", projectCode: "my-project", number: 337 },
     });
     const out = await resolvePostInput(c, {
       urlOpt: "https://x.dooray.com/task/to/999",
     });
-    expect(out).toEqual({ projectId: "p1", projectCode: "tc-ocr", postId: "999", postNumber: 337 });
+    expect(out).toEqual({ projectId: "p1", projectCode: "my-project", postId: "999", postNumber: 337 });
     expect(c.getPostStandalone).toHaveBeenCalledWith("999");
   });
 
   it("--id 단독 → standalone 호출", async () => {
     const c = makeClient({
-      standalone: { id: "4319587406666362045", projectId: "p1", projectCode: "tc-ocr", number: 337 },
+      standalone: { id: "1234567890123456789", projectId: "p1", projectCode: "my-project", number: 337 },
     });
-    const out = await resolvePostInput(c, { idOpt: "4319587406666362045" });
-    expect(out.postId).toBe("4319587406666362045");
-    expect(c.getPostStandalone).toHaveBeenCalledWith("4319587406666362045");
+    const out = await resolvePostInput(c, { idOpt: "1234567890123456789" });
+    expect(out.postId).toBe("1234567890123456789");
+    expect(c.getPostStandalone).toHaveBeenCalledWith("1234567890123456789");
   });
 
   it("positional 1개가 URL이면 standalone", async () => {
     const c = makeClient({
-      standalone: { id: "999", projectId: "p1", projectCode: "tc-ocr", number: 337 },
+      standalone: { id: "999", projectId: "p1", projectCode: "my-project", number: 337 },
     });
     const out = await resolvePostInput(c, {
       projectArg: "https://x.dooray.com/task/to/999",
@@ -78,18 +78,18 @@ describe("resolvePostInput", () => {
     vi.mocked(resolvePost).mockResolvedValue("post-id-123");
 
     const c = makeClient({});
-    const out = await resolvePostInput(c, { projectArg: "tc-ocr", postNumberArg: "337" });
+    const out = await resolvePostInput(c, { projectArg: "my-project", postNumberArg: "337" });
     expect(out.projectId).toBe("proj-id-abc");
     expect(out.postId).toBe("post-id-123");
-    expect(out.projectCode).toBe("tc-ocr");
+    expect(out.projectCode).toBe("my-project");
     expect(out.postNumber).toBe(337);
-    expect(resolveProject).toHaveBeenCalledWith(c, "tc-ocr");
+    expect(resolveProject).toHaveBeenCalledWith(c, "my-project");
     expect(resolvePost).toHaveBeenCalledWith(c, "proj-id-abc", 337);
   });
 
   it("post-number 비정수 → 에러", async () => {
     await expect(
-      resolvePostInput(makeClient({}), { projectArg: "tc-ocr", postNumberArg: "abc" }),
+      resolvePostInput(makeClient({}), { projectArg: "my-project", postNumberArg: "abc" }),
     ).rejects.toBeInstanceOf(DoorayCliError);
   });
 
@@ -109,8 +109,8 @@ describe("resolvePostInput", () => {
   it("positional 2번째가 19자리 postId → --id 안내 에러", async () => {
     await expect(
       resolvePostInput(makeClient({}), {
-        projectArg: "tc-ocr",
-        postNumberArg: "4319587406666362045",
+        projectArg: "my-project",
+        postNumberArg: "1234567890123456789",
       }),
     ).rejects.toThrow(/--id/);
   });
@@ -125,20 +125,20 @@ describe("resolvePostInput", () => {
   // --id 에 URL → --url 안내
   it("--id 에 URL → --url 안내 에러", async () => {
     await expect(
-      resolvePostInput(makeClient({}), { idOpt: "https://x.dooray.com/task/to/4319587406666362045" }),
+      resolvePostInput(makeClient({}), { idOpt: "https://x.dooray.com/task/to/1234567890123456789" }),
     ).rejects.toThrow(/--url/);
   });
 
   // Issue #83 — /project/tasks/{postId} URL → 정상 standalone 호출
   it("positional 1개가 /project/tasks/ URL이면 standalone", async () => {
     const c = makeClient({
-      standalone: { id: "4319587406666362045", projectId: "p1", projectCode: "tc-ocr", number: 337 },
+      standalone: { id: "1234567890123456789", projectId: "p1", projectCode: "my-project", number: 337 },
     });
     const out = await resolvePostInput(c, {
-      projectArg: "https://x.dooray.com/project/tasks/4319587406666362045",
+      projectArg: "https://x.dooray.com/project/tasks/1234567890123456789",
     });
-    expect(out.postId).toBe("4319587406666362045");
-    expect(c.getPostStandalone).toHaveBeenCalledWith("4319587406666362045");
+    expect(out.postId).toBe("1234567890123456789");
+    expect(c.getPostStandalone).toHaveBeenCalledWith("1234567890123456789");
   });
 
   // 기존 정상 케이스 회귀 — <project> 337
@@ -146,8 +146,8 @@ describe("resolvePostInput", () => {
     vi.mocked(resolveProject).mockResolvedValue("proj-id-abc");
     vi.mocked(resolvePost).mockResolvedValue("post-id-123");
     const c = makeClient({});
-    const out = await resolvePostInput(c, { projectArg: "tc-ocr", postNumberArg: "337" });
-    expect(out.projectCode).toBe("tc-ocr");
+    const out = await resolvePostInput(c, { projectArg: "my-project", postNumberArg: "337" });
+    expect(out.projectCode).toBe("my-project");
     expect(out.postNumber).toBe(337);
   });
 });
@@ -159,7 +159,7 @@ describe("classifyPostInputToken", () => {
   });
 
   it("15자리 이상 numeric → postId", () => {
-    expect(classifyPostInputToken("4319587406666362045")).toBe("postId");
+    expect(classifyPostInputToken("1234567890123456789")).toBe("postId");
     expect(classifyPostInputToken("123456789012345")).toBe("postId");
   });
 
@@ -170,7 +170,7 @@ describe("classifyPostInputToken", () => {
   });
 
   it("비숫자 문자열 → project", () => {
-    expect(classifyPostInputToken("tc-ocr")).toBe("project");
+    expect(classifyPostInputToken("my-project")).toBe("project");
     expect(classifyPostInputToken("abc")).toBe("project");
     expect(classifyPostInputToken("my-project-code")).toBe("project");
   });

--- a/src/resolvers/post-input.ts
+++ b/src/resolvers/post-input.ts
@@ -5,6 +5,22 @@ import { parseDoorayTaskUrl, isLikelyDoorayUrl } from "../utils/dooray-url.js";
 import { DoorayCliError } from "../utils/errors.js";
 import { EXIT_PARAM_ERROR } from "../utils/exit-codes.js";
 
+export type PostInputTokenType = "postId" | "postNumber" | "url" | "project";
+
+/**
+ * 입력 토큰을 형태로 분류. 추론을 '명시화' 하는 단일 분류기.
+ * - url:        http(s):// 로 시작
+ * - postId:     15자리 이상 numeric (Dooray postId 는 19자리, ADR-030 의 15+ 기준과 일관)
+ * - postNumber: 1~14자리 numeric (업무 번호 #N)
+ * - project:    그 외 (프로젝트 코드 등 비숫자)
+ */
+export function classifyPostInputToken(token: string): PostInputTokenType {
+  if (/^https?:\/\//.test(token)) return "url";
+  if (/^\d{15,}$/.test(token)) return "postId";
+  if (/^\d+$/.test(token)) return "postNumber";
+  return "project";
+}
+
 export interface PostInputArgs {
   projectArg?: string;
   postNumberArg?: string;
@@ -24,6 +40,12 @@ const INPUT_HELP =
   "  - <project> <post-number>     예: tc-ocr 337\n" +
   "  - --id <postId>                예: --id 4319587406666362045\n" +
   "  - <Dooray URL>                 예: https://x.dooray.com/task/to/4319587406666362045";
+
+const URL_FORMAT_HINT =
+  "지원 형식:\n" +
+  "  https://x.dooray.com/task/to/{postId}\n" +
+  "  https://x.dooray.com/task/{projectId}/{postId}\n" +
+  "  https://x.dooray.com/project/tasks/{postId}";
 
 async function resolveByPostId(
   client: DoorayApiClient,
@@ -67,7 +89,7 @@ export async function resolvePostInput(
     const postId = parseDoorayTaskUrl(urlOpt);
     if (!postId) {
       throw new DoorayCliError(
-        `--url 형식이 올바르지 않습니다: "${urlOpt}"\n예: https://x.dooray.com/task/to/4319587406666362045`,
+        `--url 형식이 올바르지 않습니다: "${urlOpt}"\n${URL_FORMAT_HINT}`,
         EXIT_PARAM_ERROR,
       );
     }
@@ -76,6 +98,22 @@ export async function resolvePostInput(
 
   // 4. --id 단독
   if (idOpt) {
+    const idType = classifyPostInputToken(idOpt);
+    if (idType === "postNumber") {
+      throw new DoorayCliError(
+        `"${idOpt}" 는 업무 번호로 보입니다. <project> <post-number> 형식을 쓰세요:\n` +
+          `  dooray post get <project> ${idOpt}`,
+        EXIT_PARAM_ERROR,
+      );
+    }
+    if (idType === "url") {
+      throw new DoorayCliError(
+        `"${idOpt}" 는 URL 형식입니다. --url 옵션을 쓰세요:\n` +
+          `  dooray post get --url "${idOpt}"`,
+        EXIT_PARAM_ERROR,
+      );
+    }
+    // project (비숫자) 또는 postId → resolveByPostId 에 위임 (API 404 응답으로 알림)
     return resolveByPostId(client, idOpt);
   }
 
@@ -84,18 +122,33 @@ export async function resolvePostInput(
     const postId = parseDoorayTaskUrl(projectArg);
     if (!postId) {
       throw new DoorayCliError(
-        `Dooray URL 형식이 올바르지 않습니다: "${projectArg}"\n예: https://x.dooray.com/task/to/4319587406666362045`,
+        `Dooray URL 형식이 올바르지 않습니다: "${projectArg}"\n${URL_FORMAT_HINT}`,
         EXIT_PARAM_ERROR,
       );
     }
     return resolveByPostId(client, postId);
   }
 
-  // 6. positional 2개 (기존 경로)
+  // 6. positional 2개
   if (projectArg && postNumberArg) {
+    const numType = classifyPostInputToken(postNumberArg);
+    if (numType === "postId") {
+      throw new DoorayCliError(
+        `"${postNumberArg}" 는 내부 ID(postId)로 보입니다.\n` +
+          `업무 번호(#N)가 아닌 내부 ID 로 조회하려면 --id 옵션을 사용하세요:\n` +
+          `  dooray post get --id ${postNumberArg}`,
+        EXIT_PARAM_ERROR,
+      );
+    }
+    if (numType !== "postNumber") {
+      throw new DoorayCliError(
+        `<post-number>가 올바르지 않습니다: "${postNumberArg}"`,
+        EXIT_PARAM_ERROR,
+      );
+    }
     const projectId = await resolveProject(client, projectArg);
     const num = Number(postNumberArg);
-    if (!Number.isFinite(num) || num <= 0) {
+    if (num <= 0) {
       throw new DoorayCliError(
         `<post-number>가 올바르지 않습니다: "${postNumberArg}"`,
         EXIT_PARAM_ERROR,

--- a/src/resolvers/post-input.ts
+++ b/src/resolvers/post-input.ts
@@ -35,17 +35,18 @@ export interface ResolvedPostInput {
   postNumber: number;
 }
 
-const INPUT_HELP =
-  "업무를 식별할 정보가 부족합니다. 다음 중 하나를 입력하세요:\n" +
-  "  - <project> <post-number>     예: tc-ocr 337\n" +
-  "  - --id <postId>                예: --id 4319587406666362045\n" +
-  "  - <Dooray URL>                 예: https://x.dooray.com/task/to/4319587406666362045";
-
 const URL_FORMAT_HINT =
   "지원 형식:\n" +
   "  https://x.dooray.com/task/to/{postId}\n" +
   "  https://x.dooray.com/task/{projectId}/{postId}\n" +
   "  https://x.dooray.com/project/tasks/{postId}";
+
+// URL 형식 목록은 URL_FORMAT_HINT 단일 소스를 참조 (중복 정의 회피)
+const INPUT_HELP =
+  "업무를 식별할 정보가 부족합니다. 다음 중 하나를 입력하세요:\n" +
+  "  - <project> <post-number>     예: my-project 337\n" +
+  "  - --id <postId>                예: --id 1234567890123456789\n" +
+  `  - <Dooray URL>\n  ${URL_FORMAT_HINT}`;
 
 async function resolveByPostId(
   client: DoorayApiClient,
@@ -113,7 +114,8 @@ export async function resolvePostInput(
         EXIT_PARAM_ERROR,
       );
     }
-    // project (비숫자) 또는 postId → resolveByPostId 에 위임 (API 404 응답으로 알림)
+    // project (비숫자) 또는 postId → resolveByPostId 에 위임 (의도된 pass-through)
+    // 비숫자는 ky 가 URL 인코딩 처리, 존재하지 않는 postId 이므로 서버가 404 로 거부
     return resolveByPostId(client, idOpt);
   }
 
@@ -148,7 +150,9 @@ export async function resolvePostInput(
     }
     const projectId = await resolveProject(client, projectArg);
     const num = Number(postNumberArg);
-    if (num <= 0) {
+    // classifyPostInputToken 이 postNumber 를 보장하므로 NaN 불가하나,
+    // 분류 로직 변경 시 NaN <= 0 (false) 로 0번 조회되는 회귀 방지로 isFinite 명시
+    if (!Number.isFinite(num) || num <= 0) {
       throw new DoorayCliError(
         `<post-number>가 올바르지 않습니다: "${postNumberArg}"`,
         EXIT_PARAM_ERROR,

--- a/src/utils/dooray-url.test.ts
+++ b/src/utils/dooray-url.test.ts
@@ -41,6 +41,32 @@ describe("parseDoorayTaskUrl", () => {
   it("/task/<projectId>/<postId> 형도 dooray.com 도메인 외 reject", () => {
     expect(parseDoorayTaskUrl("https://other.com/task/123/456")).toBeNull();
   });
+
+  // Issue #83 — 브라우저 '프로젝트 업무 목록 → 업무 열기' URL
+  it("/project/tasks/<postId> 에서 postId 추출", () => {
+    expect(
+      parseDoorayTaskUrl("https://x.dooray.com/project/tasks/4319587406666362045"),
+    ).toBe("4319587406666362045");
+  });
+
+  it("/project/tasks/<postId> query string 무시", () => {
+    expect(
+      parseDoorayTaskUrl("https://x.dooray.com/project/tasks/4319587406666362045?workflowIds=a,b,c"),
+    ).toBe("4319587406666362045");
+  });
+
+  it("/project/tasks/<postId> dooray.com 도메인 외 reject", () => {
+    expect(parseDoorayTaskUrl("https://other.com/project/tasks/123")).toBeNull();
+  });
+
+  // Issue #83 — /task/{pid}/{id}?workflowIds= 회귀 (TASK_URL_ALT_RE 의 query 무시 확인)
+  it("/task/<projectId>/<postId>?workflowIds=a,b,c query 무시 회귀", () => {
+    expect(
+      parseDoorayTaskUrl(
+        "https://x.dooray.com/task/1234567890123456789/9876543210987654321?workflowIds=a,b,c",
+      ),
+    ).toBe("9876543210987654321");
+  });
 });
 
 describe("parseDoorayWikiUrl", () => {

--- a/src/utils/dooray-url.test.ts
+++ b/src/utils/dooray-url.test.ts
@@ -3,8 +3,8 @@ import { parseDoorayTaskUrl, parseDoorayWikiUrl, isLikelyDoorayUrl } from "./doo
 
 describe("parseDoorayTaskUrl", () => {
   it("정상 URL에서 postId 추출", () => {
-    expect(parseDoorayTaskUrl("https://nhnent.dooray.com/task/to/4319587406666362045"))
-      .toBe("4319587406666362045");
+    expect(parseDoorayTaskUrl("https://x.dooray.com/task/to/1234567890123456789"))
+      .toBe("1234567890123456789");
   });
   it("query string 무시", () => {
     expect(parseDoorayTaskUrl("https://x.dooray.com/task/to/123?projectScope=from_to_cc"))
@@ -24,7 +24,7 @@ describe("parseDoorayTaskUrl", () => {
     expect(parseDoorayTaskUrl("https://x.dooray.com/wiki/123")).toBeNull();
   });
   it("URL 형식이 아니면 null", () => {
-    expect(parseDoorayTaskUrl("tc-ocr/337")).toBeNull();
+    expect(parseDoorayTaskUrl("my-project/337")).toBeNull();
     expect(parseDoorayTaskUrl("12345")).toBeNull();
   });
   it("/task/<projectId>/<postId> 형 URL 에서 postId 추출", () => {
@@ -45,14 +45,14 @@ describe("parseDoorayTaskUrl", () => {
   // Issue #83 — 브라우저 '프로젝트 업무 목록 → 업무 열기' URL
   it("/project/tasks/<postId> 에서 postId 추출", () => {
     expect(
-      parseDoorayTaskUrl("https://x.dooray.com/project/tasks/4319587406666362045"),
-    ).toBe("4319587406666362045");
+      parseDoorayTaskUrl("https://x.dooray.com/project/tasks/1234567890123456789"),
+    ).toBe("1234567890123456789");
   });
 
   it("/project/tasks/<postId> query string 무시", () => {
     expect(
-      parseDoorayTaskUrl("https://x.dooray.com/project/tasks/4319587406666362045?workflowIds=a,b,c"),
-    ).toBe("4319587406666362045");
+      parseDoorayTaskUrl("https://x.dooray.com/project/tasks/1234567890123456789?workflowIds=a,b,c"),
+    ).toBe("1234567890123456789");
   });
 
   it("/project/tasks/<postId> dooray.com 도메인 외 reject", () => {
@@ -89,7 +89,7 @@ describe("isLikelyDoorayUrl", () => {
     expect(isLikelyDoorayUrl("http://x.com")).toBe(true);
   });
   it("URL 아니면 false", () => {
-    expect(isLikelyDoorayUrl("tc-ocr")).toBe(false);
+    expect(isLikelyDoorayUrl("my-project")).toBe(false);
     expect(isLikelyDoorayUrl("12345")).toBe(false);
   });
 });

--- a/src/utils/dooray-url.ts
+++ b/src/utils/dooray-url.ts
@@ -3,6 +3,9 @@ const TASK_URL_RE = /^https?:\/\/[\w.-]+\.dooray\.com\/task\/to\/(\d+)(?:[/?#].*
 // projectId 는 비캡처 — `parseDoorayTaskUrl` 시그니처가 string|null 단일 반환이라 사용 안 함.
 // postId 가 캡처 1 이 되어 short form (`m1[1]`) 과 인덱스 일관.
 const TASK_URL_ALT_RE = /^https?:\/\/[\w.-]+\.dooray\.com\/task\/(?:\d+)\/(\d+)(?:[/?#].*)?$/;
+// 브라우저 '프로젝트 업무 목록 → 업무 열기' URL — /project/tasks/<postId> (#83)
+const TASK_PROJECT_TASKS_RE =
+  /^https?:\/\/[\w.-]+\.dooray\.com\/project\/tasks\/(\d+)(?:[/?#].*)?$/;
 
 const WIKI_URL_RE = /^https?:\/\/[\w.-]+\.dooray\.com\/wiki\/(\d+)\/(\d+)(?:[/?#].*)?$/;
 
@@ -11,6 +14,8 @@ export function parseDoorayTaskUrl(input: string): string | null {
   if (m1) return m1[1];
   const m2 = TASK_URL_ALT_RE.exec(input);
   if (m2) return m2[1];
+  const m3 = TASK_PROJECT_TASKS_RE.exec(input);
+  if (m3) return m3[1];
   return null;
 }
 

--- a/tasks/041-feat-post-input-type-classifier/index.json
+++ b/tasks/041-feat-post-input-type-classifier/index.json
@@ -2,7 +2,7 @@
   "name": "041-feat-post-input-type-classifier",
   "description": "GitHub Issue #82 + #83 통합. 두 이슈의 공통 근원은 resolvePostInput 의 '만능 추론' — 입력값 형태로 타입을 짐작하다 경계가 흐려진다. #82: post create 가 internal postId 만 출력해, post get 에 그 id 를 positional 로 넣으면 업무 번호로 처리되어 USER_INVALID_ERROR. #83: URL 파서가 /task/to/{id} 형태만 받고 브라우저가 만드는 /project/tasks/{id} 를 거부. 결정(2026-06-08): 추론을 없애지 않고 명시화한다. classifyPostInputToken 순수 함수가 토큰을 네 타입(postId, postNumber, url, project)으로 분류하고, 진입점마다 기대 타입과 불일치하면 타입별 안내 에러를 던진다. #82 는 positional 2번째가 postId 면 --id 사용을 안내한다. #83 은 parseDoorayTaskUrl 에 /project/tasks/{id} 를 추가한다. 길이 임계는 안내 트리거로만 쓰고 조회 분기로는 쓰지 않아 ADR-020 의 'numeric 자동 인식' 기각과 일관된다. ADR-020 에 보강 섹션을 추가한다. SKILL 과 README 에 'create 출력은 internal postId 이므로 후속 조회·수정은 --id 사용' 을 안내해 AI 라우팅을 코드 에러 이전에 잡는다.",
   "created_at": "2026-06-08T00:00:00Z",
-  "status": "pending",
+  "status": "in_progress",
   "current_phase": 1,
   "total_phases": 2,
   "error_message": null,
@@ -12,7 +12,7 @@
       "number": 1,
       "title": "classifyPostInputToken 판별기 + dooray-url /project/tasks 확장 + resolvePostInput 타입 검증 + 단위 테스트",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {

--- a/tasks/041-feat-post-input-type-classifier/index.json
+++ b/tasks/041-feat-post-input-type-classifier/index.json
@@ -17,7 +17,7 @@
     },
     {
       "number": 2,
-      "title": "docs — ADR-020 보강 + CLAUDE.md + code-architecture.md + README + SKILL 라우팅 안내",
+      "title": "docs — README + SKILL 라우팅 안내 (사용자 가이드, planning 결정 docs 는 3단계 선반영)",
       "file": "phase-02.md",
       "status": "pending",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]

--- a/tasks/041-feat-post-input-type-classifier/index.json
+++ b/tasks/041-feat-post-input-type-classifier/index.json
@@ -2,8 +2,8 @@
   "name": "041-feat-post-input-type-classifier",
   "description": "GitHub Issue #82 + #83 통합. 두 이슈의 공통 근원은 resolvePostInput 의 '만능 추론' — 입력값 형태로 타입을 짐작하다 경계가 흐려진다. #82: post create 가 internal postId 만 출력해, post get 에 그 id 를 positional 로 넣으면 업무 번호로 처리되어 USER_INVALID_ERROR. #83: URL 파서가 /task/to/{id} 형태만 받고 브라우저가 만드는 /project/tasks/{id} 를 거부. 결정(2026-06-08): 추론을 없애지 않고 명시화한다. classifyPostInputToken 순수 함수가 토큰을 네 타입(postId, postNumber, url, project)으로 분류하고, 진입점마다 기대 타입과 불일치하면 타입별 안내 에러를 던진다. #82 는 positional 2번째가 postId 면 --id 사용을 안내한다. #83 은 parseDoorayTaskUrl 에 /project/tasks/{id} 를 추가한다. 길이 임계는 안내 트리거로만 쓰고 조회 분기로는 쓰지 않아 ADR-020 의 'numeric 자동 인식' 기각과 일관된다. ADR-020 에 보강 섹션을 추가한다. SKILL 과 README 에 'create 출력은 internal postId 이므로 후속 조회·수정은 --id 사용' 을 안내해 AI 라우팅을 코드 에러 이전에 잡는다.",
   "created_at": "2026-06-08T00:00:00Z",
-  "status": "in_progress",
-  "current_phase": 1,
+  "status": "completed",
+  "current_phase": 2,
   "total_phases": 2,
   "error_message": null,
   "blocked_reason": null,
@@ -19,9 +19,9 @@
       "number": 2,
       "title": "docs — README + SKILL 라우팅 안내 (사용자 가이드, planning 결정 docs 는 3단계 선반영)",
       "file": "phase-02.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],
-  "updated_at": "2026-06-08T00:00:00Z"
+  "updated_at": "2026-06-08T14:30:00Z"
 }

--- a/tasks/041-feat-post-input-type-classifier/phase-01.md
+++ b/tasks/041-feat-post-input-type-classifier/phase-01.md
@@ -87,7 +87,7 @@ export function parseDoorayTaskUrl(input: string): string | null {
 
 | 진입점 | 검증 대상 | 기대 타입 | 불일치 시 동작 |
 |---|---|---|---|
-| `--id` 단독 (경로 4) | `idOpt` | postId | `postNumber` → "`<project> <number>` 형식을 쓰세요"<br>`url` → "`--url` 을 쓰세요" |
+| `--id` 단독 (경로 4) | `idOpt` | postId | `postNumber` → "`<project> <number>` 형식을 쓰세요"<br>`url` → "`--url` 을 쓰세요"<br>`project` (비숫자) → 기존 pass-through 유지 (resolveByPostId → API 404 위임) |
 | positional 2개 (경로 6) | `postNumberArg` | postNumber | `postId` → **#82 안내** (아래 코드)<br>그 외 → "`<post-number>`가 올바르지 않습니다" |
 | `--url` / positional URL | URL 문자열 | url | parse 실패 → **지원 형식 목록** 제시 (아래) |
 
@@ -131,6 +131,10 @@ if (numType !== "postNumber") {
 - positional 2번째가 15+자리 numeric → `--id` 안내 에러 (`rejects.toThrow(/--id/)`)
 - `--id` 에 업무 번호(짧은 numeric) → `<project> <number>` 안내 에러
 - 기존 정상 케이스 회귀: `<project> 337`, `--id <19자리>`, `--url /task/to/{id}` 통과
+- **기존 테스트 교체 (회귀 방지, critic 노트)**: 현재 `--id 999` 정상 케이스 (line 57-64) 는
+  3자리라 신규 guard 에서 `postNumber` 로 분류돼 깨진다.
+  → `--id` 정상 케이스의 입력값과 standalone mock `id` 를 **19자리 postId** 로 함께 교체한다.
+  (line 50-54 의 `--url .../task/to/999` 는 URL 경로라 classifier 무관 — 유지)
 
 `dooray-url.test.ts`:
 - `/project/tasks/{id}` → postId 반환

--- a/tasks/041-feat-post-input-type-classifier/phase-02.md
+++ b/tasks/041-feat-post-input-type-classifier/phase-02.md
@@ -1,69 +1,34 @@
-# Phase 02 — docs: ADR-020 보강 + CLAUDE.md + code-architecture.md + README + SKILL
+# Phase 02 — docs: README + SKILL 라우팅 안내 (사용자 가이드)
 
 ## 컨텍스트
 
-phase-01 코드(타입 판별기 + URL 확장 + 진입점 검증)의 docs 반영.
+phase-01 코드 (타입 판별기 + URL 확장 + 진입점 검증) 의 **사용자 가이드 docs** 반영.
 
-**왜 docs 가 planning 이 아닌 phase 에 있는가**: 사용자가 "계획만 이 세션, 구현은 다른 세션 단일 실행" 으로 요청.
-ADR-020 보강 문구는 본 phase 에 최종형으로 박아두어 구현 세션이 그대로 반영한다.
-README/SKILL 은 phase-01 의 실제 에러 문구·옵션에 의존하므로 코드 확정 후 작성.
+**planning 결정 docs 는 이미 반영됨**:
+ADR-020 보강 / CLAUDE.md / code-architecture.md 는 build-with-teams 3단계 (docs 최신화) 에서 team-lead 가 먼저 커밋했다 (commit 75ae661).
+본 phase 는 사용자 가이드 docs (README / SKILL) 만 다룬다.
+README/SKILL 은 phase-01 의 실제 에러 문구·옵션에 의존하므로 코드 확정 후 작성한다.
 
 ## 변경 파일 (정확)
 
 ```
-docs/adr.md                       (수정 — ADR-020 본문 끝에 보강 섹션)
-CLAUDE.md                         (수정 — "공통 — 명령 입력 통합" 섹션에 타입 판별 한 줄)
-docs/code-architecture.md         (수정 — resolvers/ + utils/dooray-url 줄에 한 줄)
-README.md                         (수정 — post get/comment 사용 예: --id 안내 + URL 형식들)
-skills/dooray-cli/SKILL.md        (수정 — 라우팅 안내 + 빠른 참조)
+README.md                       (수정 — post get/comment 사용 예: --id 안내 + URL 형식들)
+skills/dooray-cli/SKILL.md      (수정 — 라우팅 안내 + 빠른 참조)
 tasks/041-feat-post-input-type-classifier/index.json   (완료 마킹)
 ```
 
 ## 작업 항목 (5개 이하)
 
-### 1. ADR-020 보강 섹션 — `docs/adr.md`
-
-ADR-020 본문 끝(`후속 (wiki input 통합, CI 통합) 은 별도 task.` 줄 다음, `---` 앞)에 추가:
-
-```markdown
-**보강 (Issue #82/#83, 2026-06)**: 입력 처리를 '만능 추론' 에서 '명시적 타입 분류' 로 강화.
-`classifyPostInputToken` 이 토큰을 postId / postNumber / url / project 로 분류한다.
-진입점(`--id` / `--url` / positional)이 기대 타입과 불일치하면 타입별 안내 에러를 던진다.
-
-- positional 2번째가 postId(15+자리 numeric)면 "`--id` 를 쓰세요" 안내 (#82).
-- URL 형식에 `/project/tasks/{postId}` 추가 (#83 — `/task/{pid}/{id}` 는 기존 처리).
-
-길이 임계(15+자리)는 **안내 트리거로만** 쓰고 조회 분기로는 쓰지 않는다.
-따라서 본 ADR 의 'positional numeric → postId 자동 인식 기각' 은 유지된다.
-긴 numeric 을 postId 로 조용히 조회하지 않고 `--id` 명시 경로로 유도한다.
-ID 체계가 바뀌어 분류가 틀려도 `--id` 경로는 영향받지 않는다.
-```
-
-### 2. CLAUDE.md — "공통 — 명령 입력 통합" 섹션
-
-`resolvePostInput` 설명에 타입 판별 한 줄 추가 (기존 분기 헬퍼 설명 아래):
-
-```markdown
-  - 입력 토큰 타입 판별 (`classifyPostInputToken`): postId(15+자리) / postNumber / url / project
-    - 진입점이 기대 타입과 불일치 시 타입별 안내 에러 (예: positional 에 postId → `--id` 안내). ADR-020 보강
-```
-
-ADR 참조 표의 ADR-020 행은 이미 존재 → 변경 불요(보강이라 신규 행 없음).
-
-### 3. docs/code-architecture.md — resolver/url 한 줄
-
-- `resolvers/post-input.ts` 설명에 "입력 토큰 타입 판별 (`classifyPostInputToken`) + 진입점별 검증 (ADR-020 보강)" 추가
-- `utils/dooray-url.ts` 설명에 "지원 URL: `/task/to/{id}`, `/task/{pid}/{id}`, `/project/tasks/{id}`" 명시
-
-### 4. README.md — post 조회 사용 예
+### 1. README.md — post 조회 사용 예
 
 - `post get` / `post comment` 예시에 세 입력 방식 정리:
   - `<project> <업무번호>`
   - `--id <postId>` (internal ID — create 출력값을 그대로)
   - `--url <브라우저 URL>` (지원 형식 3종 표기)
 - "create 가 출력하는 긴 숫자는 internal postId → 조회 시 `--id` 로" 한 줄 주의.
+- 예시의 ID 는 placeholder (`<postId>`) 또는 dummy 패턴 사용 — 실제 19자리 금지.
 
-### 5. skills/dooray-cli/SKILL.md — AI 라우팅 안내 강화 (사용자 핵심 요청)
+### 2. skills/dooray-cli/SKILL.md — AI 라우팅 안내 강화 (사용자 핵심 요청)
 
 빠른 참조 표 / 자동화 시나리오에 **강하게** 명시:
 
@@ -74,14 +39,22 @@ ADR 참조 표의 ADR-020 행은 이미 존재 → 변경 불요(보강이라 �
 - positional `<project> <number>` 의 number 자리에 internal postId 를 넣으면 안 된다 (안내 에러로 거부됨).
 - 브라우저 URL 을 그대로 넘길 때 `--url` 지원 형식: `/task/to/{id}`, `/task/{pid}/{id}`, `/project/tasks/{id}`.
 
+### 3. index.json 완료 마킹
+
+- `status` 를 `"completed"` 로
+- `current_phase` 를 `2` 로
+- phase-01 / phase-02 의 `status` 를 각각 `"completed"` 로
+- `updated_at` 갱신
+
 ## 검증 기준
 
-- `docs/adr.md` 보강 섹션이 ADR-020 본문 안에 위치 (신규 ADR 번호 아님)
-- 가독성 self-check: phase 작성 형식 6패턴 + 한국어 표현 정책 grep 통과
+- 개인 식별 정보 grep 통과 — README/SKILL 예시에 placeholder 사용
   ```bash
-  for f in docs/adr.md CLAUDE.md docs/code-architecture.md; do
-    grep -nE "매트릭스|게이트|트리아지|베이스라인|스파이크" "$f"
-  done
+  # cwd: <repo root>
+  grep -rnE "tc-ocr|nhnent|nhn-comico|@(nhn|nhnent)\.com" README.md skills/ 2>/dev/null
+  # 0건이어야 함
+  grep -rnE "[0-9]{15,}" README.md skills/ 2>/dev/null | grep -vE "1234567890123456789|9876543210987654321|<postId>|<pageId>"
   # 0건이어야 함
   ```
-- 개인 식별 정보 grep (CLAUDE.md 검증 절차) 통과 — README/SKILL 예시에 placeholder 사용
+- 가독성 self-check: docs 작성 형식 6패턴 + 한국어 표현 정책 grep 통과
+- README / SKILL 의 `--url` 지원 형식이 phase-01 의 실제 3종과 일치


### PR DESCRIPTION
## 개요

GitHub Issue #82 + #83 통합. 두 이슈의 공통 근원은 `resolvePostInput` 의 '만능 추론' — 입력값 형태로 타입을 짐작하다 경계가 흐려지는 문제다.

- **#82**: `post create` 가 internal postId 만 출력해, `post get` 에 그 id 를 positional 로 넣으면 업무 번호로 처리되어 `USER_INVALID_ERROR`.
- **#83**: URL 파서가 `/task/to/{id}` 형태만 받고 브라우저가 만드는 `/project/tasks/{id}` 를 거부.

## 결정 (2026-06-08)

추론을 없애지 않고 **명시화**한다.

- `classifyPostInputToken` 순수 함수가 토큰을 네 타입 (postId / postNumber / url / project) 으로 분류
- 진입점마다 기대 타입과 불일치하면 타입별 안내 에러를 던진다
- #82: positional 2번째가 postId (15+자리) 면 `--id` 사용을 안내
- #83: `parseDoorayTaskUrl` 에 `/project/tasks/{id}` 추가
- 길이 임계는 **안내 트리거로만** 쓰고 조회 분기로는 쓰지 않아 ADR-020 의 'numeric 자동 인식' 기각과 일관

## 검증

- `pnpm tsc --noEmit`: 0건
- `pnpm test`: 24 files / 183 tests passed
- `pnpm run build`: success
- critic APPROVE / code-reviewer PASS / docs-verifier PASS

Closes #82
Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)
