### PR TITLE
feat(commands): add wiki tree subcommand for page hierarchy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,7 @@ bash scripts/benchmark.sh [project] [post-number] [wiki-page-id]
 
 - 1 명령: `dooray wiki tree <project>` — 페이지 계층 트리 (root 부터 재귀 drill-down)
 - **list endpoint 는 flat 전체 조회 미제공** — `GET .../pages` 는 root 만, `?parentPageId=X` 는 X 직속 자식만. root 응답엔 `parentPageId` 없음 (자식에만)
-- client: `getAllWikiPages(wikiId, maxDepth?)` — 레벨별 BFS + 형제 `Promise.all` 병렬, flat `WikiPage[]` 반환
+- client: `getAllWikiPages(wikiId, maxDepth?)` — 레벨별 BFS + 형제 병렬 조회(동시 상한 10, chunk 단위), flat `WikiPage[]` 반환
 - `--depth N`: 재귀 상한 (미지정 시 전체)
 - 출력
   - text: `formatWikiTree` — flat → `parentPageId` 로 트리 조립 후 `├─└─` 렌더
@@ -264,7 +264,7 @@ bash scripts/benchmark.sh [project] [post-number] [wiki-page-id]
 | Wiki 명령 (`wiki page create/edit`) 추가/수정              | **ADR-026** (parentPageId 자동 폴백 + `--title`→`subject` 매핑 + 수정 endpoint 3종 분기)       |
 | Wiki page file 명령 (`wiki page file *`) 추가/수정         | **ADR-029** (multipart `type` 필드 순서 의존 + 307 redirect — ADR-015 재사용)                  |
 | `wiki page delete` 명령 (비공식 endpoint)                  | **ADR-032** (미문서화 DELETE endpoint + 하위 페이지 조부모 재부착 실측 + confirm 기본, Issue #87) |
-| `wiki tree` 명령 (페이지 계층 트리)                        | **ADR-034** (list endpoint flat 미제공 → root 부터 레벨별 재귀 drill-down + `Promise.all` 병렬 + `--depth` 상한 + `--json` flat 유지, Issue #101) |
+| `wiki tree` 명령 (페이지 계층 트리)                        | **ADR-034** (list endpoint flat 미제공 → root 부터 레벨별 재귀 drill-down + 형제 병렬 조회(동시 상한 10) + `--depth` 상한 + `--json` flat 유지, Issue #101) |
 | `messenger send` / `channel-send` 명령                     | **ADR-033** (direct-send memberId 직접 + channel logs + `--to` id/email + `--channel` id/이름 lookup, Issue #88) |
 | member-group resolver (응답 shape 정규화 + 가드)           | **ADR-028** (nested array unwrap `flat()` + id 직접 입력 fallback + `match.ts` 가드, Issue #65 #76) |
 | project resolver (numeric 입력 fallback)                   | **ADR-030** (`PROJECT_ID_RE` 분기 + cache 우회 + 권한은 후속 API 4xx 위임, Issue #78)         |

--- a/README.md
+++ b/README.md
@@ -378,6 +378,8 @@ dooray post workflow <project> 42 "진행 중"    # 워크플로우 변경
 ```bash
 dooray wiki list                           # 위키 목록
 dooray wiki pages <project>                   # 페이지 목록
+dooray wiki tree <project>                    # 페이지 계층 트리 (root 부터 재귀)
+dooray wiki tree <project> --depth 2          # 손자까지만
 dooray wiki page get <project> <page-id>      # 페이지 상세
 dooray wiki page create <project> --title "..." [--parent <page-id>] [--body "..." | --body-file <path>]
 dooray wiki page edit <project> <page-id> --title "새 제목"                   # 제목만 (비대화형)

--- a/docs/adr/034-wiki-tree-drill-down.md
+++ b/docs/adr/034-wiki-tree-drill-down.md
@@ -1,7 +1,7 @@
 ## ADR-034: wiki tree 레벨별 drill-down 재귀 조립 (flat list endpoint 부재)
 
 **결정**: `dooray wiki tree` 는 root 페이지부터 레벨별 재귀로 전체 페이지를 모아 트리를 그린다.
-- 클라이언트에 `getAllWikiPages(wikiId, maxDepth?)` 신설 — 레벨별 BFS + 같은 부모 형제는 `Promise.all` 병렬 조회.
+- 클라이언트에 `getAllWikiPages(wikiId, maxDepth?)` 신설 — 레벨별 BFS + 같은 부모 형제는 병렬 조회(동시 요청 상한 10).
 - `--depth N` 으로 재귀 상한 지정, 미지정 시 전체.
 - `--json` 은 flat 배열 (`parentPageId` 포함) — 기존 `wiki pages --json` 스키마와 동일. 트리는 text 출력에만 적용.
 
@@ -20,6 +20,8 @@
 - `--json` 을 children 중첩 트리로 — 기존 `wiki pages --json` flat 스키마와 어긋나 자동화 파싱 호환이 깨짐.
 
 **트레이드오프**: 대형 위키는 페이지 수만큼 호출이 발생한다.
-레벨별 `Promise.all` 병렬화로 완화하고, `--depth` 로 사용자가 범위를 좁힐 수 있게 한다.
+레벨 내 형제를 병렬 조회하되 동시 요청을 상한 10 으로 제한해 완화한다.
+상한 없는 `Promise.all` 은 자식이 수백 개인 레벨에서 병렬 요청이 폭증해 rate limit / 커넥션 고갈 위험이 있어 chunk 단위로 나눠 처리한다.
+`--depth` 로 사용자가 범위를 좁힐 수도 있다.
 
 > 페이지 create/edit 쪽 함정은 ADR-026 으로 분리 (읽기 drill-down 과 무관한 별 관심사).

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -82,6 +82,7 @@ dooray doctor                                 # 설정 검증
 | 댓글 삭제 | `dooray post comment delete <project> <number> <comment-id>` |
 | 위키 목록 | `dooray wiki list` |
 | 위키 페이지 목록 | `dooray wiki pages <project>` |
+| 위키 페이지 트리 | `dooray wiki tree <project>` (계층 트리, `--depth N` 상한, `--json` 은 flat) |
 | 위키 페이지 상세 | `dooray wiki page get <project> <page-id>` |
 | 위키 페이지 생성 | `dooray wiki page create <project> --title "..." [--parent <page-id>] [--body "..."]` (--parent 생략 시 위키 home 페이지 아래 생성) |
 | 위키 페이지 수정 (제목) | `dooray wiki page edit <project> <page-id> --title "..."` |
@@ -231,6 +232,9 @@ dooray wiki pages <project> --json
 
 # 2. 페이지 내용 조회
 dooray wiki page get <project> <pageId> --json
+
+# 3. 전체 계층을 트리로 훑기 (--json 은 flat 배열 — wiki pages 와 동일 스키마로 파싱)
+dooray wiki tree <project> --json
 ```
 
 ### 첨부파일 일괄 다운로드 후 실패 분리

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -508,16 +508,26 @@ export class DoorayApiClient {
   }
 
   async getAllWikiPages(wikiId: string, maxDepth?: number): Promise<WikiPage[]> {
+    // 한 레벨의 형제 자식 조회를 병렬화하되, 동시 요청 수를 상한으로 제한한다.
+    // 상한이 없으면 자식이 수백 개인 레벨에서 병렬 요청이 폭증해
+    // rate limit / 커넥션 고갈 위험이 있다. chunk 를 순서대로 처리해
+    // 레벨 내 페이지 순서는 그대로 보존한다.
+    const CONCURRENCY = 10;
     const all: WikiPage[] = [];
     let level = (await this.getWikiPages(wikiId)).result;
     let depth = 1;
     while (level.length > 0) {
       all.push(...level);
       if (maxDepth !== undefined && depth >= maxDepth) break;
-      const childBatches = await Promise.all(
-        level.map((p) => this.getWikiPages(wikiId, p.id).then((r) => r.result)),
-      );
-      level = childBatches.flat();
+      const next: WikiPage[] = [];
+      for (let i = 0; i < level.length; i += CONCURRENCY) {
+        const chunk = level.slice(i, i + CONCURRENCY);
+        const batches = await Promise.all(
+          chunk.map((p) => this.getWikiPages(wikiId, p.id).then((r) => r.result)),
+        );
+        next.push(...batches.flat());
+      }
+      level = next;
       depth++;
     }
     return all;

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -31,6 +31,7 @@ import type {
   MilestoneListResponse,
   MemberGroupListResponse,
   WikiListResponse,
+  WikiPage,
   WikiPagesResponse,
   WikiPageResponse,
   CreateWikiPageRequest,
@@ -504,6 +505,22 @@ export class DoorayApiClient {
     } catch (e) {
       throw await toDoorayCliError(e);
     }
+  }
+
+  async getAllWikiPages(wikiId: string, maxDepth?: number): Promise<WikiPage[]> {
+    const all: WikiPage[] = [];
+    let level = (await this.getWikiPages(wikiId)).result;
+    let depth = 1;
+    while (level.length > 0) {
+      all.push(...level);
+      if (maxDepth !== undefined && depth >= maxDepth) break;
+      const childBatches = await Promise.all(
+        level.map((p) => this.getWikiPages(wikiId, p.id).then((r) => r.result)),
+      );
+      level = childBatches.flat();
+      depth++;
+    }
+    return all;
   }
 
   async getWikiPage(wikiId: string, pageId: string): Promise<WikiPageResponse> {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -495,6 +495,7 @@ export interface WikiPage {
   root: boolean;
   creator: Creator;
   subject: string;
+  parentPageId?: string;
 }
 
 export type WikiPagesResponse = DoorayApiResponse<WikiPage[]>;

--- a/src/commands/wiki/tree.ts
+++ b/src/commands/wiki/tree.ts
@@ -1,0 +1,35 @@
+import { Command } from "commander";
+import { getConfigOrThrow } from "../../config/store.js";
+import { DoorayApiClient } from "../../api/client.js";
+import { resolveWiki } from "../../resolvers/wiki.js";
+import { formatWikiTree } from "../../formatters/wiki.js";
+import { startSpinner, stopSpinner } from "../../utils/spinner.js";
+import { DoorayCliError } from "../../utils/errors.js";
+import { EXIT_PARAM_ERROR } from "../../utils/exit-codes.js";
+import type { OutputOptions } from "../../formatters/table.js";
+
+export const wikiTreeCommand = new Command("tree")
+  .description("위키 페이지 계층 트리 조회")
+  .argument("<project>", "프로젝트 코드 또는 ID")
+  .option("--depth <n>", "재귀 최대 깊이 (root=1, 미지정 시 전체)")
+  .action(async (project, opts) => {
+    const globalOpts = wikiTreeCommand.optsWithGlobals() as OutputOptions;
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+
+    let maxDepth: number | undefined;
+    if (opts.depth !== undefined) {
+      const parsed = Number(opts.depth);
+      if (!Number.isInteger(parsed) || parsed < 1) {
+        throw new DoorayCliError("--depth 는 1 이상의 정수여야 합니다", EXIT_PARAM_ERROR);
+      }
+      maxDepth = parsed;
+    }
+
+    startSpinner("위키 페이지 트리 조회 중...");
+    const wikiId = await resolveWiki(client, project);
+    const pages = await client.getAllWikiPages(wikiId, maxDepth);
+    stopSpinner(true, "위키 페이지 트리 조회 완료");
+
+    formatWikiTree(pages, globalOpts);
+  });

--- a/src/formatters/wiki.test.ts
+++ b/src/formatters/wiki.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import type { WikiPage } from "../api/types.js";
+import { buildWikiTree, renderWikiTree } from "./wiki.js";
+
+function page(overrides: Partial<WikiPage> & Pick<WikiPage, "id" | "subject">): WikiPage {
+  return {
+    wikiId: "w-1",
+    version: 1,
+    root: false,
+    creator: { type: "member", member: { organizationMemberId: "u1", name: "가상사용자" } },
+    ...overrides,
+  };
+}
+
+describe("buildWikiTree", () => {
+  it("flat 배열을 부모-자식 트리로 조립한다 (root 1 + 자식 2 + 손자 1)", () => {
+    const pages: WikiPage[] = [
+      page({ id: "p-root", subject: "Home", root: true }),
+      page({ id: "p-child-1", subject: "자식 A", parentPageId: "p-root" }),
+      page({ id: "p-child-2", subject: "자식 B", parentPageId: "p-root" }),
+      page({ id: "p-grandchild-1", subject: "손자 A", parentPageId: "p-child-1" }),
+    ];
+
+    const tree = buildWikiTree(pages);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0].page.id).toBe("p-root");
+    expect(tree[0].children).toHaveLength(2);
+    expect(tree[0].children.map((c) => c.page.id)).toEqual(["p-child-1", "p-child-2"]);
+    expect(tree[0].children[0].children).toHaveLength(1);
+    expect(tree[0].children[0].children[0].page.id).toBe("p-grandchild-1");
+  });
+
+  it("root: true 페이지가 여러 개면 최상단 노드도 여러 개다", () => {
+    const pages: WikiPage[] = [
+      page({ id: "p-root-1", subject: "Home 1", root: true }),
+      page({ id: "p-root-2", subject: "Home 2", root: true }),
+    ];
+
+    const tree = buildWikiTree(pages);
+
+    expect(tree).toHaveLength(2);
+    expect(tree.map((n) => n.page.id)).toEqual(["p-root-1", "p-root-2"]);
+  });
+
+  it("parentPageId 가 배열 내 어떤 id 와도 매칭 안 되면 루트로 승격한다", () => {
+    const pages: WikiPage[] = [
+      page({ id: "p-root", subject: "Home", root: true }),
+      page({ id: "p-orphan", subject: "고아 페이지", parentPageId: "p-missing" }),
+    ];
+
+    const tree = buildWikiTree(pages);
+
+    expect(tree).toHaveLength(2);
+    expect(tree.map((n) => n.page.id)).toEqual(["p-root", "p-orphan"]);
+  });
+
+  it("빈 배열 입력 시 빈 배열을 반환한다", () => {
+    expect(buildWikiTree([])).toEqual([]);
+  });
+});
+
+describe("renderWikiTree", () => {
+  it("형제 중 마지막이 아니면 ├─, 마지막이면 └─ 커넥터를 쓴다", () => {
+    const pages: WikiPage[] = [
+      page({ id: "p-root", subject: "Home", root: true }),
+      page({ id: "p-child-1", subject: "자식 A", parentPageId: "p-root" }),
+      page({ id: "p-child-2", subject: "자식 B", parentPageId: "p-root" }),
+    ];
+
+    const rendered = renderWikiTree(buildWikiTree(pages));
+    const lines = rendered.split("\n");
+
+    expect(lines[1]).toMatch(/├─자식 A/);
+    expect(lines[2]).toMatch(/└─자식 B/);
+  });
+
+  it("각 라인에 (<id>) 가 노출된다", () => {
+    const pages: WikiPage[] = [page({ id: "p-root", subject: "Home", root: true })];
+
+    const rendered = renderWikiTree(buildWikiTree(pages));
+
+    expect(rendered).toContain("(p-root)");
+  });
+
+  it("subject 에 개행이 있어도 한 줄로 정규화해 트리 구조를 깨지 않는다", () => {
+    const pages: WikiPage[] = [
+      page({ id: "p-root", subject: "제목\n줄바꿈", root: true }),
+    ];
+
+    const rendered = renderWikiTree(buildWikiTree(pages));
+
+    expect(rendered.split("\n")).toHaveLength(1);
+    expect(rendered).toContain("제목 줄바꿈");
+  });
+});

--- a/src/formatters/wiki.ts
+++ b/src/formatters/wiki.ts
@@ -1,6 +1,6 @@
 import type { Wiki, WikiPage, WikiPageDetail } from "../api/types.js";
 import type { OutputOptions } from "./table.js";
-import { output, printJson } from "./table.js";
+import { output, printJson, printQuiet } from "./table.js";
 
 export function formatWikiList(wikis: Wiki[], opts: OutputOptions): void {
   output(opts, {
@@ -22,6 +22,70 @@ export function formatWikiPages(pages: WikiPage[], opts: OutputOptions): void {
     raw: pages,
     ids: pages.map((p) => p.id),
   });
+}
+
+export interface WikiTreeNode {
+  page: WikiPage;
+  children: WikiTreeNode[];
+}
+
+export function buildWikiTree(pages: WikiPage[]): WikiTreeNode[] {
+  const ids = new Set(pages.map((p) => p.id));
+  const childrenByParent = new Map<string, WikiPage[]>();
+  const roots: WikiPage[] = [];
+
+  for (const page of pages) {
+    const parentId = page.parentPageId;
+    const isRoot = page.root === true || !parentId || !ids.has(parentId);
+    if (isRoot) {
+      roots.push(page);
+      continue;
+    }
+    const siblings = childrenByParent.get(parentId) ?? [];
+    siblings.push(page);
+    childrenByParent.set(parentId, siblings);
+  }
+
+  const toNode = (page: WikiPage): WikiTreeNode => ({
+    page,
+    children: (childrenByParent.get(page.id) ?? []).map(toNode),
+  });
+
+  return roots.map(toNode);
+}
+
+function normalizeSubject(subject: string): string {
+  return subject.replace(/[\r\n]+/g, " ");
+}
+
+export function renderWikiTree(nodes: WikiTreeNode[], prefix = ""): string {
+  const lines: string[] = [];
+
+  nodes.forEach((node, index) => {
+    const isLast = index === nodes.length - 1;
+    const connector = isLast ? "└─" : "├─";
+    const subject = normalizeSubject(node.page.subject);
+    lines.push(`${prefix}${connector}${subject} (${node.page.id})`);
+
+    if (node.children.length > 0) {
+      const childPrefix = prefix + (isLast ? "   " : "│  ");
+      lines.push(renderWikiTree(node.children, childPrefix));
+    }
+  });
+
+  return lines.join("\n");
+}
+
+export function formatWikiTree(pages: WikiPage[], opts: OutputOptions): void {
+  if (opts.json) {
+    printJson(pages);
+    return;
+  }
+  if (opts.quiet) {
+    printQuiet(pages.map((p) => p.id));
+    return;
+  }
+  process.stdout.write(renderWikiTree(buildWikiTree(pages)) + "\n");
 }
 
 export function formatWikiPageDetail(page: WikiPageDetail, opts: OutputOptions): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import { fileUploadCommand } from "./commands/post/file/upload.js";
 import { fileDeleteCommand } from "./commands/post/file/delete.js";
 import { wikiListCommand } from "./commands/wiki/list.js";
 import { wikiPagesCommand } from "./commands/wiki/pages.js";
+import { wikiTreeCommand } from "./commands/wiki/tree.js";
 import { wikiPageGetCommand } from "./commands/wiki/page-get.js";
 import { wikiPageCreateCommand } from "./commands/wiki/page-create.js";
 import { wikiPageEditCommand } from "./commands/wiki/page-edit.js";
@@ -114,6 +115,7 @@ postCommand.addCommand(fileCommand);
 const wikiCommand = new Command("wiki").description("위키 관련 명령");
 wikiCommand.addCommand(wikiListCommand);
 wikiCommand.addCommand(wikiPagesCommand);
+wikiCommand.addCommand(wikiTreeCommand);
 
 // wiki page 서브커맨드 그룹
 const wikiPageCommand = new Command("page").description("위키 페이지 관련 명령");

--- a/tasks/048-feat-wiki-tree/index.json
+++ b/tasks/048-feat-wiki-tree/index.json
@@ -2,9 +2,9 @@
   "name": "048-feat-wiki-tree",
   "description": "wiki tree 신규 서브커맨드 — root 부터 레벨별 재귀 drill-down 으로 페이지 계층 트리 출력 (Issue #101, ADR-034)",
   "created_at": "2026-07-14T00:00:00Z",
-  "updated_at": "2026-07-14T00:00:00Z",
-  "status": "pending",
-  "current_phase": 0,
+  "updated_at": "2026-07-14T09:07:35Z",
+  "status": "completed",
+  "current_phase": 4,
   "total_phases": 4,
   "error_message": null,
   "blocked_reason": null,
@@ -13,32 +13,58 @@
       "number": 1,
       "title": "WikiPage 타입 확장 + client getAllWikiPages 재귀 조회",
       "file": "phase-01.md",
-      "status": "pending",
-      "allowedTools": ["Read", "Edit", "Grep", "Glob", "Bash"],
+      "status": "completed",
+      "allowedTools": [
+        "Read",
+        "Edit",
+        "Grep",
+        "Glob",
+        "Bash"
+      ],
       "model": "sonnet"
     },
     {
       "number": 2,
       "title": "formatWikiTree 포맷터 + wiki tree 커맨드 + index.ts 등록",
       "file": "phase-02.md",
-      "status": "pending",
-      "allowedTools": ["Read", "Write", "Edit", "Grep", "Glob", "Bash"],
+      "status": "completed",
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Grep",
+        "Glob",
+        "Bash"
+      ],
       "model": "sonnet"
     },
     {
       "number": 3,
       "title": "트리 조립 로직 단위 테스트 + 빌드/타입체크 검증",
       "file": "phase-03.md",
-      "status": "pending",
-      "allowedTools": ["Read", "Write", "Edit", "Grep", "Glob", "Bash"],
+      "status": "completed",
+      "allowedTools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Grep",
+        "Glob",
+        "Bash"
+      ],
       "model": "sonnet"
     },
     {
       "number": 4,
       "title": "README + SKILL.md 사용자 가이드 갱신 + 최종 검증 + completed 마킹",
       "file": "phase-04.md",
-      "status": "pending",
-      "allowedTools": ["Read", "Edit", "Grep", "Glob", "Bash"],
+      "status": "completed",
+      "allowedTools": [
+        "Read",
+        "Edit",
+        "Grep",
+        "Glob",
+        "Bash"
+      ],
       "model": "sonnet"
     }
   ]

--- a/tasks/048-feat-wiki-tree/phase-01.md
+++ b/tasks/048-feat-wiki-tree/phase-01.md
@@ -108,7 +108,7 @@ async getAllWikiPages(wikiId: string, maxDepth?: number): Promise<WikiPage[]> {
 ## 검증
 
 ```bash
-# cwd: /Users/nhn/personal/dooray-cli
+# cwd: /Users/nhn/personal/dooray-cli/.claude/worktrees/plan048
 pnpm tsc --noEmit
 # 0 에러
 

--- a/tasks/048-feat-wiki-tree/phase-02.md
+++ b/tasks/048-feat-wiki-tree/phase-02.md
@@ -29,6 +29,7 @@ export function formatWikiTree(pages: WikiPage[], opts: OutputOptions): void
 - 그 외(text) → 아래 트리 렌더.
 
 `printJson` / `printQuiet` 은 `./table.js` 에서 이미 export (재사용, 새로 만들지 않음).
+현재 `wiki.ts` 상단 import 는 `{ output, printJson }` 뿐 — `printQuiet` 를 import 목록에 추가한다.
 
 **순수 함수로 분리 (테스트 가능성 — phase-03 이 I/O 없이 검증)**:
 
@@ -74,7 +75,7 @@ export const wikiTreeCommand = new Command("tree")
     if (opts.depth !== undefined) {
       const parsed = Number(opts.depth);
       if (!Number.isInteger(parsed) || parsed < 1) {
-        throw new DoorayCliError("--depth 는 1 이상의 정수여야 합니다", EXIT_...);
+        throw new DoorayCliError("--depth 는 1 이상의 정수여야 합니다", EXIT_PARAM_ERROR);
       }
       maxDepth = parsed;
     }
@@ -127,7 +128,7 @@ export const wikiTreeCommand = new Command("tree")
 ## 검증
 
 ```bash
-# cwd: /Users/nhn/personal/dooray-cli
+# cwd: /Users/nhn/personal/dooray-cli/.claude/worktrees/plan048
 pnpm tsc --noEmit
 # 0 에러
 

--- a/tasks/048-feat-wiki-tree/phase-03.md
+++ b/tasks/048-feat-wiki-tree/phase-03.md
@@ -53,7 +53,7 @@ phase-01/02 산출물이 빌드·타입·테스트를 통과하는지 확인한�
 ## 검증
 
 ```bash
-# cwd: /Users/nhn/personal/dooray-cli
+# cwd: /Users/nhn/personal/dooray-cli/.claude/worktrees/plan048
 pnpm tsc --noEmit
 # 0 에러
 

--- a/tasks/048-feat-wiki-tree/phase-04.md
+++ b/tasks/048-feat-wiki-tree/phase-04.md
@@ -55,7 +55,8 @@ dooray wiki tree <project> --depth 2          # 손자까지만
 ## 검증
 
 ```bash
-# cwd: /Users/nhn/personal/dooray-cli
+# cwd: /Users/nhn/personal/dooray-cli/.claude/worktrees/plan048
+# branch: feat/048-feat-wiki-tree
 
 # 내부 참조 0건 (외부 facing 문서)
 grep -rnE "ADR-[0-9]+|Issue #[0-9]+|task [0-9]+" README.md skills/dooray-cli/SKILL.md 2>/dev/null


### PR DESCRIPTION
## 개요

`dooray wiki tree <project>` 신규 서브커맨드 추가.
위키 페이지 계층을 root 부터 재귀 drill-down 으로 조회해 트리로 출력한다.

```
Home (p-root)
├─ 가이드 (p-child-1)
│  └─ 설치 (p-grandchild-1)
└─ FAQ (p-child-2)
```

## 배경 — flat 조회 endpoint 부재

Dooray Wiki 페이지 목록 endpoint 는 전체 flat 조회를 제공하지 않는다 (실측).

- `GET .../pages` (parentPageId 없이) → root 페이지만 반환
- `GET .../pages?parentPageId=X` → X 직속 자식만 반환
- root 응답 항목엔 `parentPageId` 없음, 자식 응답에만 존재

따라서 root 부터 레벨별로 자식을 재귀 조회해 전체를 모은다.

## 주요 결정

- **client `getAllWikiPages(wikiId, maxDepth?)`** — 레벨별 BFS + 형제 `Promise.all` 병렬 조회, flat `WikiPage[]` 반환. `maxDepth` 로 재귀 상한 (root=depth 1).
- **포맷터 순수 함수 분리** — `buildWikiTree`(flat→중첩) / `renderWikiTree`(트리→문자열) 를 I/O 와 분리해 단위 테스트 가능.
- **`--json` 은 flat 유지** — 기존 `wiki pages --json` 스키마 호환 (children 중첩으로 바꾸면 자동화 파싱이 어긋남). text 출력에만 트리 렌더.
- **`--depth N`** — 재귀 최대 깊이. 검증은 spinner 시작 전 (불필요한 API 호출 방지).
- 트리 라인에 페이지 id 노출 — 사용자가 후속 `wiki get`/`wiki page delete` 에 곧바로 쓰도록.

## 검증

- `pnpm tsc --noEmit` 0건
- `pnpm test` 209 tests PASS (신규 wiki.test.ts 7 케이스 — flat→트리·다중 root·고아 parentPageId 승격·빈 배열·커넥터·id 노출·subject 개행 정규화)
- `pnpm run build` OK
- `node dist/index.js wiki tree --help` 정상 노출
- critic 계획 평가 ACCEPT / code-reviewer PASS / docs-verifier PASS (코드↔docs 정합성)
