### PR TITLE
feat(config): config set 값에 stdin 규약 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ dooray                # 글로벌 링크 시
 - **옵션 이름**
   - 제목은 post·wiki 모두 `--title` (`--subject` 는 deprecated alias — stderr 경고 후 동작)
   - 본문은 `--body` / `--body-file` (둘 다 `-` 로 stdin 을 받는다)
+  - `config set <key> <value>` 의 값도 `-` 로 stdin 을 받는다 — 토큰이 셸 기록과 프로세스 목록에 남지 않게 하는 경로다
   - `post edit`, `wiki page edit`, `post`·`wiki page` 의 `comment add`/`edit` 는 둘 다 없으면 `$EDITOR` 가 열린다. 단 `post edit` 의 태그·참조자·담당자 변경 옵션은 제목·본문 없이도 비대화형 수정으로 실행한다. `create` 계열은 fallback 없이 에러가 된다
 - **resolver 매칭**: 정확일치 → 이름 부분일치 → 모호하면 에러와 후보 목록 출력
 - **출력**: `--json` 은 raw 유지, `--quiet` 은 식별자만

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -55,6 +55,15 @@ dooray config set base-url https://api.dooray.com
 dooray doctor
 ```
 
+값에 `-` 를 주면 stdin 에서 읽는다. 토큰을 명령 인자로 넘기지 않으려는 경로다.
+
+```
+printf '%s' "$TOKEN" | dooray config set api-key -
+```
+
+인자로 넘기면 셸 기록과 프로세스 목록에 값이 남는다.
+stdin 으로 받은 값은 양끝 공백을 지운 뒤 저장하고, 비어 있으면 저장하지 않고 종료 코드 3 으로 끝낸다.
+
 ## Claude Code 스킬 관리 흐름
 
 스킬 관리는 API·메일 설정과 독립적으로 실행한다.

--- a/skills/dooray-cli/references/common.md
+++ b/skills/dooray-cli/references/common.md
@@ -22,6 +22,15 @@ dooray config set api-key <YOUR_API_TOKEN>   # https://{org}.dooray.com/setting/
 dooray doctor                                 # 설정 검증
 ```
 
+값 자리에 `-` 를 주면 stdin 에서 읽는다. 토큰을 명령 인자로 넘기지 않을 때 쓴다.
+
+```bash
+printf '%s' "$TOKEN" | dooray config set api-key -
+```
+
+인자로 넘긴 값은 셸 기록과 프로세스 목록에 남는다.
+stdin 값은 양끝 공백을 지운 뒤 저장하고, 비어 있으면 저장하지 않고 종료 코드 3 으로 끝낸다.
+
 ## Claude Code 스킬 관리
 
 ```bash

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import chalk from "chalk";
 import { getConfig, setConfigValue } from "../config/store.js";
+import { resolveConfigValue } from "../utils/config-value.js";
 import { DoorayCliError } from "../utils/errors.js";
 import { EXIT_CONFIG_ERROR } from "../utils/exit-codes.js";
 
@@ -16,10 +17,10 @@ configCommand
   .command("set")
   .description("설정 값 저장")
   .argument("<key>", "설정 키 (api-key, base-url)")
-  .argument("<value>", "설정 값")
+  .argument("<value>", "설정 값 (`-` 이면 stdin 에서 읽음)")
   .action(async (key: string, value: string) => {
     try {
-      await setConfigValue(key, value);
+      await setConfigValue(key, await resolveConfigValue(value));
       console.log(chalk.green(`✓ ${key} 설정 완료`));
     } catch (err) {
       if (err instanceof DoorayCliError) {

--- a/src/utils/body-input.ts
+++ b/src/utils/body-input.ts
@@ -43,7 +43,7 @@ export async function readBodyInputOrNull(
   return readBodyInput(opts);
 }
 
-async function readStdin(): Promise<string> {
+export async function readStdin(): Promise<string> {
   if (process.stdin.isTTY) {
     throw new DoorayCliError(
       "stdin에서 읽으려면 파이프로 데이터를 전달해주세요.",

--- a/src/utils/config-value.test.ts
+++ b/src/utils/config-value.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveConfigValue } from "./config-value.js";
+import { DoorayCliError } from "./errors.js";
+import { EXIT_PARAM_ERROR } from "./exit-codes.js";
+
+describe("resolveConfigValue", () => {
+  it("일반 값은 그대로 반환하고 stdin 을 읽지 않는다", async () => {
+    const read = vi.fn();
+
+    await expect(resolveConfigValue("abc123", read)).resolves.toBe("abc123");
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it("`-` 이면 stdin 에서 읽는다", async () => {
+    const read = vi.fn().mockResolvedValue("token-from-stdin");
+
+    await expect(resolveConfigValue("-", read)).resolves.toBe(
+      "token-from-stdin",
+    );
+    expect(read).toHaveBeenCalledOnce();
+  });
+
+  it("stdin 값의 양끝 공백과 줄바꿈을 제거한다", async () => {
+    const read = vi.fn().mockResolvedValue("  token-with-newline\n");
+
+    await expect(resolveConfigValue("-", read)).resolves.toBe(
+      "token-with-newline",
+    );
+  });
+
+  it("stdin 값이 비면 EXIT_PARAM_ERROR 로 거부한다", async () => {
+    const read = vi.fn().mockResolvedValue("\n  \n");
+
+    await expect(resolveConfigValue("-", read)).rejects.toMatchObject({
+      exitCode: EXIT_PARAM_ERROR,
+    });
+    await expect(resolveConfigValue("-", read)).rejects.toBeInstanceOf(
+      DoorayCliError,
+    );
+  });
+
+  it("값 안의 `-` 는 stdin 으로 해석하지 않는다", async () => {
+    const read = vi.fn();
+
+    await expect(resolveConfigValue("a-b", read)).resolves.toBe("a-b");
+    expect(read).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/config-value.ts
+++ b/src/utils/config-value.ts
@@ -1,0 +1,31 @@
+import { readStdin } from "./body-input.js";
+import { DoorayCliError } from "./errors.js";
+import { EXIT_PARAM_ERROR } from "./exit-codes.js";
+
+/**
+ * `config set <key> <value>` 의 값을 확정한다.
+ *
+ * - 값이 `"-"` 이면 stdin 에서 읽는다 (`--body -` 와 같은 규약).
+ * - stdin 으로 받은 값은 양끝 공백을 제거한다. 파이프는 대개 줄바꿈을 덧붙이는데,
+ *   API 토큰에 줄바꿈이 섞이면 인증이 조용히 실패한다.
+ * - 비면 저장하지 않고 에러를 낸다. 빈 값을 저장하면 설정 파일은 있는데
+ *   값이 없는 상태가 되어 진단이 어려워진다.
+ *
+ * 토큰 같은 값을 명령 인자로 넘기면 셸 기록과 프로세스 목록에 남는다.
+ * stdin 경로는 그 노출을 피하려는 것이다.
+ */
+export async function resolveConfigValue(
+  raw: string,
+  read: () => Promise<string> = readStdin,
+): Promise<string> {
+  if (raw !== "-") return raw;
+
+  const value = (await read()).trim();
+  if (value === "") {
+    throw new DoorayCliError(
+      "stdin 으로 받은 값이 비어 있습니다.",
+      EXIT_PARAM_ERROR,
+    );
+  }
+  return value;
+}


### PR DESCRIPTION
`#133` 해결.

## 무엇을

`dooray config set <key> <value>` 의 값 자리에 `-` 를 주면 stdin 에서 읽는다.

```bash
printf '%s' "$TOKEN" | dooray config set api-key -
```

## 왜

토큰을 명령 인자로 넘기면 셸 기록과 프로세스 목록에 남는다.
에이전트가 대신 실행하는 경우에는 도구 실행 로그에도 남는다.
에이전트에게 "토큰을 출력하지 말라" 고 지시해도 실행되는 명령 자체의 노출은 막지 못한다.

## 인터페이스 선택

이슈 초안에는 `--stdin` 플래그로 적었지만 `-` 로 바꿨다.
이 저장소는 이미 `--body -` 와 `--body-file -` 로 stdin 을 받는 규약이 있고 `readStdin` 헬퍼도 있다.
새 플래그를 만들면 같은 일을 하는 방식이 둘이 된다.

## 동작

- 값이 `-` 일 때만 stdin 을 읽는다. `a-b` 처럼 값 안의 `-` 는 해당하지 않는다
- 파이프는 대개 줄바꿈을 덧붙이므로 양끝 공백을 지운 뒤 저장한다. 토큰에 줄바꿈이 섞이면 인증이 조용히 실패한다
- 비어 있으면 저장하지 않고 종료 코드 3 으로 끝낸다. 빈 값을 저장하면 설정 파일은 있는데 값이 없는 상태가 되어 진단이 어렵다
- 기존 인자 방식은 그대로 동작한다

## 검증

임시 HOME 으로 격리해 네 경우를 실행했다.

| 입력 | 결과 |
| --- | --- |
| `printf '%s' "abc-token" \| ... api-key -` | 저장됨 |
| `printf '\n  \n' \| ... api-key -` | 종료 코드 3, 저장 안 함 |
| `printf '%s\n' "  spaced-token  " \| ... api-key -` | 공백 제거 후 저장 |
| `... api-key literal-value` | 기존 방식 그대로 |

단위 테스트 5개 추가, 전체 367개 통과. 타입 검사와 빌드, 패키지 검증 통과.

## 문서

`CLAUDE.md` 공통 규약, `docs/flow.md` 수동 설정 흐름, 스킬의 초기 설정 절에 반영했다.

`skills/dooray-persona/references/bootstrap.md` 는 이번에 바꾸지 않았다.
그 프롬프트는 npm 에 공개된 버전을 설치하는데, `-` 를 모르는 버전에서는 문자열 `-` 가 토큰으로 저장되어 조용히 실패한다.
릴리스 후에 프롬프트를 바꾼다.
