### PR TITLE
feat(commands): add wiki page delete command

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,11 @@ dooray wiki page create <project> --title "..." [--parent <page-id>] [--body "..
 dooray wiki page edit <project> <page-id> --title "새 제목"                   # 제목만 (비대화형)
 dooray wiki page edit <project> <page-id> --body "..." | --body-file <path>  # 본문만 (비대화형)
 dooray wiki page edit <project> <page-id>                                     # $EDITOR (플래그 없을 때)
+dooray wiki page delete <project> <page-id>                                   # 삭제 (y/N 확인)
+dooray wiki page delete <project> <page-id> --yes                            # 확인 없이 삭제 (자동화용)
 ```
+
+하위 페이지가 있는 페이지를 삭제하면 하위 페이지는 상위 페이지로 재부착된다 (사라지지 않음).
 
 #### 위키 페이지 첨부파일
 

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -87,6 +87,7 @@ dooray doctor                                 # 설정 검증
 | 위키 페이지 수정 (제목) | `dooray wiki page edit <project> <page-id> --title "..."` |
 | 위키 페이지 수정 (본문) | `dooray wiki page edit <project> <page-id> --body "..."` 또는 `--body-file ./new.md` |
 | 위키 페이지 수정 (에디터) | `dooray wiki page edit <project> <page-id>` (플래그 없으면 $EDITOR 열림) |
+| 위키 페이지 삭제 | `dooray wiki page delete <project> <page-id>` (y/N 확인 기본, `--yes`로 자동화 시 생략. 하위 페이지는 상위 페이지로 재부착) |
 | 위키 페이지 첨부 목록 | `dooray wiki page file list <project> <page-id>` (general + inline 합산, type 컬럼) |
 | 위키 페이지 첨부 업로드 | `dooray wiki page file upload <project> <page-id> --file <path> [--type inline_image]` (multipart `type` 필드를 `file` 앞에 전송) |
 | 위키 페이지 첨부 다운로드 | `dooray wiki page file download <project> <page-id> --file-id <id> -o <dir>` |
@@ -133,10 +134,11 @@ CLI로 처리 **불가능한** 작업. 아래 항목을 요청받으면 웹 UI �
 
 | 작업 | 대체 경로 | 근거 |
 |---|---|---|
-| 위키 페이지 **삭제** | 웹 UI (`https://{tenant}.dooray.com/wiki/...`) | Dooray REST API 미제공 (댓글·첨부파일 삭제는 있지만 페이지 삭제 endpoint 없음) |
+| 위키 페이지 이동 (상위 페이지 변경) | 웹 UI (`https://{tenant}.dooray.com/wiki/...`) | Dooray REST API 미지원 |
 | 프로젝트 삭제 | 웹 UI (admin 페이지) | API 미지원 |
 
-위키 페이지를 잘못 만든 경우(테스트/중복) **soft delete(빈 제목·본문) 우회 금지** — 페이지가 트리에 남아 사용자 혼란 유발.
+위키 페이지를 잘못 만든 경우(테스트/중복)는 `dooray wiki page delete <project> <page-id>` 로 정리한다.
+공식 문서화된 endpoint 가 아니라 서버 정책이 바뀌면 동작이 달라질 수 있음에 유의한다.
 
 ---
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -560,6 +560,17 @@ export class DoorayApiClient {
     }
   }
 
+  // 비공식(미문서화) endpoint — Dooray 공식 API 문서에 없으나 실측 확인 (ADR-032)
+  async deleteWikiPage(wikiId: string, pageId: string): Promise<DoorayApiUnitResponse> {
+    try {
+      return await this.api
+        .delete(`wiki/v1/wikis/${wikiId}/pages/${pageId}`)
+        .json<DoorayApiUnitResponse>();
+    } catch (e) {
+      throw await toDoorayCliError(e);
+    }
+  }
+
   // ─── Post Files ─────────────────────────────────────
 
   async getPostFiles(projectId: string, postId: string): Promise<PostFileListResponse> {

--- a/src/commands/post/file/delete.ts
+++ b/src/commands/post/file/delete.ts
@@ -71,5 +71,5 @@ export const fileDeleteCommand = new Command("delete")
     stopSpinner(true, "삭제 완료");
 
     // ADR-031: --json / --quiet / plain 3 모드 분기
-    emitDeleteResult(globalOpts, { fileId });
+    emitDeleteResult(globalOpts, { id: fileId });
   });

--- a/src/commands/wiki/page-delete.ts
+++ b/src/commands/wiki/page-delete.ts
@@ -43,7 +43,10 @@ export const wikiPageDeleteCommand = new Command("delete")
         default: false,
       });
       if (!ok) {
-        process.stdout.write("취소되었습니다.\n");
+        // 취소는 삭제 미수행 — 머신 모드(--json/--quiet)에는 성공 출력을 내지 않는다 (파싱 오염 방지).
+        if (!globalOpts.json && !globalOpts.quiet) {
+          process.stdout.write("취소되었습니다.\n");
+        }
         return;
       }
     }

--- a/src/commands/wiki/page-delete.ts
+++ b/src/commands/wiki/page-delete.ts
@@ -1,0 +1,65 @@
+import { Command } from "commander";
+import { getConfigOrThrow } from "../../config/store.js";
+import { DoorayApiClient } from "../../api/client.js";
+import { resolveWikiPageInput } from "../../resolvers/wiki-page-input.js";
+import { startSpinner, stopSpinner } from "../../utils/spinner.js";
+import { DoorayCliError } from "../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../utils/exit-codes.js";
+import type { OutputOptions } from "../../formatters/table.js";
+import { emitDeleteResult } from "../../formatters/file-output.js";
+
+export const wikiPageDeleteCommand = new Command("delete")
+  .description("위키 페이지 삭제 (비공식 endpoint)")
+  .argument("[arg1]", "프로젝트 코드, Dooray Wiki URL, 또는 (`--id`/`--url` 모드일 때) 미사용")
+  .argument("[arg2]", "page-id (positional 2개 모드)")
+  .option("--id <pageId>", "위키 페이지 ID")
+  .option("--url <url>", "Dooray Wiki URL")
+  .option("--project <code>", "프로젝트 코드 (--id 모드에서 wikiId 해석용)")
+  .option("-y, --yes", "확인 없이 삭제 (자동화용)")
+  .action(async (arg1, arg2, opts) => {
+    const globalOpts = wikiPageDeleteCommand.optsWithGlobals() as OutputOptions;
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+
+    // resolveWikiPageInput 을 confirm/spinner 보다 먼저 호출 (validation-before-spinner)
+    const { wikiId, pageId } = await resolveWikiPageInput(client, {
+      projectArg: arg1,
+      pageIdArg: arg2,
+      idOpt: opts.id,
+      urlOpt: opts.url,
+      project: opts.project,
+    });
+
+    if (!opts.yes) {
+      if (!process.stdin.isTTY) {
+        throw new DoorayCliError(
+          "non-TTY 환경에서는 확인 없이 삭제할 수 없습니다. --yes(-y) 플래그로 다시 실행하세요.",
+          EXIT_PARAM_ERROR,
+        );
+      }
+      const { confirm } = await import("@inquirer/prompts");
+      const ok = await confirm({
+        message: `페이지(${pageId})를 삭제할까요? 하위 페이지가 있으면 상위 페이지로 재부착됩니다.`,
+        default: false,
+      });
+      if (!ok) {
+        process.stdout.write("취소되었습니다.\n");
+        return;
+      }
+    }
+
+    startSpinner("페이지 삭제 중...");
+    try {
+      await client.deleteWikiPage(wikiId, pageId);
+      stopSpinner(true, "삭제 완료");
+
+      emitDeleteResult(globalOpts, {
+        id: pageId,
+        jsonKey: "pageId",
+        message: `페이지(${pageId})가 삭제되었습니다.`,
+      });
+    } catch (e) {
+      stopSpinner(false);
+      throw e;
+    }
+  });

--- a/src/commands/wiki/page-file/delete.ts
+++ b/src/commands/wiki/page-file/delete.ts
@@ -76,7 +76,7 @@ export const wikiPageFileDeleteCommand = new Command("delete")
       stopSpinner(true, "삭제 완료");
 
       // ADR-031: --json / --quiet / plain 3 모드 분기
-      emitDeleteResult(globalOpts, { fileId });
+      emitDeleteResult(globalOpts, { id: fileId });
     } catch (e) {
       stopSpinner(false);
       throw e;

--- a/src/formatters/file-output.test.ts
+++ b/src/formatters/file-output.test.ts
@@ -139,4 +139,35 @@ describe("emitDeleteResult", () => {
     expect(writes.join("")).toContain("abc123");
     expect(writes.join("")).toContain("삭제");
   });
+
+  // wiki page delete 처럼 jsonKey/message 를 override 하는 호출부 (ADR-032)
+  const pageDeleteFixture: DeleteResult = {
+    id: "page1",
+    jsonKey: "pageId",
+    message: "페이지(page1)가 삭제되었습니다.",
+  };
+
+  it("--json 모드, jsonKey override — { pageId, status: 'deleted' } JSON 출력", () => {
+    const { writes, restore } = captureStdout();
+    emitDeleteResult({ json: true }, pageDeleteFixture);
+    restore();
+    const parsed = JSON.parse(writes.join(""));
+    expect(parsed.pageId).toBe("page1");
+    expect(parsed.fileId).toBeUndefined();
+    expect(parsed.status).toBe("deleted");
+  });
+
+  it("--quiet 모드, jsonKey override — id 값만 한 줄 출력 (필드명 무관)", () => {
+    const { writes, restore } = captureStdout();
+    emitDeleteResult({ quiet: true }, pageDeleteFixture);
+    restore();
+    expect(writes.join("").trim()).toBe("page1");
+  });
+
+  it("plain 모드, message override — 커스텀 메시지 그대로 출력", () => {
+    const { writes, restore } = captureStdout();
+    emitDeleteResult({}, pageDeleteFixture);
+    restore();
+    expect(writes.join("").trim()).toBe("페이지(page1)가 삭제되었습니다.");
+  });
 });

--- a/src/formatters/file-output.test.ts
+++ b/src/formatters/file-output.test.ts
@@ -111,7 +111,7 @@ describe("emitDownloadAllResult", () => {
 
 // --- emitDeleteResult ---
 
-const deleteFixture: DeleteResult = { fileId: "abc123" };
+const deleteFixture: DeleteResult = { id: "abc123" };
 
 describe("emitDeleteResult", () => {
   afterEach(() => vi.restoreAllMocks());

--- a/src/formatters/file-output.ts
+++ b/src/formatters/file-output.ts
@@ -24,7 +24,11 @@ export interface DownloadAllResult {
 }
 
 export interface DeleteResult {
-  fileId: string;
+  id: string;
+  // --json 출력의 id 필드명. 기본 "fileId" (기존 file 명령군 호환, ADR-031)
+  jsonKey?: string;
+  // plain 모드 전체 문장 override (예: "이/가" 조사 차이 대응). 기본 "파일(${id})이 삭제되었습니다."
+  message?: string;
 }
 
 // ADR-031 file 명령 출력 헬퍼
@@ -61,11 +65,13 @@ export function emitDeleteResult(
   globalOpts: OutputOptions,
   result: DeleteResult,
 ): void {
+  const jsonKey = result.jsonKey ?? "fileId";
+  const message = result.message ?? `파일(${result.id})이 삭제되었습니다.`;
   if (globalOpts.json) {
-    printJson({ fileId: result.fileId, status: "deleted" });
+    printJson({ [jsonKey]: result.id, status: "deleted" });
   } else if (globalOpts.quiet) {
-    process.stdout.write(`${result.fileId}\n`);
+    process.stdout.write(`${result.id}\n`);
   } else {
-    process.stdout.write(`파일(${result.fileId})이 삭제되었습니다.\n`);
+    process.stdout.write(`${message}\n`);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import { wikiPagesCommand } from "./commands/wiki/pages.js";
 import { wikiPageGetCommand } from "./commands/wiki/page-get.js";
 import { wikiPageCreateCommand } from "./commands/wiki/page-create.js";
 import { wikiPageEditCommand } from "./commands/wiki/page-edit.js";
+import { wikiPageDeleteCommand } from "./commands/wiki/page-delete.js";
 import { wikiPageFileCommand } from "./commands/wiki/page-file/index.js";
 import { wikiPageCommentCommand } from "./commands/wiki/page-comment/index.js";
 import { memberCommand } from "./commands/member/index.js";
@@ -118,6 +119,7 @@ const wikiPageCommand = new Command("page").description("위키 페이지 관련
 wikiPageCommand.addCommand(wikiPageGetCommand);
 wikiPageCommand.addCommand(wikiPageCreateCommand);
 wikiPageCommand.addCommand(wikiPageEditCommand);
+wikiPageCommand.addCommand(wikiPageDeleteCommand);
 wikiPageCommand.addCommand(wikiPageFileCommand);
 wikiPageCommand.addCommand(wikiPageCommentCommand);
 wikiCommand.addCommand(wikiPageCommand);

--- a/tasks/046-feat-wiki-page-delete/index.json
+++ b/tasks/046-feat-wiki-page-delete/index.json
@@ -2,8 +2,8 @@
   "name": "046-feat-wiki-page-delete",
   "description": "Issue #87 — dooray wiki page delete 명령 추가. 비공식(미문서화) DELETE /wiki/v1/wikis/{wikiId}/pages/{pageId} endpoint (실측 확인). 설계는 ADR-032 + CLAUDE.md 'wiki page delete' 섹션 단일 소스. 입력 resolveWikiPageInput 재사용, client deleteWikiPage plain .delete() (307 불요), 파괴적이라 confirm 기본 + --yes/-y 생략 + non-TTY abort, 하위 페이지는 조부모 재부착이라 사전 조회 없음, 출력 {pageId, status:deleted}/quiet pageId. 도움말·client 주석에 비공식 표기. planning 결정 docs(ADR-032/CLAUDE.md/code-architecture/flow)는 반영 완료 — phase 안에서 변경 금지. README/SKILL 만 마지막 phase 에서 갱신.",
   "created_at": "2026-07-13T00:00:00Z",
-  "status": "pending",
-  "current_phase": 1,
+  "status": "in_progress",
+  "current_phase": 2,
   "total_phases": 2,
   "error_message": null,
   "blocked_reason": null,
@@ -12,7 +12,7 @@
       "number": 1,
       "title": "client deleteWikiPage + page-delete.ts 명령 + 등록 + confirm/출력",
       "file": "phase-01.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     },
     {
@@ -23,5 +23,5 @@
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],
-  "updated_at": "2026-07-13T00:00:00Z"
+  "updated_at": "2026-07-13T01:00:00Z"
 }

--- a/tasks/046-feat-wiki-page-delete/index.json
+++ b/tasks/046-feat-wiki-page-delete/index.json
@@ -2,7 +2,7 @@
   "name": "046-feat-wiki-page-delete",
   "description": "Issue #87 — dooray wiki page delete 명령 추가. 비공식(미문서화) DELETE /wiki/v1/wikis/{wikiId}/pages/{pageId} endpoint (실측 확인). 설계는 ADR-032 + CLAUDE.md 'wiki page delete' 섹션 단일 소스. 입력 resolveWikiPageInput 재사용, client deleteWikiPage plain .delete() (307 불요), 파괴적이라 confirm 기본 + --yes/-y 생략 + non-TTY abort, 하위 페이지는 조부모 재부착이라 사전 조회 없음, 출력 {pageId, status:deleted}/quiet pageId. 도움말·client 주석에 비공식 표기. planning 결정 docs(ADR-032/CLAUDE.md/code-architecture/flow)는 반영 완료 — phase 안에서 변경 금지. README/SKILL 만 마지막 phase 에서 갱신.",
   "created_at": "2026-07-13T00:00:00Z",
-  "status": "in_progress",
+  "status": "completed",
   "current_phase": 2,
   "total_phases": 2,
   "error_message": null,
@@ -19,9 +19,9 @@
       "number": 2,
       "title": "단위 테스트 + README/SKILL 갱신 + 완료 마킹",
       "file": "phase-02.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
     }
   ],
-  "updated_at": "2026-07-13T01:00:00Z"
+  "updated_at": "2026-07-13T02:00:00Z"
 }


### PR DESCRIPTION
## 개요

`dooray wiki page delete` 명령을 추가한다 (Issue #87). Dooray 공식 API 에 없는 **비공식(미문서화) DELETE endpoint** 를 실측 확인해 감싼다.

## 동작

- endpoint: `DELETE /wiki/v1/wikis/{wikiId}/pages/{pageId}` (plain `.delete()`, 파일 API 의 307 처리 불요).
- 입력: `resolveWikiPageInput` 재사용 — `<project> <page-id>` / `--id`+`--project` / `--url` / positional Dooray URL.
- 파괴적 → confirm 기본. non-TTY 는 abort, `--yes`(`-y`) 로 생략.
- 출력: `--json {pageId, status:"deleted"}` / `--quiet pageId` / 기본 prose. confirm 거부 시 머신 모드는 출력 없음.
- 도움말·client 주석에 비공식 endpoint 표기.

## 하위 페이지

삭제 시 하위 페이지가 상위(조부모)로 재부착됨을 실측 확인 — orphan 없음. 사전 조회·차단을 두지 않는다.

## 설계 근거

`docs/adr/032-wiki-page-delete.md` (비공식 endpoint, 재부착 관찰, 휴지통 여부 미확인, 페이지 이동 API 불가 참고).

## 리팩토링

`emitDeleteResult` 를 `{fileId}` 고정에서 `{id, jsonKey?, message?}` 로 일반화 — 기존 file delete 2 호출부 출력은 기본값으로 byte-identical 보존 (테스트로 검증).

## 검증

- `pnpm build` OK, `pnpm tsc --noEmit` 0, 전체 테스트 193개 통과 (신규 3).
- 독립 code-reviewer 리뷰: spec 준수 PASS, CRITICAL/HIGH 0. 지적된 confirm-취소 출력 모드 건 반영.
- 파괴적 API 실호출은 하지 않음 (build/tsc/help 로 검증) — 실삭제는 사용자가 테스트 페이지로 확인 권장.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)
