### PR TITLE
fix(cache): use dirname for writeJson dir derivation (Windows)

### DIFF
--- a/src/cache/store.test.ts
+++ b/src/cache/store.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// writeJson 은 내부 함수라 public setter (setMe) 를 통해 검증한다.
+// 재현 대상: Windows 에서 캐시 디렉터리가 생성되지 않아 write 가 실패하던 문제 (#89).
+// 근본 원인은 dir 도출을 수동 "/" 파싱으로 해서 join() 이 만든 플랫폼 구분자와 어긋난 것.
+// 여기서는 중첩 캐시 디렉터리가 없을 때 setMe 가 dir 을 만들고 write 에 성공하는지 확인한다.
+describe("cache store writeJson 디렉터리 생성", () => {
+  let home: string;
+  const origHome = process.env.HOME;
+  const origProfile = process.env.USERPROFILE;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), "dooray-cache-test-"));
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+  });
+
+  afterEach(async () => {
+    process.env.HOME = origHome;
+    process.env.USERPROFILE = origProfile;
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("캐시 디렉터리가 없어도 setMe 가 중첩 dir 을 만들고 파일을 쓴다", async () => {
+    // homedir() 가 import 시점에 평가되므로 env 설정 후 동적 import.
+    const { setMe, getMe } = await import("./store.js");
+
+    await setMe({ id: "1", name: "홍길동" } as never);
+
+    const filePath = join(home, ".dooray", "cache", "me.json");
+    const s = await stat(filePath);
+    expect(s.isFile()).toBe(true);
+
+    const entry = await getMe();
+    expect(entry?.data).toMatchObject({ id: "1", name: "홍길동" });
+  });
+});

--- a/src/cache/store.test.ts
+++ b/src/cache/store.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtemp, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { CachedMe } from "./types.js";
 
 // writeJson 은 내부 함수라 public setter (setMe) 를 통해 검증한다.
 // 재현 대상: Windows 에서 캐시 디렉터리가 생성되지 않아 write 가 실패하던 문제 (#89).
@@ -28,7 +29,7 @@ describe("cache store writeJson 디렉터리 생성", () => {
     // homedir() 가 import 시점에 평가되므로 env 설정 후 동적 import.
     const { setMe, getMe } = await import("./store.js");
 
-    await setMe({ id: "1", name: "홍길동" } as never);
+    await setMe({ id: "1", name: "홍길동", orgId: "test-org" } satisfies CachedMe);
 
     const filePath = join(home, ".dooray", "cache", "me.json");
     const s = await stat(filePath);

--- a/src/cache/store.ts
+++ b/src/cache/store.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile, rm, mkdir, readdir } from "node:fs/promises";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import type {
   CacheEntry,
@@ -42,7 +42,7 @@ async function readJson<T>(path: string): Promise<T | null> {
 }
 
 async function writeJson(path: string, data: unknown): Promise<void> {
-  const dir = path.substring(0, path.lastIndexOf("/"));
+  const dir = dirname(path);
   await ensureDir(dir);
   await writeFile(path, JSON.stringify(data, null, 2) + "\n");
 }


### PR DESCRIPTION
## 개요

Windows 에서 `dooray setup` 시 캐시/설정 파일 write 가 실패하던 버그를 수정한다.

## 원인

`src/cache/store.ts` 의 `writeJson` 이 부모 디렉터리를 다음처럼 도출했다:

```ts
const dir = path.substring(0, path.lastIndexOf("/"));
```

캐시 경로는 `node:path` 의 `join()` 으로 생성되어 플랫폼 구분자를 쓴다.
Windows(`\`)에서는 `lastIndexOf("/")` 가 `-1` 을 반환 → `substring(0, -1)` 이
마지막 문자를 뗀 잘못된 경로를 만든다 → `ensureDir` 실패 → write 실패.

## 수정

- 수동 `/` 파싱을 `node:path` 의 `dirname()` 으로 교체 — 구분자가 `join()` 과 모든 플랫폼에서 일치.
- 회귀 테스트 추가: 캐시 디렉터리가 없는 임시 HOME 에서 `setMe` 가 중첩 dir 을 만들고 write 에 성공하는지 검증.

## 검증

- `pnpm run build` 성공
- 전체 테스트 188개 통과 (신규 1개 포함)
- `grep -rn "lastIndexOf" src/` 0건

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)
