### PR TITLE
chore(docs): readability reformat of docs/pitfalls/ (lossless)

### DIFF
--- a/docs/pitfalls/code-review/bare-await-never-return-ts2366.md
+++ b/docs/pitfalls/code-review/bare-await-never-return-ts2366.md
@@ -8,7 +8,8 @@ source: [code-review 2-1, PR #48, plan026]
 related: []
 ---
 
-**증상**: 헬퍼 `async function bail(...): Promise<never>` 를 catch 블록에서 `await bail(e)` 만 호출하고 끝냄 (`return` / `throw` 없음). bare `await Promise<never>` 는 런타임에는 throw 로 unwind 되지만 TypeScript control-flow 분석은 catch 블록을 never-returning 으로 못 잡고 `TS2366: Function lacks ending return statement and return type does not include 'undefined'` 발생.
+**증상**: 헬퍼 `async function bail(...): Promise<never>` 를 catch 블록에서 `await bail(e)` 만 호출하고 끝냄 (`return` / `throw` 없음).
+bare `await Promise<never>` 는 런타임에는 throw 로 unwind 되지만 TypeScript control-flow 분석은 catch 블록을 never-returning 으로 못 잡고 `TS2366: Function lacks ending return statement and return type does not include 'undefined'` 발생.
 
 **Good**: `return await bail(e)` 로 control flow 종결을 명시. async 시그니처를 유지하면서 호출자 패턴만 바꾸는 리팩토링에서 특히 주의.
 

--- a/docs/pitfalls/code-review/empty-result-to-stderr.md
+++ b/docs/pitfalls/code-review/empty-result-to-stderr.md
@@ -8,7 +8,9 @@ source: [CLI8, PR #40]
 related: []
 ---
 
-**증상**: 첨부 0 개 / 댓글 0 개 같은 **정상 빈 상태** 메시지를 `process.stderr.write` 로 보냄. CLAUDE.md 컨벤션은 `데이터=stdout / 에러·진행로그=stderr`. 빈 결과는 에러가 아니므로 stderr 위반 + 자동화 파이프 처리 어색함.
+**증상**: 첨부 0 개 / 댓글 0 개 같은 **정상 빈 상태** 메시지를 `process.stderr.write` 로 보냄.
+CLAUDE.md 컨벤션은 `데이터=stdout / 에러·진행로그=stderr`.
+빈 결과는 에러가 아니므로 stderr 위반 + 자동화 파이프 처리 어색함.
 **Good**: 빈 결과는 `--json` 시 `[]` / `{}` stdout, 일반 모드는 `'결과 없음'` 등 stdout 또는 무출력. `--quiet` 시 무출력.
 **검출**: `grep -rnE 'stderr\.write.*없음|stderr\.write.*empty' src/commands/`.
 **Why**: PR #40 review — `comment file list` 가 "첨부 없음" 을 stderr 출력 → 컨벤션 위반.

--- a/docs/pitfalls/code-review/exitcode-mapping-mismatch.md
+++ b/docs/pitfalls/code-review/exitcode-mapping-mismatch.md
@@ -8,9 +8,13 @@ source: [code-review 2-2, PR #63, plan029]
 related: [mock-reject-value-not-mirroring-production]
 ---
 
-**증상**: resolver / command 에서 `catch (err)` 후 `err instanceof DoorayCliError && err.exitCode === EXIT_PARAM_ERROR` 같은 분기로 "특정 에러만 변환 + 나머지 re-throw" 를 시도. 하지만 `toDoorayCliError` (src/api/client.ts) 는 HTTP 에러에 `EXIT_AUTH_ERROR` (401/403) 또는 `EXIT_API_ERROR` (그 외, 404 포함) 만 부여. `EXIT_PARAM_ERROR` (3) 는 CLI 자체 입력 검증 경로에서만 발생 — API 호출 경로의 catch 에서는 절대 매칭 안 됨. 결과: 분기 조건이 항상 false → "특정 에러 변환" 코드가 dead path 가 되고, 사용자는 의도된 친절 메시지 대신 raw 에러를 봄.
+**증상**: resolver / command 에서 `catch (err)` 후 `err instanceof DoorayCliError && err.exitCode === EXIT_PARAM_ERROR` 같은 분기로 "특정 에러만 변환 + 나머지 re-throw" 를 시도.
+하지만 `toDoorayCliError` (src/api/client.ts) 는 HTTP 에러에 `EXIT_AUTH_ERROR` (401/403) 또는 `EXIT_API_ERROR` (그 외, 404 포함) 만 부여.
+`EXIT_PARAM_ERROR` (3) 는 CLI 자체 입력 검증 경로에서만 발생 — API 호출 경로의 catch 에서는 절대 매칭 안 됨.
+결과: 분기 조건이 항상 false → "특정 에러 변환" 코드가 dead path 가 되고, 사용자는 의도된 친절 메시지 대신 raw 에러를 봄.
 
-**Good**: catch 안에서 HTTP 에러를 분류하려면 `EXIT_API_ERROR` (404 포함 4xx/5xx) 와 `EXIT_AUTH_ERROR` (401/403) 중에서 선택. status code 까지 구분하려면 `err.message` 의 `(404)` 패턴이나 별도 metadata 가 필요 — 단순 exitCode 비교로는 404 / 5xx / timeout 을 구별 못함을 인지하고 설계.
+**Good**: catch 안에서 HTTP 에러를 분류하려면 `EXIT_API_ERROR` (404 포함 4xx/5xx) 와 `EXIT_AUTH_ERROR` (401/403) 중에서 선택.
+status code 까지 구분하려면 `err.message` 의 `(404)` 패턴이나 별도 metadata 가 필요 — 단순 exitCode 비교로는 404 / 5xx / timeout 을 구별 못함을 인지하고 설계.
 
 ```ts
 // BAD — EXIT_PARAM_ERROR 는 API 경로에서 절대 발생 안 함 → 분기 항상 false
@@ -38,4 +42,7 @@ grep -rnE "exitCode\s*===\s*EXIT_PARAM_ERROR" src/resolvers/ src/commands/ src/a
 
 **Self-check**: catch 안에서 exitCode 분기를 쓰는 코드를 작성/리뷰할 때, `src/api/client.ts` 의 `toDoorayCliError` 가 그 에러 케이스에 어떤 exitCode 를 *실제로* 부여하는지 grep 으로 확인했는가? mock 으로 짠 테스트가 그 exitCode 를 mirror 하는가?
 
-**Why**: PR #63 (plan029) — `resolveMember` 의 catch 가 `EXIT_PARAM_ERROR` 검사. 테스트도 같은 값으로 reject 해서 7/7 PASS 였지만 실제 production path 의 `toDoorayCliError` 는 `EXIT_API_ERROR` 부여 → 분기 dead. code-reviewer 가 catch 케이스 ↔ toDoorayCliError 매핑 대조해서 잡음. 다른 resolver/command 에서 같은 패턴 추가 시 또 발생 가능.
+**Why**: PR #63 (plan029) — `resolveMember` 의 catch 가 `EXIT_PARAM_ERROR` 검사.
+테스트도 같은 값으로 reject 해서 7/7 PASS 였지만 실제 production path 의 `toDoorayCliError` 는 `EXIT_API_ERROR` 부여 → 분기 dead.
+code-reviewer 가 catch 케이스 ↔ toDoorayCliError 매핑 대조해서 잡음.
+다른 resolver/command 에서 같은 패턴 추가 시 또 발생 가능.

--- a/docs/pitfalls/code-review/io-and-throw-coupled-untestable.md
+++ b/docs/pitfalls/code-review/io-and-throw-coupled-untestable.md
@@ -8,7 +8,13 @@ source: [CLI12, PR #43]
 related: []
 ---
 
-**증상**: 한 helper 가 (1) stderr 출력, (2) readline 사용자 입력, (3) DoorayCliError throw 를 동시에 담당. vitest 에서 stdin/stdout mock 없이 단위 테스트 작성 불가 → 결국 테스트 누락.
+**증상**: 한 helper 가
+1. stderr 출력
+2. readline 사용자 입력
+3. DoorayCliError throw
+
+를 동시에 담당.
+vitest 에서 stdin/stdout mock 없이 단위 테스트 작성 불가 → 결국 테스트 누락.
 **Good**: 책임 분리 — `printWarning(...)` (stderr 만) / `confirmPrompt(): Promise<boolean>` (입력만) / `orchestrator(...)` (throw 결정). 순수 helper 만이라도 단위 테스트로 보호.
 **검출**: `async function ... Promise<void>` 안에 `process.stderr.write` + `readline.createInterface` + `throw` 셋이 동시에 있으면 분리 후보.
 **Why**: PR #43 review — `guardDroppedAttachments` 가 세 책임을 묶어 테스트 작성 안 됨. 분리 후 sanitize / extract / findDropped 단위 테스트로 회귀 보호.

--- a/docs/pitfalls/code-review/mock-reject-value-not-mirroring-production.md
+++ b/docs/pitfalls/code-review/mock-reject-value-not-mirroring-production.md
@@ -8,7 +8,9 @@ source: [code-review 2-3, PR #63, plan029]
 related: [exitcode-mapping-mismatch]
 ---
 
-**증상**: `vi.fn().mockRejectedValue(new DoorayCliError("...", EXIT_PARAM_ERROR))` 같이 mock 을 만들 때, 실제 production path 의 에러 객체 (`toDoorayCliError` 가 부여하는 exitCode / 메시지 prefix) 와 다른 값을 사용. 테스트는 통과 (mock 이 그 값을 reject 하니까) 하지만 실제 코드 경로는 다른 exitCode 를 받음 → 분기/메시지 변환 코드가 실제로는 동작 안 함. 테스트가 자기 자신만 검증하고 production 검증 못함.
+**증상**: `vi.fn().mockRejectedValue(new DoorayCliError("...", EXIT_PARAM_ERROR))` 같이 mock 을 만들 때, 실제 production path 의 에러 객체 (`toDoorayCliError` 가 부여하는 exitCode / 메시지 prefix) 와 다른 값을 사용.
+테스트는 통과 (mock 이 그 값을 reject 하니까) 하지만 실제 코드 경로는 다른 exitCode 를 받음 → 분기/메시지 변환 코드가 실제로는 동작 안 함.
+테스트가 자기 자신만 검증하고 production 검증 못함.
 
 **Good**: API client 함수의 throw path 가 `toDoorayCliError` 를 통과한다면 mock 도 같은 함수가 만들 객체를 흉내내야 함:
 - HTTP 4xx (404 포함) → `new DoorayCliError("API 호출 실패: <메시지>", EXIT_API_ERROR)`

--- a/docs/pitfalls/code-review/sequential-endpoint-partial-failure-missing.md
+++ b/docs/pitfalls/code-review/sequential-endpoint-partial-failure-missing.md
@@ -11,7 +11,11 @@ related: []
 **증상**: 본문 변경(`updatePost`) + 메타데이터 변경(`setPostParent` / `setPostWorkflow` / `deletePostFile` + `updatePost` 댓글 PUT 합성 등) 을 sequential 로 호출.
 atomic 보장 없으므로 첫 호출 성공 + 두 번째 실패 시 부분 상태 발생.
 catch 가 `toDoorayCliError` 로 throw 만 하면 사용자는 "전체 실패" 로 오해 → 본문 재실행으로 mention prepend 중복 등 부작용.
-**Good**: sequential 호출의 catch 안에서 (1) `stopSpinner(false, "...")`, (2) `process.stderr.write("⚠  본문은 수정되었으나 X 변경에 실패했습니다. 본문 재실행 금지 — ...")`, (3) re-throw.
+**Good**: sequential 호출의 catch 안에서
+1. `stopSpinner(false, "...")`
+2. `process.stderr.write("⚠  본문은 수정되었으나 X 변경에 실패했습니다. 본문 재실행 금지 — ...")`
+3. re-throw.
+
 phase 본문 작업 항목에 try/catch + stderr 안내 코드 스니펫 명시.
 **검출**: phase diff 에 `client.X` + `client.Y` 두 호출이 같은 비-Promise.all 블록에 있으면 의심. grep 패턴:
 ```bash

--- a/docs/pitfalls/code-review/spinner-missing-try-catch.md
+++ b/docs/pitfalls/code-review/spinner-missing-try-catch.md
@@ -24,9 +24,11 @@ try {
 ```
 
 **검출**: `grep -A 20 "startSpinner" src/commands/` 결과에서 `try\s*\{` 가 같은 블록 내 없으면 의심.
-**Why**: PR #46 — `comment/get.ts` 의 `startSpinner` 후 `resolvePostInput` / `getPostComment` 가 try 없이 호출 → 에러 경로 spinner 잔존. 1-1 과 다른 패턴 (1-1 은 호출 위치, 1-2 는 cleanup 누락).
+**Why**: PR #46 — `comment/get.ts` 의 `startSpinner` 후 `resolvePostInput` / `getPostComment` 가 try 없이 호출 → 에러 경로 spinner 잔존.
+1-1 과 다른 패턴 (1-1 은 호출 위치, 1-2 는 cleanup 누락).
 
-**기존 spinner 블록에 새 헬퍼 호출 추가 / 위치 이동 시 (재발 패턴)**: spinner 블록 내부에 새 헬퍼 (`readBodyInput`, `resolveTemplate`, `getProjectTemplateDetail` 등) 호출을 추가하거나 spinner 전에 있던 호출을 spinner 후로 이동하는 경우, 그 새 위치도 동일하게 try/catch 보호가 필요하다. spinner 전에 있을 때는 안전했던 호출 (예: `readBodyInput` 의 파일 부재 throw) 이 spinner 후 위치로 이동하면 leak 경로가 생긴다.
+**기존 spinner 블록에 새 헬퍼 호출 추가 / 위치 이동 시 (재발 패턴)**: spinner 블록 내부에 새 헬퍼 (`readBodyInput`, `resolveTemplate`, `getProjectTemplateDetail` 등) 호출을 추가하거나 spinner 전에 있던 호출을 spinner 후로 이동하는 경우, 그 새 위치도 동일하게 try/catch 보호가 필요하다.
+spinner 전에 있을 때는 안전했던 호출 (예: `readBodyInput` 의 파일 부재 throw) 이 spinner 후 위치로 이동하면 leak 경로가 생긴다.
 
 ```ts
 // PR #64 — readBodyInput 을 template body fallback 로직 위해 spinner 후로 이동.

--- a/docs/pitfalls/plan/bsd-sed-word-boundary.md
+++ b/docs/pitfalls/plan/bsd-sed-word-boundary.md
@@ -8,7 +8,8 @@ source: [1-9]
 related: []
 ---
 
-**증상**: rename plan 에 `sed -i '' 's|foo\b|bar|g'`. macOS BSD `sed` 는 `\b` 미지원 → 0 매치.
+**증상**: rename plan 에 `sed -i '' 's|foo\b|bar|g'`.
+macOS BSD `sed` 는 `\b` 미지원 → 0 매치.
 검증: `echo "x.contentReview.y" | sed 's|contentReview\b|X|g'` → 변경 없음.
 **왜**: 핵심 치환 누락, 빌드 / 타입 검증 실패하지만 phase 본문은 통과로 보일 수 있음.
 

--- a/docs/pitfalls/plan/inaccurate-file-scope.md
+++ b/docs/pitfalls/plan/inaccurate-file-scope.md
@@ -16,4 +16,5 @@ git diff <base>..<target> --name-only -- <scope-dir>/
 ```
 
 **Self-check**: 파일 목록을 plan 에 전부 나열했고, 각 파일 처리 원칙이 서술됐는가?
-디렉터리 단위 정리 task (docs 일괄 backfill / lint 전 적용 등) 는 `ls <dir>/*.md` 결과를 plan 본문에 직접 인용하여 큰 파일 누락 회피 (plan034 PR #69 — `docs/guide-mvp-with-ai-agent.md` 878줄 누락이 critic REVISE 사유).
+디렉터리 단위 정리 task (docs 일괄 backfill / lint 전 적용 등) 는 `ls <dir>/*.md` 결과를 plan 본문에 직접 인용하여 큰 파일 누락 회피.
+(plan034 PR #69 — `docs/guide-mvp-with-ai-agent.md` 878줄 누락이 critic REVISE 사유)

--- a/docs/pitfalls/plan/inconsistent-resolver-validation-policy.md
+++ b/docs/pitfalls/plan/inconsistent-resolver-validation-policy.md
@@ -23,5 +23,6 @@ grep -nE "selectOne|mandatory|MandatoryGroups|SelectOneGroups" src/resolvers/tag
 # 신규 helper 가 위 정책 중 어느 것을 포함하는지 plan 본문에 명시
 ```
 
-**Why**: PR #68 (plan033) code-reviewer MEDIUM — `validateMandatoryCoverage` 가 mandatory 만 검증, selectOne 누락. `resolveTags` 는 둘 다 검증이라 post create 와 post edit 의 정책 비대칭.
+**Why**: PR #68 (plan033) code-reviewer MEDIUM — `validateMandatoryCoverage` 가 mandatory 만 검증, selectOne 누락.
+  `resolveTags` 는 둘 다 검증이라 post create 와 post edit 의 정책 비대칭.
   다른 helper 분리 시 (예: `validateUsersCoverage`, `validateWorkflowChange` 등) 동일 패턴 재발 가능.

--- a/docs/pitfalls/plan/missing-final-phase-completion-marking.md
+++ b/docs/pitfalls/plan/missing-final-phase-completion-marking.md
@@ -9,7 +9,8 @@ related: []
 ---
 
 **증상**: 마지막 phase 본문에 "index.json status + 모든 phase status 를 `completed` 로 + 단일 commit 포함" 지시 없음.
-**왜**: executor 는 scope 가드로 자체 추가 안 함 (올바른 행동) → team-lead 가 PR 직전 amend / 별도 commit. main 직접 수정 유혹 발생.
+**왜**: executor 는 scope 가드로 자체 추가 안 함 (올바른 행동) → team-lead 가 PR 직전 amend / 별도 commit.
+main 직접 수정 유혹 발생.
 
 ```bash
 sed -i '' 's/"status": "pending"/"status": "completed"/g' tasks/{plan}/index.json
@@ -19,7 +20,9 @@ grep -lE "index\.json.*completed" tasks/{plan}/phase-*.md   # 마지막 phase �
 
 **Self-check**: 마지막 phase 에 마킹 지시 + 단일 commit 포함 명시?
 
-**`current_phase` 도 함께 갱신** (PR #62 review 추가): 위 sed 는 `status` 3건만 치환. `index.json` 의 `current_phase` 필드는 그대로 남아 "완료지만 phase 1 진행 중" 모순 발생. 마지막 phase 본문에 다음 1줄 sed 도 명시:
+**`current_phase` 도 함께 갱신** (PR #62 review 추가): 위 sed 는 `status` 3건만 치환.
+`index.json` 의 `current_phase` 필드는 그대로 남아 "완료지만 phase 1 진행 중" 모순 발생.
+마지막 phase 본문에 다음 1줄 sed 도 명시:
 
 ```bash
 sed -i '' 's/"current_phase": 1/"current_phase": 2/' tasks/{plan}/index.json

--- a/docs/pitfalls/plan/missing-four-surface-guard.md
+++ b/docs/pitfalls/plan/missing-four-surface-guard.md
@@ -9,7 +9,11 @@ related: []
 ---
 
 **증상**: 캐시 스키마에 신규 필드 추가 + 일부 read 경로에만 가드 + writer 누락.
-**왜**: 같은 불변식이 다른 표면에서 깨짐 (cache writer 드랍 / resolver 통과 / formatter 미반영 / config schema 미반영 등).
+**왜**: 같은 불변식이 다른 표면에서 깨짐.
+- cache writer 드랍
+- resolver 통과
+- formatter 미반영
+- config schema 미반영 등
 
 **4면 검사 체크리스트** (load-bearing 불변식인 경우 필수):
 1. **Schema / Type**: `src/api/types.ts` / `src/cache/types.ts` 에 정의

--- a/docs/pitfalls/plan/missing-tsc-noemit-check.md
+++ b/docs/pitfalls/plan/missing-tsc-noemit-check.md
@@ -8,8 +8,11 @@ source: [1-10]
 related: [unverified-function-signature]
 ---
 
-**증상**: phase 성공 기준이 `pnpm build && pnpm test` 만 명시. 신규 type 정의/import/시그니처 변경을 포함한 phase 가 빌드/테스트 통과해도 tsc 검증을 우회 → 머지 후 다음 PR 에서 회귀 발견.
-**왜**: tsup (esbuild) 과 vitest 모두 type-check 를 스킵. dooray-cli CI 도 historically `pnpm build && pnpm test` 만 돌림. type 회귀가 생산 build 에서는 안 보이고 type 전용 step (`tsc --noEmit`) 에서만 보인다.
+**증상**: phase 성공 기준이 `pnpm build && pnpm test` 만 명시.
+신규 type 정의/import/시그니처 변경을 포함한 phase 가 빌드/테스트 통과해도 tsc 검증을 우회 → 머지 후 다음 PR 에서 회귀 발견.
+**왜**: tsup (esbuild) 과 vitest 모두 type-check 를 스킵.
+dooray-cli CI 도 historically `pnpm build && pnpm test` 만 돌림.
+type 회귀가 생산 build 에서는 안 보이고 type 전용 step (`tsc --noEmit`) 에서만 보인다.
 
 **Good** (type 변경을 포함한 phase 의 성공 기준):
 ```bash
@@ -18,4 +21,13 @@ pnpm tsc --noEmit 2>&1 | grep -E "^src/" | wc -l
 # 기대: <baseline 수치>  (변경 전 기준선 또는 0)
 ```
 
-**검출 (plan 작성 시 grep)**: phase 본문에 `interface ` / `export type ` / `import type` / `: Promise<` / `: never` / 새 시그니처 추가 / catch 블록 패턴 변경 같은 키워드가 등장하는데 성공 기준에 `tsc --noEmit` 0건. → 누락.
+**검출 (plan 작성 시 grep)**: phase 본문에 같은 키워드가 등장하는데 성공 기준에 `tsc --noEmit` 0건.
+- `interface `
+- `export type `
+- `import type`
+- `: Promise<`
+- `: never`
+- 새 시그니처 추가
+- catch 블록 패턴 변경
+
+→ 누락.

--- a/docs/pitfalls/team/code-reviewer-missing-plan-context.md
+++ b/docs/pitfalls/team/code-reviewer-missing-plan-context.md
@@ -11,4 +11,9 @@ related: []
 **증상**: code-reviewer 가 plan 컨텍스트 모르면 정상 helper 사용을 권장하다 설계 의도와 충돌 (false positive LOW 양산).
 **왜**: team-lead 가 일일이 판정해야 함.
 
-team-lead 의 검사 시작 메시지에 plan 의 비자명 결정 (helper 우회 사유 / 의도된 raw pattern / 의도된 placeholder 등) 1-2 줄 첨부.
+team-lead 의 검사 시작 메시지에 plan 의 비자명 결정
+- helper 우회 사유
+- 의도된 raw pattern
+- 의도된 placeholder 등
+
+1-2 줄 첨부.

--- a/docs/pitfalls/team/cwd-dual-git-status-check.md
+++ b/docs/pitfalls/team/cwd-dual-git-status-check.md
@@ -8,8 +8,10 @@ source: [2-9]
 related: [executor-cwd-isolation]
 ---
 
-**증상**: team-lead 가 task 재작성 / commit 시 cwd 가 main repo 인지 worktree 인지 헷갈림. 동일 상대경로가 다른 파일 가리킴.
-**왜**: main repo 의 task 파일 의도치 않게 수정 / 삭제. system-reminder 알림이 어느 working tree 인지 명확히 표기 안 됨.
+**증상**: team-lead 가 task 재작성 / commit 시 cwd 가 main repo 인지 worktree 인지 헷갈림.
+동일 상대경로가 다른 파일 가리킴.
+**왜**: main repo 의 task 파일 의도치 않게 수정 / 삭제.
+system-reminder 알림이 어느 working tree 인지 명확히 표기 안 됨.
 
 commit 전 `pwd` + 양쪽 동시 점검:
 ```bash

--- a/docs/pitfalls/team/executor-scope-expansion.md
+++ b/docs/pitfalls/team/executor-scope-expansion.md
@@ -8,7 +8,8 @@ source: [2-5]
 related: []
 ---
 
-**증상**: phase 도중 task 범위 외 (pre-existing 에러 / 발견한 bug / ADR 위반 자체 변경) 를 자체 추가. 또는 `@ts-ignore` / `@ts-expect-error` 자체 추가.
+**증상**: phase 도중 task 범위 외 (pre-existing 에러 / 발견한 bug / ADR 위반 자체 변경) 를 자체 추가.
+또는 `@ts-ignore` / `@ts-expect-error` 자체 추가.
 **왜**: critic 게이트 우회 → 사후 평가 사이클 추가 + task 본문 / 성공 기준 어긋남.
 
 executor 프롬프트에:

--- a/tasks/044-chore-pitfalls-readability/index.json
+++ b/tasks/044-chore-pitfalls-readability/index.json
@@ -1,0 +1,34 @@
+{
+  "name": "044-chore-pitfalls-readability",
+  "description": "docs/pitfalls/ 66 패턴 파일 + INDEX.md 가 원본 monolith 에서 계승한 가독성 위반(200자+ 긴 줄, 인라인 slash 나열, bullet 다중 속성 압축)에 CLAUDE.md 'docs/ADR 작성 형식' 6패턴을 적용한다. 결정(2026-07-13): 순수 재포맷 pass — 단어·의미·코드블록·frontmatter·grep 명령은 절대 불변, 줄바꿈·bullet 구조만 조정. task 043(분리)의 무손실 원칙을 재포맷 버전으로 이어감. 기계적으로 모든 120자 줄을 쪼개지 않고, 가독성이 실제 개선되는 곳(run-on 문장, 인라인 나열→list, 압축 bullet→sub-bullet)에만 적용. 완료 후 독립 docs-verifier 로 의미 보존 검증.",
+  "created_at": "2026-07-13T00:00:00Z",
+  "status": "pending",
+  "current_phase": 1,
+  "total_phases": 3,
+  "error_message": null,
+  "blocked_reason": null,
+  "phases": [
+    {
+      "number": 1,
+      "title": "plan/ (19) + INDEX.md 가독성 재포맷",
+      "file": "phase-01.md",
+      "status": "pending",
+      "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+    },
+    {
+      "number": 2,
+      "title": "team/ (11) 가독성 재포맷",
+      "file": "phase-02.md",
+      "status": "pending",
+      "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+    },
+    {
+      "number": 3,
+      "title": "code-review/ (38) 가독성 재포맷 + 전체 최종 검증",
+      "file": "phase-03.md",
+      "status": "pending",
+      "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+    }
+  ],
+  "updated_at": "2026-07-13T00:00:00Z"
+}

--- a/tasks/044-chore-pitfalls-readability/index.json
+++ b/tasks/044-chore-pitfalls-readability/index.json
@@ -3,7 +3,7 @@
   "description": "docs/pitfalls/ 66 패턴 파일 + INDEX.md 가 원본 monolith 에서 계승한 가독성 위반(200자+ 긴 줄, 인라인 slash 나열, bullet 다중 속성 압축)에 CLAUDE.md 'docs/ADR 작성 형식' 6패턴을 적용한다. 결정(2026-07-13): 순수 재포맷 pass — 단어·의미·코드블록·frontmatter·grep 명령은 절대 불변, 줄바꿈·bullet 구조만 조정. task 043(분리)의 무손실 원칙을 재포맷 버전으로 이어감. 기계적으로 모든 120자 줄을 쪼개지 않고, 가독성이 실제 개선되는 곳(run-on 문장, 인라인 나열→list, 압축 bullet→sub-bullet)에만 적용. 완료 후 독립 docs-verifier 로 의미 보존 검증.",
   "created_at": "2026-07-13T00:00:00Z",
   "status": "in_progress",
-  "current_phase": 2,
+  "current_phase": 3,
   "total_phases": 3,
   "error_message": null,
   "blocked_reason": null,
@@ -19,7 +19,7 @@
       "number": 2,
       "title": "team/ (11) 가독성 재포맷",
       "file": "phase-02.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {

--- a/tasks/044-chore-pitfalls-readability/index.json
+++ b/tasks/044-chore-pitfalls-readability/index.json
@@ -2,7 +2,7 @@
   "name": "044-chore-pitfalls-readability",
   "description": "docs/pitfalls/ 66 패턴 파일 + INDEX.md 가 원본 monolith 에서 계승한 가독성 위반(200자+ 긴 줄, 인라인 slash 나열, bullet 다중 속성 압축)에 CLAUDE.md 'docs/ADR 작성 형식' 6패턴을 적용한다. 결정(2026-07-13): 순수 재포맷 pass — 단어·의미·코드블록·frontmatter·grep 명령은 절대 불변, 줄바꿈·bullet 구조만 조정. task 043(분리)의 무손실 원칙을 재포맷 버전으로 이어감. 기계적으로 모든 120자 줄을 쪼개지 않고, 가독성이 실제 개선되는 곳(run-on 문장, 인라인 나열→list, 압축 bullet→sub-bullet)에만 적용. 완료 후 독립 docs-verifier 로 의미 보존 검증.",
   "created_at": "2026-07-13T00:00:00Z",
-  "status": "in_progress",
+  "status": "completed",
   "current_phase": 3,
   "total_phases": 3,
   "error_message": null,
@@ -26,7 +26,7 @@
       "number": 3,
       "title": "code-review/ (38) 가독성 재포맷 + 전체 최종 검증",
       "file": "phase-03.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],

--- a/tasks/044-chore-pitfalls-readability/index.json
+++ b/tasks/044-chore-pitfalls-readability/index.json
@@ -2,8 +2,8 @@
   "name": "044-chore-pitfalls-readability",
   "description": "docs/pitfalls/ 66 패턴 파일 + INDEX.md 가 원본 monolith 에서 계승한 가독성 위반(200자+ 긴 줄, 인라인 slash 나열, bullet 다중 속성 압축)에 CLAUDE.md 'docs/ADR 작성 형식' 6패턴을 적용한다. 결정(2026-07-13): 순수 재포맷 pass — 단어·의미·코드블록·frontmatter·grep 명령은 절대 불변, 줄바꿈·bullet 구조만 조정. task 043(분리)의 무손실 원칙을 재포맷 버전으로 이어감. 기계적으로 모든 120자 줄을 쪼개지 않고, 가독성이 실제 개선되는 곳(run-on 문장, 인라인 나열→list, 압축 bullet→sub-bullet)에만 적용. 완료 후 독립 docs-verifier 로 의미 보존 검증.",
   "created_at": "2026-07-13T00:00:00Z",
-  "status": "pending",
-  "current_phase": 1,
+  "status": "in_progress",
+  "current_phase": 2,
   "total_phases": 3,
   "error_message": null,
   "blocked_reason": null,
@@ -12,7 +12,7 @@
       "number": 1,
       "title": "plan/ (19) + INDEX.md 가독성 재포맷",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {

--- a/tasks/044-chore-pitfalls-readability/phase-01.md
+++ b/tasks/044-chore-pitfalls-readability/phase-01.md
@@ -1,0 +1,61 @@
+# Phase 01 — plan/ (19) + INDEX.md 가독성 재포맷 (규칙 앵커)
+
+## 컨텍스트
+
+`docs/pitfalls/` 파일들이 원본 monolith 에서 계승한 가독성 위반을 정리한다.
+**순수 재포맷** — 무엇을 말하는지(단어·의미)는 100% 보존, 어떻게 줄바꿈·나열하는지(형식)만 조정.
+
+**작업 위치**: worktree `/Users/nhn/personal/dooray-cli/.claude/worktrees/pitfalls-readability`.
+모든 경로 이 루트 기준. git 은 `git -C <worktree> ...`. branch `chore/pitfalls-readability`.
+
+본 phase 가 **규칙 단일 소스**다. phase 2·3 이 그대로 따른다.
+
+## 적용 대상 (CLAUDE.md "docs / ADR 작성 형식" 6패턴)
+
+1. **semantic line break** — 한 단락의 여러 문장을 문장당 한 줄로 분리.
+2. **enumerated inline 금지** — `A / B / C` (3개+), `①②③`, `1) 2) 3)` → markdown bullet list.
+3. **괄호 중첩 2겹 금지** — `(... (...) ...)` → 단락/불릿 분리로 평탄화.
+4. **`=` / `→` 동치·인과 압축은 한 문장 1회** — 여러 관계 압축 시 문장 분리.
+5. **긴 문장 의미 단위 분할** — 약 80자 초과 + 백틱/괄호 다수면 의미 단위로.
+6. **한 bullet 다중 속성 압축 금지** — 한 bullet 에 마침표·콤마·`+`·슬래시로 2개+ 독립 속성이 이어지면 sub-bullet 으로 분리.
+
+## 불가침 (절대 건드리지 않음)
+
+- **코드 블록**(``` … ```) 내부 — grep/bash/yaml 명령·예시. 한 글자도 변경 금지.
+- **frontmatter**(`--- … ---`) — id/category/title/triggers/tool_catchable/source/related.
+- 인라인 코드(`` `…` ``), URL, 숫자, 파일명, 식별자.
+- **단어 자체** — 요약·재작성·동의어 교체·단어 추가/삭제 전부 금지. 오직 줄바꿈·bullet 구조만.
+
+## 기계적 금지 (과잉 방지)
+
+- 120자 넘는다고 **무조건** 쪼개지 않는다. 하나의 응집된 문장이면 그대로 둔다 (억지 분할이 오히려 나쁨).
+- 원본에 이미 잘 읽히는 곳은 손대지 않는다 (외과적 — 실제 위반만).
+
+## 작업 항목 (5개 이하)
+
+1. `docs/pitfalls/plan/*.md` (19) 각 파일의 **prose 본문**에 6패턴 적용. 코드블록·frontmatter 불가침.
+2. `docs/pitfalls/INDEX.md` 동일 적용.
+3. 각 파일 편집 후 **단어 토큰 무손실 체크**(아래) 통과 — 실패 시 그 파일 되돌려 재작업.
+4. `git -C <wt>` 로 phase 1 commit (`chore(pitfalls): readability reformat plan/ + INDEX`, 끝에 `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`).
+5. index.json phase 1 completed, current_phase 2.
+
+## 검증 — 단어 토큰 무손실 (필수, 파일마다)
+
+재포맷은 줄바꿈·bullet 마커(`-`)·콤마만 바뀌고 **단어 토큰 집합은 불변**이어야 한다.
+편집 전 원본은 `git -C <wt> show HEAD:<path>` (이 phase 시작 시점 = 미편집).
+
+```bash
+# 단어 토큰 수: 한글/영문/숫자 시퀀스만 카운트 (마커·공백·구두점 무시)
+words_head() { git -C "$WT" show "HEAD:$1" | grep -oE "[가-힣A-Za-z0-9]+" | wc -l | tr -d ' '; }
+words_cur()  { grep -oE "[가-힣A-Za-z0-9]+" "$WT/$1" | wc -l | tr -d ' '; }
+# 모든 편집 파일에 대해 두 값이 같아야 함
+for f in docs/pitfalls/plan/*.md docs/pitfalls/INDEX.md; do
+  h=$(words_head "$f"); c=$(words_cur "$f")
+  [ "$h" = "$c" ] || echo "WORD MISMATCH $f: head=$h cur=$c"
+done
+# 출력 0줄이어야 통과. MISMATCH 면 그 파일 단어 누락/추가 → 재작업
+```
+
+추가 확인:
+- 코드블록 불변: `git -C "$WT" diff -- docs/pitfalls/plan docs/pitfalls/INDEX.md` 에서 ``` 안 라인이 변경되지 않았는지 육안 확인.
+- frontmatter 7키 그대로.

--- a/tasks/044-chore-pitfalls-readability/phase-02.md
+++ b/tasks/044-chore-pitfalls-readability/phase-02.md
@@ -1,0 +1,27 @@
+# Phase 02 — team/ (11) 가독성 재포맷
+
+## 컨텍스트
+
+`docs/pitfalls/team/*.md` (10 패턴 + 00-checklist = 11) 에 가독성 6패턴 적용.
+**규칙·불가침·무손실 체크는 phase-01.md 를 그대로 따른다** (단일 소스).
+
+worktree·branch 동일. 순수 재포맷 — 단어·의미·코드블록·frontmatter 불변.
+
+## 작업 항목 (5개 이하)
+
+1. `docs/pitfalls/team/*.md` (11) prose 본문에 6패턴 적용. 실제 위반만(외과적), 억지 분할 금지.
+2. 파일마다 단어 토큰 무손실 체크(phase-01 스크립트, 대상 경로만 `docs/pitfalls/team/*.md`) 통과.
+3. 코드블록·frontmatter 불변 육안 확인.
+4. phase 2 commit (`chore(pitfalls): readability reformat team/`).
+5. index.json phase 2 completed, current_phase 3.
+
+## 검증
+
+```bash
+for f in docs/pitfalls/team/*.md; do
+  h=$(git -C "$WT" show "HEAD:$f" | grep -oE "[가-힣A-Za-z0-9]+" | wc -l | tr -d ' ')
+  c=$(grep -oE "[가-힣A-Za-z0-9]+" "$WT/$f" | wc -l | tr -d ' ')
+  [ "$h" = "$c" ] || echo "WORD MISMATCH $f: head=$h cur=$c"
+done
+# 0줄 = 통과
+```

--- a/tasks/044-chore-pitfalls-readability/phase-03.md
+++ b/tasks/044-chore-pitfalls-readability/phase-03.md
@@ -1,0 +1,39 @@
+# Phase 03 — code-review/ (38) 가독성 재포맷 + 전체 최종 검증
+
+## 컨텍스트
+
+`docs/pitfalls/code-review/*.md` (38, 위반 최다 ~131 긴 줄) 에 가독성 6패턴 적용.
+**규칙·불가침·무손실 체크는 phase-01.md 준수.** 순수 재포맷.
+
+이 dir 은 grep/bash 코드블록이 많다 — **코드블록 불가침이 특히 중요**. 긴 줄 상당수가 코드블록 안(명령)이며 이는 손대지 않는다.
+
+worktree·branch 동일.
+
+## 작업 항목 (5개 이하)
+
+1. `docs/pitfalls/code-review/*.md` (38) prose 본문에 6패턴 적용. 코드블록 안 긴 줄은 제외(불변).
+2. 파일마다 단어 토큰 무손실 체크 통과 (38 전부).
+3. phase 3 commit (`chore(pitfalls): readability reformat code-review/`).
+4. **전체 최종 검증**(아래) 통과.
+5. index.json phase 3 completed + status "completed".
+
+## 검증 (code-review + 전체)
+
+```bash
+# 1) code-review 단어 무손실
+for f in docs/pitfalls/code-review/*.md; do
+  h=$(git -C "$WT" show "HEAD:$f" | grep -oE "[가-힣A-Za-z0-9]+" | wc -l | tr -d ' ')
+  c=$(grep -oE "[가-힣A-Za-z0-9]+" "$WT/$f" | wc -l | tr -d ' ')
+  [ "$h" = "$c" ] || echo "WORD MISMATCH $f: head=$h cur=$c"
+done
+# 0줄 = 통과
+
+# 2) 전체 트리 파일 수 불변 (69 = 66 패턴 + 2 checklist + INDEX)
+ls docs/pitfalls/*/*.md docs/pitfalls/INDEX.md | wc -l   # 기대 69
+
+# 3) frontmatter 훼손 없음 — 모든 패턴 파일 첫 줄 ---
+for f in docs/pitfalls/*/*.md; do head -1 "$f" | grep -q "^---$" || echo "frontmatter 깨짐: $f"; done
+```
+
+- 파일 추가/삭제 0 (재포맷만). 3개 phase 통틀어 신규/삭제 파일 없어야 함.
+- 코드 변경 0 — docs 전용.


### PR DESCRIPTION
## 개요

`docs/pitfalls/` 파일들이 원본 monolith 에서 계승한 가독성 위반에 CLAUDE.md "docs/ADR 작성 형식" 6패턴을 적용한다.

## 성격 — 순수 재포맷

- 단어·의미·코드블록·frontmatter 는 100% 불변. 줄바꿈·bullet 구조만 조정.
- 적용 패턴: semantic line break, 인라인 나열 → bullet/numbered list, 압축 bullet → sub-bullet, 긴 문장 의미 분할.
- 기계적 금지 — 120자 넘는다고 무조건 쪼개지 않고 실제 개선되는 곳만(외과적). 코드블록 안 긴 줄(grep 명령)은 불변.

## 변경 범위

- 16파일 편집 (plan 6 + team 3 + code-review 7).
- 전체 69파일 수 불변, 신규/삭제 0.

## 검증

- **단어 토큰 무손실** — 편집 전후 각 파일의 한글/영문/숫자 토큰 수 완전 일치 (독립 재확인, MISMATCH 0). 재포맷이 단어를 하나도 더하거나 빼지 않았음을 기계적으로 보증.
- frontmatter 7키 온전, 코드블록 라인 diff 0.
- 코드 변경 0 — docs 전용.

## 참고

단어 100% 보존 제약 때문에 일부 전환 문구가 다소 딱딱하게 남은 곳이 있으나(문장 매끄럽게 하려면 단어 추가가 필요해 의도적으로 지양) 의미는 그대로다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
