### PR TITLE
feat(commands): add messenger send/channel-send

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,28 @@ dooray mail send --to "a@b.com" --subject "HTML 메일" --body "<h1>Hello</h1>" 
 dooray mail reply <uid> --body "답장 내용"
 ```
 
+### 메신저
+
+Dooray 메신저로 1:1 다이렉트 메시지 또는 대화방 메시지를 보낼 수 있습니다.
+전송은 API 토큰 소유자 명의로 나갑니다.
+
+```bash
+# 1:1 다이렉트 메시지 (받는 사람은 organizationMemberId 또는 이메일)
+dooray messenger send --to "user@example.com" --body "배포 완료했습니다."
+dooray messenger send --to <memberId> --body-file ./message.md
+
+# 대화방 메시지 (channelId 또는 대화방 이름)
+dooray messenger channel-send --channel "배포 알림방" --body "빌드 성공"
+dooray messenger channel-send --channel <channelId> --body-file -   # stdin
+
+# --body 없이 실행하면 $EDITOR 로 본문을 작성
+dooray messenger send --to "user@example.com"
+```
+
+- `--to`는 이름 검색을 지원하지 않습니다. organizationMemberId 또는 이메일만 입력하세요.
+- `--channel`은 채널 ID 또는 자신이 속한 대화방 이름(부분일치)으로 지정할 수 있습니다.
+  이름이 겹치는 대화방이 여러 개면 후보 목록이 함께 출력됩니다.
+
 ### 첨부파일
 
 업무에 파일을 첨부하거나, 첨부된 파일을 다운로드할 수 있습니다.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -45,6 +45,7 @@ CLI는 터미널이 있는 환경이면 어디서든 동작하고, 자연스러�
 - `dooray wiki page comment` — 페이지 댓글 목록·최신·조회·추가·수정·삭제 (post comment 패턴 mirror, mention/cc/file 부재 — WikiComment 시그니처 차이)
 - `dooray mail` — 목록·조회·검색·발송·답장 (v0.2.0)
 - `dooray feedback` — `gh` CLI 위임으로 GitHub 이슈 자동 생성 (`--last` 옵션으로 직전 명령 sanitized argv + 에러 자동 첨부, ADR-022/023)
+- `dooray messenger` — 1:1 다이렉트 메시지 (`send`) / 대화방 메시지 (`channel-send`) 전송 (`--to` id·email, `--channel` id·이름, ADR-033)
 
 ### 제외 (v1)
 

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -105,6 +105,8 @@ dooray doctor                                 # 설정 검증
 | 메일 상세 | `dooray mail get <uid>` |
 | 메일 발송 | `dooray mail send --to "..." --subject "..." --body "..."` |
 | 메일 답장 | `dooray mail reply <uid> --body "..."` |
+| 메신저 1:1 다이렉트 메시지 | `dooray messenger send --to "<id\|email>" --body "..."` (`--to`는 id/이메일만, 이름 미지원) |
+| 메신저 대화방 메시지 | `dooray messenger channel-send --channel "<channelId\|이름>" --body "..."` (이름은 자신이 속한 방만 검색) |
 | 첨부파일 목록 | `dooray post file list <project> <number>` |
 | 첨부파일 다운로드 | `dooray post file download <project> <number> <file-id>` |
 | 전체 첨부파일 다운로드 | `dooray post file download-all <project> <number>` |
@@ -202,6 +204,22 @@ COMMENT_ID=$(dooray post comment add <project> <post-num> --body "스크린샷 �
 
 # 2. 그 댓글에 파일을 첨부 (post-level 업로드 + 댓글 본문 markdown 자동 추가)
 dooray post comment file upload <project> <post-num> "$COMMENT_ID" ./screenshot.png
+```
+
+### 시나리오 — 배포 알림 메신저 자동 전송
+
+CI/배포 스크립트가 완료 알림을 담당자 DM 또는 팀 대화방에 자동으로 보낼 때 사용.
+전송은 API 토큰 소유자 명의로 나가며, 본문은 plain text 만 지원한다.
+
+```bash
+# 담당자 DM (id 또는 이메일만 가능 — 이름 검색 미지원)
+dooray messenger send --to "user@example.com" --body "배포가 완료되었습니다 (v1.2.3)."
+
+# 팀 대화방 (channelId 또는 자신이 속한 대화방 이름)
+dooray messenger channel-send --channel "배포 알림방" --body-file ./release-note.md
+
+# --json 으로 log-id 확인 (자동화 파이프라인에서 후속 처리 시)
+dooray messenger send --to <memberId> --body "..." --json
 ```
 
 ### 위키 페이지 조회

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -52,6 +52,10 @@ import type {
   UploadFileResponse,
   TemplateListResponse,
   TemplateDetailResponse,
+  DirectSendRequest,
+  ChannelLogRequest,
+  MessengerSendResponse,
+  MessengerChannelListResponse,
 } from "./types.js";
 
 export interface GetPostsParams {
@@ -915,6 +919,45 @@ export class DoorayApiClient {
           searchParams: { interpolation: String(interpolation) },
         })
         .json<TemplateDetailResponse>();
+    } catch (e) {
+      throw await toDoorayCliError(e);
+    }
+  }
+
+  // ─── Messenger (ADR-033) ────────────────────────────
+
+  async sendDirectMessage(
+    organizationMemberId: string,
+    text: string,
+  ): Promise<MessengerSendResponse> {
+    try {
+      return await this.api
+        .post("messenger/v1/channels/direct-send", {
+          json: { text, organizationMemberId } satisfies DirectSendRequest,
+        })
+        .json<MessengerSendResponse>();
+    } catch (e) {
+      throw await toDoorayCliError(e);
+    }
+  }
+
+  async sendChannelMessage(channelId: string, text: string): Promise<MessengerSendResponse> {
+    try {
+      return await this.api
+        .post(`messenger/v1/channels/${channelId}/logs`, {
+          json: { text } satisfies ChannelLogRequest,
+        })
+        .json<MessengerSendResponse>();
+    } catch (e) {
+      throw await toDoorayCliError(e);
+    }
+  }
+
+  async getMessengerChannels(): Promise<MessengerChannelListResponse> {
+    try {
+      return await this.api
+        .get("messenger/v1/channels")
+        .json<MessengerChannelListResponse>();
     } catch (e) {
       throw await toDoorayCliError(e);
     }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -597,4 +597,32 @@ export interface TemplateDetail extends TemplateMeta {
 }
 
 export type TemplateListResponse = DoorayApiResponse<TemplateMeta[]> & { totalCount: number };
+
+// ─── Messenger (ADR-033) ─────────────────────────────────
+
+export interface DirectSendRequest {
+  text: string;
+  organizationMemberId: string;
+}
+
+export interface ChannelLogRequest {
+  text: string;
+}
+
+// direct-send 응답은 { id } 만, channel logs 응답은 { id, channelId } — 하나의 타입으로 흡수
+export interface MessengerSendResult {
+  id: string;
+  channelId?: string;
+}
+
+export type MessengerSendResponse = DoorayApiResponse<MessengerSendResult>;
+
+// 채널 목록 매칭에 필요한 필드만 (title 매칭용). direct/me 방은 title 빈값.
+export interface MessengerChannel {
+  id: string;
+  title: string;
+  type: string;
+}
+
+export type MessengerChannelListResponse = DoorayApiResponse<MessengerChannel[]>;
 export type TemplateDetailResponse = DoorayApiResponse<TemplateDetail>;

--- a/src/commands/messenger/channel-send.ts
+++ b/src/commands/messenger/channel-send.ts
@@ -29,10 +29,9 @@ export const messengerChannelSendCommand = new Command("channel-send")
     let bodyContent = await readBodyInputOrNull(opts);
     if (bodyContent == null) {
       bodyContent = await openInEditor("");
-      if (!bodyContent.trim()) {
-        process.stdout.write("빈 메시지는 전송할 수 없습니다.\n");
-        return;
-      }
+    }
+    if (!bodyContent.trim()) {
+      throw new DoorayCliError("빈 메시지는 전송할 수 없습니다.", EXIT_PARAM_ERROR);
     }
 
     startSpinner("메시지 전송 중...");

--- a/src/commands/messenger/channel-send.ts
+++ b/src/commands/messenger/channel-send.ts
@@ -1,0 +1,53 @@
+import { Command } from "commander";
+import { getConfigOrThrow } from "../../config/store.js";
+import { DoorayApiClient } from "../../api/client.js";
+import { resolveMessengerChannel } from "../../resolvers/messenger-channel.js";
+import { openInEditor } from "../../editor/index.js";
+import { readBodyInputOrNull } from "../../utils/body-input.js";
+import type { OutputOptions } from "../../formatters/table.js";
+import { printJson, printQuiet } from "../../formatters/table.js";
+import { startSpinner, stopSpinner } from "../../utils/spinner.js";
+import { DoorayCliError } from "../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../utils/exit-codes.js";
+
+export const messengerChannelSendCommand = new Command("channel-send")
+  .description("메신저 대화방 메시지 전송 (--body 없으면 $EDITOR)")
+  .option("--channel <channelId|이름>", "대화방 channelId 또는 이름 (부분일치)")
+  .option("--body <text>", "메시지 본문 (- 입력 시 stdin에서 읽기)")
+  .option("--body-file <path>", "본문 파일 경로 (- 입력 시 stdin에서 읽기)")
+  .action(async (opts) => {
+    if (!opts.channel) {
+      throw new DoorayCliError("--channel 옵션은 필수입니다.", EXIT_PARAM_ERROR);
+    }
+
+    const globalOpts = messengerChannelSendCommand.optsWithGlobals() as OutputOptions;
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+
+    const channelId = await resolveMessengerChannel(client, opts.channel);
+
+    let bodyContent = await readBodyInputOrNull(opts);
+    if (bodyContent == null) {
+      bodyContent = await openInEditor("");
+      if (!bodyContent.trim()) {
+        process.stdout.write("빈 메시지는 전송할 수 없습니다.\n");
+        return;
+      }
+    }
+
+    startSpinner("메시지 전송 중...");
+    try {
+      const res = await client.sendChannelMessage(channelId, bodyContent);
+      stopSpinner(true, `메시지를 전송했습니다 (log-id: ${res.result.id})`);
+      if (globalOpts.json) {
+        printJson(res.result);
+      } else if (globalOpts.quiet) {
+        printQuiet([res.result.id]);
+      } else {
+        process.stdout.write(`메시지를 전송했습니다 (log-id: ${res.result.id})\n`);
+      }
+    } catch (e) {
+      stopSpinner(false);
+      throw e;
+    }
+  });

--- a/src/commands/messenger/index.ts
+++ b/src/commands/messenger/index.ts
@@ -1,0 +1,9 @@
+import { Command } from "commander";
+import { messengerSendCommand } from "./send.js";
+import { messengerChannelSendCommand } from "./channel-send.js";
+
+export const messengerCommand = new Command("messenger")
+  .description("메신저 관련 명령");
+
+messengerCommand.addCommand(messengerSendCommand);
+messengerCommand.addCommand(messengerChannelSendCommand);

--- a/src/commands/messenger/send.ts
+++ b/src/commands/messenger/send.ts
@@ -35,10 +35,9 @@ export const messengerSendCommand = new Command("send")
     let bodyContent = await readBodyInputOrNull(opts);
     if (bodyContent == null) {
       bodyContent = await openInEditor("");
-      if (!bodyContent.trim()) {
-        process.stdout.write("빈 메시지는 전송할 수 없습니다.\n");
-        return;
-      }
+    }
+    if (!bodyContent.trim()) {
+      throw new DoorayCliError("빈 메시지는 전송할 수 없습니다.", EXIT_PARAM_ERROR);
     }
 
     startSpinner("메시지 전송 중...");

--- a/src/commands/messenger/send.ts
+++ b/src/commands/messenger/send.ts
@@ -1,0 +1,59 @@
+import { Command } from "commander";
+import { getConfigOrThrow } from "../../config/store.js";
+import { DoorayApiClient } from "../../api/client.js";
+import { resolveMemberByIdOrEmail } from "../../resolvers/member.js";
+import { openInEditor } from "../../editor/index.js";
+import { readBodyInputOrNull } from "../../utils/body-input.js";
+import type { OutputOptions } from "../../formatters/table.js";
+import { printJson, printQuiet } from "../../formatters/table.js";
+import { startSpinner, stopSpinner } from "../../utils/spinner.js";
+import { DoorayCliError } from "../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../utils/exit-codes.js";
+
+export const messengerSendCommand = new Command("send")
+  .description("메신저 1:1 다이렉트 메시지 전송 (--body 없으면 $EDITOR)")
+  .option("--to <id|email>", "받는 사람 (organizationMemberId 또는 이메일 — 이름 미지원)")
+  .option("--body <text>", "메시지 본문 (- 입력 시 stdin에서 읽기)")
+  .option("--body-file <path>", "본문 파일 경로 (- 입력 시 stdin에서 읽기)")
+  .action(async (opts) => {
+    if (!opts.to) {
+      throw new DoorayCliError("--to 옵션은 필수입니다.", EXIT_PARAM_ERROR);
+    }
+
+    const globalOpts = messengerSendCommand.optsWithGlobals() as OutputOptions;
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+
+    const memberId = await resolveMemberByIdOrEmail(client, opts.to);
+    if (memberId == null) {
+      throw new DoorayCliError(
+        `--to 는 organizationMemberId 또는 이메일만 지원합니다 (이름 미지원): "${opts.to}"`,
+        EXIT_PARAM_ERROR,
+      );
+    }
+
+    let bodyContent = await readBodyInputOrNull(opts);
+    if (bodyContent == null) {
+      bodyContent = await openInEditor("");
+      if (!bodyContent.trim()) {
+        process.stdout.write("빈 메시지는 전송할 수 없습니다.\n");
+        return;
+      }
+    }
+
+    startSpinner("메시지 전송 중...");
+    try {
+      const res = await client.sendDirectMessage(memberId, bodyContent);
+      stopSpinner(true, `메시지를 전송했습니다 (log-id: ${res.result.id})`);
+      if (globalOpts.json) {
+        printJson(res.result);
+      } else if (globalOpts.quiet) {
+        printQuiet([res.result.id]);
+      } else {
+        process.stdout.write(`메시지를 전송했습니다 (log-id: ${res.result.id})\n`);
+      }
+    } catch (e) {
+      stopSpinner(false);
+      throw e;
+    }
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import { mailListCommand } from "./commands/mail/list.js";
 import { mailGetCommand } from "./commands/mail/get.js";
 import { mailSendCommand } from "./commands/mail/send.js";
 import { mailReplyCommand } from "./commands/mail/reply.js";
+import { messengerCommand } from "./commands/messenger/index.js";
 import { feedbackCommand } from "./commands/feedback.js";
 import { DoorayCliError } from "./utils/errors.js";
 import { sanitizeArgv } from "./utils/argv-sanitize.js";
@@ -140,6 +141,7 @@ program.addCommand(projectCommand);
 program.addCommand(postCommand);
 program.addCommand(wikiCommand);
 program.addCommand(mailCommand);
+program.addCommand(messengerCommand);
 program.addCommand(feedbackCommand);
 
 program.parseAsync().catch(async (err) => {

--- a/src/resolvers/member.test.ts
+++ b/src/resolvers/member.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { resolveMember } from "./member.js";
+import { resolveMember, resolveMemberByIdOrEmail } from "./member.js";
 import type { DoorayApiClient } from "../api/client.js";
 import { DoorayCliError } from "../utils/errors.js";
 import { EXIT_API_ERROR } from "../utils/exit-codes.js";
@@ -108,5 +108,32 @@ describe("resolveMember 입력 자동 분기", () => {
     await expect(
       resolveMember(client, "proj", "홍길동"),
     ).resolves.toBeDefined();
+  });
+});
+
+describe("resolveMemberByIdOrEmail (messenger --to 공유 헬퍼, ADR-033)", () => {
+  it("15자리 이상 숫자 → getMemberDetail 호출 후 input 반환", async () => {
+    const id = "1234567890123456789";
+    const client = mockClient({
+      getMemberDetail: vi.fn().mockResolvedValue({ result: { id, name: "X" } }),
+    });
+    expect(await resolveMemberByIdOrEmail(client, id)).toBe(id);
+  });
+
+  it("이메일 형식 → searchMembers 1건 시 id 반환", async () => {
+    const client = mockClient({
+      searchMembers: vi.fn().mockResolvedValue({
+        result: [{ id: "9876543210987654321", name: "X" }],
+        totalCount: 1,
+      }),
+    });
+    expect(
+      await resolveMemberByIdOrEmail(client, "user@example.com"),
+    ).toBe("9876543210987654321");
+  });
+
+  it("id/email 어느 쪽에도 매칭 안 되는 입력(이름) → null 반환 (matchByName 호출 없음)", async () => {
+    const client = mockClient({});
+    expect(await resolveMemberByIdOrEmail(client, "홍길동")).toBeNull();
   });
 });

--- a/src/resolvers/member.ts
+++ b/src/resolvers/member.ts
@@ -103,11 +103,17 @@ export async function buildMemberNameMap(
   return map;
 }
 
-export async function resolveMember(
+/**
+ * id(15+자리 numeric) / 이메일 입력을 organizationMemberId 로 해석.
+ * 어느 쪽에도 매칭 안 되면 null 반환 (=이름 입력 — 호출자가 matchByName 등으로 폴백).
+ * id/email 로 매칭됐으나 404·모호이면 여기서 throw (null 반환 아님).
+ *
+ * messenger `--to` (project 스코프 없어 matchByName 불가) 와 `resolveMember` 가 공유 (ADR-033).
+ */
+export async function resolveMemberByIdOrEmail(
   client: DoorayApiClient,
-  projectId: string,
   input: string,
-): Promise<string> {
+): Promise<string | null> {
   // 1. 15자리 이상 숫자 → organizationMemberId 직접 (getMemberDetail 로 존재 검증)
   if (MEMBER_ID_RE.test(input)) {
     try {
@@ -149,6 +155,17 @@ export async function resolveMember(
     }
     return hits[0]!.id;
   }
+
+  return null;
+}
+
+export async function resolveMember(
+  client: DoorayApiClient,
+  projectId: string,
+  input: string,
+): Promise<string> {
+  const byIdOrEmail = await resolveMemberByIdOrEmail(client, input);
+  if (byIdOrEmail !== null) return byIdOrEmail;
 
   // 3. 그 외 → 기존 matchByName
   const members = await ensureMembers(client, projectId);

--- a/src/resolvers/messenger-channel.test.ts
+++ b/src/resolvers/messenger-channel.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { resolveMessengerChannel } from "./messenger-channel.js";
+import type { DoorayApiClient } from "../api/client.js";
+import { DoorayCliError } from "../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../utils/exit-codes.js";
+import { vi } from "vitest";
+
+function mockClient(channels: { id: string; title: string; type: string }[]): DoorayApiClient {
+  return {
+    getMessengerChannels: vi.fn().mockResolvedValue({ result: channels }),
+  } as unknown as DoorayApiClient;
+}
+
+const fixture = [
+  { id: "1111222233334444555", title: "공지방", type: "private" },
+  { id: "2222333344445555666", title: "개발팀", type: "private" },
+  { id: "3333444455556666777", title: "개발팀 백업", type: "private" },
+  { id: "4444555566667777888", title: "", type: "direct" },
+];
+
+describe("resolveMessengerChannel (ADR-033)", () => {
+  it("15자리 이상 숫자 → getMessengerChannels 호출 없이 그대로 channelId 반환", async () => {
+    const client = mockClient(fixture);
+    const result = await resolveMessengerChannel(client, "9999999999999999999");
+    expect(result).toBe("9999999999999999999");
+    expect(client.getMessengerChannels).not.toHaveBeenCalled();
+  });
+
+  it("title 정확일치", async () => {
+    const client = mockClient(fixture);
+    const result = await resolveMessengerChannel(client, "공지방");
+    expect(result).toBe("1111222233334444555");
+  });
+
+  it("title 부분일치 (단일 후보)", async () => {
+    const client = mockClient([fixture[0]!, fixture[1]!]);
+    const result = await resolveMessengerChannel(client, "개발");
+    expect(result).toBe("2222333344445555666");
+  });
+
+  it("title 부분일치 모호 → 복수 후보 에러 + EXIT_PARAM_ERROR", async () => {
+    const client = mockClient(fixture);
+    await expect(resolveMessengerChannel(client, "개발")).rejects.toSatisfy(
+      (err: unknown) =>
+        err instanceof DoorayCliError &&
+        err.exitCode === EXIT_PARAM_ERROR &&
+        /개발팀.*개발팀 백업/s.test(err.message),
+    );
+  });
+
+  it("title 빈값(direct 방)만 있으면 매칭 후보 0건 → not-found (direct 방 id 노출 안 됨)", async () => {
+    const directOnly = [fixture[3]!]; // title: ""
+    const client = mockClient(directOnly);
+    await expect(resolveMessengerChannel(client, "아무이름")).rejects.toSatisfy((err: unknown) => {
+      if (!(err instanceof DoorayCliError)) return false;
+      return (
+        /찾을 수 없습니다/.test(err.message) &&
+        !err.message.includes("4444555566667777888")
+      );
+    });
+  });
+
+  it("not-found → channelId 직접 입력 안내 힌트 포함", async () => {
+    const client = mockClient(fixture);
+    await expect(resolveMessengerChannel(client, "없는방")).rejects.toThrow(
+      /channelId 직접 입력/,
+    );
+  });
+});

--- a/src/resolvers/messenger-channel.ts
+++ b/src/resolvers/messenger-channel.ts
@@ -1,0 +1,28 @@
+import { DoorayApiClient } from "../api/client.js";
+import { matchByName } from "./match.js";
+
+// resolveMember 의 MEMBER_ID_RE 와 동일 패턴
+const CHANNEL_ID_RE = /^\d{15,}$/;
+
+/**
+ * `--channel` 입력을 channelId 로 해석 (ADR-033).
+ * 1. 15자리 이상 숫자 → 그대로 channelId (존재 검증은 후속 send API 4xx 에 위임)
+ * 2. 그 외 → `GET /messenger/v1/channels` (내가 속한 방) title 매칭 — 정확 → 부분 → 모호
+ *    title 빈값(direct/me 방)은 이름 매칭 불가 → 후보에서 제외 (member-group code 누락 가드와 동일 패턴)
+ */
+export async function resolveMessengerChannel(
+  client: DoorayApiClient,
+  input: string,
+): Promise<string> {
+  if (CHANNEL_ID_RE.test(input)) {
+    return input;
+  }
+
+  const res = await client.getMessengerChannels();
+  const named = res.result.filter((ch) => !!ch.title);
+  const adapter = named.map((ch) => ({ name: ch.title, id: ch.id }));
+  const match = matchByName(adapter, input, "대화방", (ch) => `${ch.name} (${ch.id})`, {
+    helpHint: "channelId 직접 입력 (15+자리 numeric) 또는 Dooray 메신저에서 방 확인",
+  });
+  return match.id;
+}

--- a/tasks/047-feat-messenger-send/index.json
+++ b/tasks/047-feat-messenger-send/index.json
@@ -3,7 +3,7 @@
   "description": "Issue #88 — dooray messenger send(1:1 DM) + channel-send(대화방) 명령 추가. Dooray Messenger API 래핑. 설계 단일 소스: ADR-033 + CLAUDE.md '### messenger' 섹션. DM=POST /messenger/v1/channels/direct-send {text, organizationMemberId}, 채널=POST /messenger/v1/channels/{channelId}/logs {text}, 둘 다 응답 {result:{id}}(채널은 channelId 추가). --to id/email only(이름 미지원, resolveMember id/email 로직 공유 추출), --channel channelId(15+자리)/이름(resolveMessengerChannel — GET channels title 매칭). body --body/--body-file/-stdin + $EDITOR fallback. 출력 --json res.result raw / --quiet id. 전송은 토큰 소유자 명의, text plain 만. planning 결정 docs(ADR-033/CLAUDE.md/code-architecture/flow) 반영 완료 — phase 안 변경 금지. README/SKILL 만 마지막 phase.",
   "created_at": "2026-07-13T00:00:00Z",
   "status": "in_progress",
-  "current_phase": 2,
+  "current_phase": 3,
   "total_phases": 3,
   "error_message": null,
   "blocked_reason": null,
@@ -26,7 +26,7 @@
       "number": 2,
       "title": "messenger 명령 (send/channel-send) + 등록 + body/confirm/출력",
       "file": "phase-02.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": [
         "Read",
         "Write",

--- a/tasks/047-feat-messenger-send/index.json
+++ b/tasks/047-feat-messenger-send/index.json
@@ -2,8 +2,8 @@
   "name": "047-feat-messenger-send",
   "description": "Issue #88 — dooray messenger send(1:1 DM) + channel-send(대화방) 명령 추가. Dooray Messenger API 래핑. 설계 단일 소스: ADR-033 + CLAUDE.md '### messenger' 섹션. DM=POST /messenger/v1/channels/direct-send {text, organizationMemberId}, 채널=POST /messenger/v1/channels/{channelId}/logs {text}, 둘 다 응답 {result:{id}}(채널은 channelId 추가). --to id/email only(이름 미지원, resolveMember id/email 로직 공유 추출), --channel channelId(15+자리)/이름(resolveMessengerChannel — GET channels title 매칭). body --body/--body-file/-stdin + $EDITOR fallback. 출력 --json res.result raw / --quiet id. 전송은 토큰 소유자 명의, text plain 만. planning 결정 docs(ADR-033/CLAUDE.md/code-architecture/flow) 반영 완료 — phase 안 변경 금지. README/SKILL 만 마지막 phase.",
   "created_at": "2026-07-13T00:00:00Z",
-  "status": "pending",
-  "current_phase": 1,
+  "status": "in_progress",
+  "current_phase": 2,
   "total_phases": 3,
   "error_message": null,
   "blocked_reason": null,
@@ -12,22 +12,43 @@
       "number": 1,
       "title": "api types + client 메서드 + resolveMessengerChannel + --to id/email 공유 헬퍼 추출",
       "file": "phase-01.md",
-      "status": "pending",
-      "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+      "status": "completed",
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash",
+        "Glob",
+        "Grep"
+      ]
     },
     {
       "number": 2,
       "title": "messenger 명령 (send/channel-send) + 등록 + body/confirm/출력",
       "file": "phase-02.md",
       "status": "pending",
-      "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash",
+        "Glob",
+        "Grep"
+      ]
     },
     {
       "number": 3,
       "title": "단위 테스트 + README/SKILL 갱신 + 완료 마킹",
       "file": "phase-03.md",
       "status": "pending",
-      "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash",
+        "Glob",
+        "Grep"
+      ]
     }
   ],
   "updated_at": "2026-07-13T00:00:00Z"

--- a/tasks/047-feat-messenger-send/index.json
+++ b/tasks/047-feat-messenger-send/index.json
@@ -2,7 +2,7 @@
   "name": "047-feat-messenger-send",
   "description": "Issue #88 — dooray messenger send(1:1 DM) + channel-send(대화방) 명령 추가. Dooray Messenger API 래핑. 설계 단일 소스: ADR-033 + CLAUDE.md '### messenger' 섹션. DM=POST /messenger/v1/channels/direct-send {text, organizationMemberId}, 채널=POST /messenger/v1/channels/{channelId}/logs {text}, 둘 다 응답 {result:{id}}(채널은 channelId 추가). --to id/email only(이름 미지원, resolveMember id/email 로직 공유 추출), --channel channelId(15+자리)/이름(resolveMessengerChannel — GET channels title 매칭). body --body/--body-file/-stdin + $EDITOR fallback. 출력 --json res.result raw / --quiet id. 전송은 토큰 소유자 명의, text plain 만. planning 결정 docs(ADR-033/CLAUDE.md/code-architecture/flow) 반영 완료 — phase 안 변경 금지. README/SKILL 만 마지막 phase.",
   "created_at": "2026-07-13T00:00:00Z",
-  "status": "in_progress",
+  "status": "completed",
   "current_phase": 3,
   "total_phases": 3,
   "error_message": null,
@@ -40,7 +40,7 @@
       "number": 3,
       "title": "단위 테스트 + README/SKILL 갱신 + 완료 마킹",
       "file": "phase-03.md",
-      "status": "pending",
+      "status": "completed",
       "allowedTools": [
         "Read",
         "Write",

--- a/tasks/047-feat-messenger-send/phase-01.md
+++ b/tasks/047-feat-messenger-send/phase-01.md
@@ -20,6 +20,7 @@ planning 결정 docs 는 반영 완료 — 이 phase 에서 ADR/CLAUDE.md/code-a
    - `sendChannelMessage(channelId, text)` → `.post("messenger/v1/channels/${channelId}/logs", { json: { text } })`.
    - `getMessengerChannels()` → `.get("messenger/v1/channels")`.
 3. **`--to` 공유 헬퍼 추출**: `src/resolvers/member.ts` 의 `resolveMember` 에서 **id 분기(getMemberDetail)+email 분기(searchMembers)** 를 `resolveMemberByIdOrEmail(client, input): Promise<string | null>` 로 추출 (id/email 이면 memberId, 아니면 null).
+   - **null 반환 의미**: 정규식 매칭(id 15+자리 / email 패턴)이 분기를 결정한다. 어느 쪽에도 매칭 안 되면 null 반환(=이름 입력). id/email 로 매칭됐으나 404·모호이면 헬퍼 내부에서 throw — null 반환 아님.
    - `resolveMember` 는 이 헬퍼 호출 후 null 이면 기존 matchByName 폴백 — **기존 동작·에러 메시지 byte 동일 보존** (기존 member 테스트 통과 확인).
 4. **`resolveMessengerChannel`** (`src/resolvers/messenger-channel.ts` 신규): 입력이 15+자리 numeric(`/^\d{15,}$/`) → 그대로 channelId. 그 외 → `getMessengerChannels()` 의 `title` 매칭.
    - `matchByName` 은 `name` 필드 기준(`NameRecord`)이므로 채널을 `{ name: title, ...ch }` 로 매핑해 넘기거나 title 기준 매칭 로직 사용. **title 빈값(direct/me 방)은 매칭 후보에서 제외** (member-group `code` 누락 가드 패턴 참조).
@@ -32,6 +33,7 @@ planning 결정 docs 는 반영 완료 — 이 phase 에서 ADR/CLAUDE.md/code-a
 ## 검증
 
 ```bash
+# cwd: .claude/worktrees/047-feat-messenger-send
 pnpm build && pnpm tsc --noEmit 2>&1 | grep "^src/" | wc -l   # 0
 pnpm test 2>&1 | grep -E "Tests "                              # 기존 member/resolver 테스트 통과
 ```

--- a/tasks/047-feat-messenger-send/phase-02.md
+++ b/tasks/047-feat-messenger-send/phase-02.md
@@ -10,6 +10,7 @@ phase 1 의 client/resolver 위에 CLI 명령을 얹는다.
 1. **`src/commands/messenger/index.ts`** — `messengerCommand` (`new Command("messenger")`) 조립, `send`/`channel-send` 서브커맨드 addCommand. `src/index.ts` 에 top-level 등록 (mail/wiki 등록 지점 옆).
 2. **`src/commands/messenger/send.ts`** — `messenger send`.
    - `--to <id|email>` (필수, 단일값 — direct-send 는 1:1), `--body` / `--body-file` / `-y` 불요.
+   - 필수 옵션 처리: Commander `requiredOption` 대신 **수동 검증 + `DoorayCliError(msg, EXIT_PARAM_ERROR)`** (repo 정책 일관 — exit-code 통일).
    - `--to` 해석: `resolveMemberByIdOrEmail`; null 이면 `DoorayCliError` "id 또는 이메일을 사용하세요 (이름 미지원)".
    - body: `--body` / `--body-file`(`-`=stdin), 없으면 `$EDITOR` fallback (comment add 의 body 수집 패턴 재사용).
    - `sendDirectMessage(memberId, text)` → 출력.
@@ -28,10 +29,12 @@ phase 1 의 client/resolver 위에 CLI 명령을 얹는다.
 ## 검증
 
 ```bash
+# cwd: .claude/worktrees/047-feat-messenger-send
 pnpm build && pnpm tsc --noEmit 2>&1 | grep "^src/" | wc -l   # 0
-node dist/index.js messenger --help
-node dist/index.js messenger send --help          # --to/--body/--body-file 노출
-node dist/index.js messenger channel-send --help  # --channel/--body 노출
+node dist/index.js messenger --help | grep -q -- send && echo OK
+node dist/index.js messenger send --help | grep -q -- --to && echo OK           # --to 노출 assert
+node dist/index.js messenger send --help | grep -q -- --body-file && echo OK
+node dist/index.js messenger channel-send --help | grep -q -- --channel && echo OK  # --channel 노출 assert
 ```
 - 실전송 없음 (help/build/tsc). 실측은 사용자가 자기 계정으로.
 - index.json phase 2 completed, current_phase 3. commit.

--- a/tasks/047-feat-messenger-send/phase-03.md
+++ b/tasks/047-feat-messenger-send/phase-03.md
@@ -15,6 +15,7 @@ README/SKILL 은 코드 산출물 의존 → planning 이 아닌 이 마지막 p
 3. **skills/dooray-cli/SKILL.md** — messenger 자동화 시나리오 추가 (배포 알림 등 `--to`/`--channel` + `--body`). 내부 참조 번호 금지.
 4. **검증 grep** (README/SKILL 수정 후):
    ```bash
+   # cwd: .claude/worktrees/047-feat-messenger-send
    grep -rnE "ADR-[0-9]+|Issue #[0-9]+|task [0-9]+" README.md skills/dooray-cli/SKILL.md   # 0건
    grep -rnoE "(https?://|@)[A-Za-z0-9.-]+\.(com|co\.kr|net)" README.md skills/ docs/ CLAUDE.md src/ 2>/dev/null | grep -vE "dooray\.com|gov-dooray\.com|dooray\.co\.kr|gov-dooray\.co\.kr|helpdesk\.dooray\.com|github\.com|npmjs\.com|example\.com|youtube\.com"   # 0건 (placeholder 만)
    ```
@@ -22,6 +23,7 @@ README/SKILL 은 코드 산출물 의존 → planning 이 아닌 이 마지막 p
 ## 검증
 
 ```bash
+# cwd: .claude/worktrees/047-feat-messenger-send
 pnpm build && pnpm test 2>&1 | grep -E "Test Files|Tests "
 pnpm tsc --noEmit 2>&1 | grep "^src/" | wc -l   # 0
 ```


### PR DESCRIPTION
## 개요

Dooray Messenger API 를 래핑한 2개 명령 추가 (Issue #88).

- `dooray messenger send` — 1:1 다이렉트 메시지 (`POST /messenger/v1/channels/direct-send`, 대화방 생성 불요)
- `dooray messenger channel-send` — 대화방 메시지 (`POST /messenger/v1/channels/{channelId}/logs`)

## 결정 근거 (ADR-033)

- `--to` (DM): id / 이메일만 — messenger 는 project 스코프가 없어 이름 부분일치 불가. `resolveMember` 의 id/email 분기를 `resolveMemberByIdOrEmail` 로 공유 추출해 재사용 (기존 `resolveMember` 동작·에러 메시지 보존).
- `--channel`: channelId (15+자리) 또는 대화방 이름. 이름 매칭은 내가 속한 방(`GET /messenger/v1/channels`) title 대상. direct 방(title 빈값)은 후보에서 제외.
- body: `--body` / `--body-file` (`-`=stdin) 또는 `$EDITOR` fallback (comment 일관).
- 출력: `--json` = `res.result` raw / `--quiet` = id / 기본 prose.
- 전송은 API 토큰 소유자 명의, 본문 `text` plain 만.

## 검증

- `pnpm run build` + `pnpm tsc --noEmit` 0건
- `pnpm test` 202 passed (신규 9건 — resolveMemberByIdOrEmail 3 + resolveMessengerChannel 6)
- critic APPROVE / code-reviewer PASS / docs-verifier PASS
- 실전송 API 호출은 미수행 — 본인 계정 DM + 테스트 채널 실측은 머지 후 진행 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
