### PR TITLE
docs(pitfalls): 파일명과 id 의 gate 어휘를 본문에 맞춤

### DIFF
--- a/docs/pitfalls/plan/missing-external-state-check.md
+++ b/docs/pitfalls/plan/missing-external-state-check.md
@@ -1,5 +1,5 @@
 ---
-id: missing-external-state-gate
+id: missing-external-state-check
 category: plan
 title: 외부 상태 사전 점검 부재
 triggers: [push, merge, PR comment, npm publish, 사전 점검, rollback]


### PR DESCRIPTION
`#134` 해결.

## 무엇을

`docs/pitfalls/plan/missing-external-state-gate.md` 의 파일명과 frontmatter `id` 를 본문 어휘에 맞춘다.

- 파일명 → `missing-external-state-check.md`
- `id` → `missing-external-state-check`

## 왜

문체 정리에서 본문의 `게이트` 를 `점검` 으로 바꿨는데 파일명과 `id` 는 `gate` 로 남았다.
본문은 "사전 점검", 식별자는 `gate` 라서 어느 쪽으로 grep 해도 반쪽만 잡힌다.
반쯤 바뀐 상태가 둘 중 하나로 통일된 상태보다 찾기 어렵다.

## 참조

이 파일을 가리키는 참조는 자기 자신의 `id` 외에 없다.
저장소 전체에서 `missing-external-state-gate` 를 찾아 0건을 확인했고, `docs/pitfalls/` 에 남은 `gate` 도 0건이다.

`docs/pitfalls/INDEX.md` 는 카테고리 디렉터리를 가리키는 라우터라 개별 파일명을 나열하지 않아 갱신 대상이 아니다.
