### PR TITLE
chore(docs): genericize internal identifiers in PII pitfall

### DIFF
--- a/docs/pitfalls/code-review/src-test-fixture-internal-identifier.md
+++ b/docs/pitfalls/code-review/src-test-fixture-internal-identifier.md
@@ -8,7 +8,7 @@ source: [code-review 8-1, PR #84, plan041]
 related: []
 ---
 
-**증상**: 테스트 fixture / 에러 메시지 예시에 실제 사내 프로젝트 코드 (`tc-ocr`), 사내 도메인 (`*.nhnent.dooray.com`), 실제일 수 있는 19자리 ID 사용.
+**증상**: 테스트 fixture / 에러 메시지 예시에 실제 사내 프로젝트 코드, 사내 도메인 (`*.<tenant>.dooray.com`), 실제일 수 있는 19자리 ID 사용.
 code-reviewer 가 "PII 정책은 README/docs 대상, src 는 범위 밖" 으로 PASS 하기 쉬움 — 하지만 public OSS 라 src 도 노출 대상이다.
 
 **Good**: 테스트/예시 식별자는 placeholder 또는 CLAUDE.md 승인 dummy 사용.
@@ -16,11 +16,13 @@ code-reviewer 가 "PII 정책은 README/docs 대상, src 는 범위 밖" 으로 
 - 도메인 → `x.dooray.com` / `example.dooray.com`
 - 19자리 ID → `1234567890123456789` / `9876543210987654321`
 
-**검출**:
+**검출** (구체 사내값을 나열하지 않고 공개 화이트리스트 밖을 잡는다):
 ```bash
-grep -rnE "tc-ocr|nhnent|nhn-comico" src/        # config 기본값 등 기능 코드는 사람이 판단
+# 공개 도메인 화이트리스트 밖의 URL/이메일 도메인 (사내 도메인 가능성)
+grep -rnoE "(https?://|@)[A-Za-z0-9.-]+\.(com|co\.kr|net)" src/ \
+  | grep -vE "dooray\.com|github\.com|npmjs\.com|example\.com"
 grep -rnE "[0-9]{15,}" src/ | grep -vE "1234567890123456789|9876543210987654321"
-# 결과가 실제 사내 값이면 placeholder/dummy 로 교체
+# 결과가 실제 사내 값이면 placeholder/dummy 로 교체. 프로젝트 코드네임은 사람이 판단.
 ```
 
 **Self-check**: 새 테스트/에러 메시지에 식별자를 넣을 때 실제 사내 값 대신 placeholder/dummy 를 썼는가? src 도 PII 대상임을 인지했는가?


### PR DESCRIPTION
## 개요

`docs/pitfalls/code-review/src-test-fixture-internal-identifier.md` 는 "사내 식별자를 public repo 에 노출하지 마라" 는 패턴인데, 정작 실제 사내 프로젝트 코드네임과 사내 Dooray tenant 도메인을 예시로 나열하고 있었다 (자기 위반).

CLAUDE.md PII 정책 — "구체 식별자는 나열하지 않고 유형만 기술, 검증은 공개 화이트리스트 밖 검출" — 과도 어긋난다.

## 수정 (2줄)

- 증상: 구체 코드네임·도메인 제거 → 유형 서술 + `*.<tenant>.dooray.com` placeholder.
- 검출 grep: 구체 식별자 나열 → 공개 도메인 화이트리스트 밖 검출 방식(다른 문서와 동일 패턴)으로 교체.

## 검증

- repo 전체 사내 식별자 grep 0건.
- 노출은 이 파일 2줄에만 있었고 다른 곳엔 없음.
- 히스토리 잔존분은 내부 코드네임 수준이라 history rewrite 는 하지 않음 — 현재 파일 정리로 충분.

🤖 Generated with [Claude Code](https://claude.com/claude-code)