### PR TITLE
chore(harness): 오버레이 사실 오류 정정과 노출 검증 스크립트화

### DIFF
--- a/.claude/agents/dooray-cli-docs-verifier.md
+++ b/.claude/agents/dooray-cli-docs-verifier.md
@@ -27,7 +27,7 @@ ADR 본문은 planning 단계에서 사용자와 함께 결정한다.
 | --- | --- |
 | ADR 번호와 주제 | `docs/adr/INDEX.md` |
 | 캐시 파일 구조와 TTL | `docs/data-schema.md` |
-| 코드 컨벤션, 개인 식별 정보 금지 유형과 검증 grep | `CLAUDE.md` |
+| 코드 컨벤션, 개인 식별 정보 금지 유형 | `CLAUDE.md` (검사는 `scripts/check-pii.sh`) |
 | docs 갱신 범위 | `.claude/planning-overlay.md` "변경 유형별 docs 영향 표" |
 | 마크다운 형식 규칙 | 글로벌 `~/.claude/rules/markdown-readability.md` |
 
@@ -166,7 +166,7 @@ docs-check 호출 시에는 위 형식에 Critical / Warning / Safe 분류를 �
 - **자기-면제 금지**: "단순 변경이라 검증 생략 가능" 같은 회신을 하지 않는다. team-lead 가 그대로 수용하면 검증이 없는 것과 같다.
 - **도메인 한정**: dooray-cli repo 만 검증한다. 다른 repo 호출은 거부한다.
 - **사용자 가이드 변경 시점**: `README.md` 와 `skills/dooray-cli/` 는 마지막 phase(사용자 가이드 갱신)에서만 변경한다. 중간 phase 에서 바뀌면 VIOLATION 이다.
-- **개인 식별 정보 노출은 즉시 VIOLATION**: `CLAUDE.md` 의 검증 grep 을 그대로 실행해 판정한다.
+- **개인 식별 정보 노출은 즉시 VIOLATION**: `bash scripts/check-pii.sh` 를 실행해 판정한다.
 
 </Self_Discipline>
 

--- a/.claude/agents/dooray-cli-executor.md
+++ b/.claude/agents/dooray-cli-executor.md
@@ -66,7 +66,7 @@ phase-XX complete: <한 줄 요약>
 - <읽은 패턴 파일>: 0건
 
 ## 개인 식별 정보 점검
-- 0건
+- scripts/check-pii.sh: 통과
 ```
 
 </Verification>

--- a/.claude/build-with-teams-overlay.md
+++ b/.claude/build-with-teams-overlay.md
@@ -32,7 +32,7 @@ phase 완료 조건은 `pnpm tsc --noEmit && pnpm run build && pnpm test` 다.
 
 ## 개인 식별 정보 노출 금지
 
-phase 완료 전과 PR 생성 전에 `CLAUDE.md` "개인 식별 정보 / 사내 식별자 노출 금지" 섹션의 검증 grep 을 실행해 0건을 확인한다.
+phase 완료 전과 PR 생성 전에 `bash scripts/check-pii.sh` 를 실행해 통과시킨다. CI 도 같은 스크립트를 돌린다.
 
 ## PR 본문
 

--- a/.claude/docs-check-overlay.md
+++ b/.claude/docs-check-overlay.md
@@ -11,7 +11,7 @@ agent 본문이 검증 항목·자동 grep 명령·도메인 지식(ADR 인덱�
 Agent({
   subagent_type: "dooray-cli-docs-verifier",
   description: "6-axis docs audit",
-  prompt: "전체 docs (docs/*.md + .claude/skills/*/SKILL.md) 6축 점검. Critical / Warning / Safe 분류 보고."
+  prompt: "전체 docs (docs/*.md, .claude/skills/*/SKILL.md, skills/*/ 공개 스킬) 6축 점검. Critical / Warning / Safe 분류 보고."
 })
 ```
 
@@ -23,7 +23,7 @@ agent 는 read-only (`disallowedTools: Write, Edit`) — team-lead 가 회신을
 
 ```bash
 # cwd: <repo root>
-ls docs/*.md docs/adr/*.md .claude/skills/*/SKILL.md skills/dooray-cli/SKILL.md
+ls docs/*.md docs/adr/*.md .claude/skills/*/SKILL.md skills/*/SKILL.md skills/*/references/*.md
 ```
 
 | 문서                                                         | 담당                                      |
@@ -34,7 +34,8 @@ ls docs/*.md docs/adr/*.md .claude/skills/*/SKILL.md skills/dooray-cli/SKILL.md
 | `docs/data-schema.md`                                        | `~/.dooray/cache/` 구조·TTL·resolver 로직 |
 | `docs/code-architecture.md`                                  | 디렉터리 트리·레이어·API 전략             |
 | `CLAUDE.md`                                                  | 코드 작업 지침, 전 명령 공통 규약, 노출 금지 정책 |
-| `README.md` / `skills/dooray-cli/SKILL.md`                   | 사용자 가이드 (외부 facing)               |
+| `README.md` / `skills/dooray-cli/`                           | 사용자 가이드 (외부 facing)               |
+| `skills/dooray-persona/`                                     | 문체 페르소나 워크플로우 (외부 facing)    |
 
 ## 실행 주기
 

--- a/.claude/docs-check-overlay.md
+++ b/.claude/docs-check-overlay.md
@@ -17,7 +17,7 @@ Agent({
 
 agent 는 read-only (`disallowedTools: Write, Edit`) — team-lead 가 회신을 받아 Critical 부터 사용자 승인 후 수정한다.
 
-**Fallback**: agent 사용 불가 환경(Claude Code 아닌 다른 harness)에서만 코어의 legacy 절차로 대체. 이때도 grep 명령의 진실원은 agent 본문.
+**Fallback**: agent 를 못 쓰는 환경에서는 코어 `docs-check` 의 6축 절차를 직접 따른다. 이때도 grep 명령의 단일 소스는 agent 본문이다.
 
 ## docs 구조 + 문서 목록
 
@@ -33,7 +33,7 @@ ls docs/*.md docs/adr/*.md .claude/skills/*/SKILL.md skills/dooray-cli/SKILL.md
 | `docs/adr/` (ADR 1개 = 파일 1개, 목록은 `docs/adr/INDEX.md`) | 기술 의사결정·왜·대안 기각                |
 | `docs/data-schema.md`                                        | `~/.dooray/cache/` 구조·TTL·resolver 로직 |
 | `docs/code-architecture.md`                                  | 디렉터리 트리·레이어·API 전략             |
-| `CLAUDE.md`                                                  | 코드 작업 가이드, 상황별 ADR 참조 표     |
+| `CLAUDE.md`                                                  | 코드 작업 지침, 전 명령 공통 규약, 노출 금지 정책 |
 | `README.md` / `skills/dooray-cli/SKILL.md`                   | 사용자 가이드 (외부 facing)               |
 
 ## 실행 주기

--- a/.claude/planning-overlay.md
+++ b/.claude/planning-overlay.md
@@ -37,7 +37,7 @@
 | 변경 유형 | CLAUDE.md | adr/ | code-architecture.md | prd.md | flow.md | data-schema.md | README.md | skills/dooray-cli/SKILL.md |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | 신규 CLI 명령 (소) | — (명령별 스펙은 CLAUDE.md 에 쌓지 않는다) | — | 디렉터리 트리, 필요 시 utils 추가 | MVP 범위 한 줄 | 사용자 흐름 섹션 | (캐시 도입 시) | 사용 예 섹션 | 빠른 참조 표, 자동화 시나리오 |
-| 신규 ADR 동반 변경 | ADR 참조 표 행 | ADR 본문 | 해당 영역 ADR-NNN 역참조 | (사용자 facing 시) | (사용자 흐름 변경 시) | (스키마 결정 시) | 사용 예 (해당 명령) | 시나리오 (해당 명령) |
+| 신규 ADR 동반 변경 | — (ADR 목록은 `docs/adr/INDEX.md` 가 소유) | ADR 본문 | 해당 영역 ADR-NNN 역참조 | (사용자 facing 시) | (사용자 흐름 변경 시) | (스키마 결정 시) | 사용 예 (해당 명령) | 시나리오 (해당 명령) |
 | 캐시 schema / TTL 변경 | 캐시 규약 행 | ADR 갱신 (ADR-004/010) | utils/cache 섹션 | — | — | 캐시 디렉터리, 스키마 본문 | — | — |
 | 새 API 호출 패턴 (재시도/redirect 등) | — | 정책 결정 ADR | api/ 섹션, ADR-NNN 역참조 | — | — | — | — | — |
 | 기존 resolver 입력 형식 확대 | 공통 규약의 resolver 줄 (규약이 바뀔 때만) | — | resolver 주석 1줄 갱신 | — | 사용 예 (자동 분기 시나리오) | — | 사용 예 | 빠른 참조 표 |

--- a/.claude/planning-overlay.md
+++ b/.claude/planning-overlay.md
@@ -48,7 +48,7 @@
 
 ### 공개 문서 내부 참조 제거 (필수 — README / SKILL 갱신 시)
 
-규칙과 검증 grep 은 `CLAUDE.md` "공개 문서(README · 공개 SKILL) — 내부 참조 번호 제외" 가 소유한다.
+규칙은 `CLAUDE.md` "공개 문서(README · 공개 SKILL) — 내부 참조 번호 제외" 가, 검사는 `scripts/check-public-refs.sh` 가 소유한다.
 planning 에서는 README 와 `skills/` 를 손대는 phase 마다 그 grep 을 통과시킨다.
 
 ## 검증
@@ -57,5 +57,5 @@ planning 에서는 README 와 `skills/` 를 손대는 phase 마다 그 grep 을 
 - **docs-verifier 흡수 원칙**: docs-verifier(`.claude/agents/dooray-cli-docs-verifier.md`)의 반복 지적은 별도 회고 docs 를 신설하지 않는다.
   - 위 "변경 유형별 docs 영향 표"에 행 추가나 보강으로 흡수한다.
   - 그 agent 가 이 표를 검증 기준으로 그대로 쓴다 — 표를 고치면 검증도 함께 달라진다.
-- **개인 식별 정보 노출 금지**: task 파일 제출 전 `CLAUDE.md` 의 검증 grep 을 실행해 0건을 확인한다.
+- **개인 식별 정보 노출 금지**: task 파일 제출 전 `bash scripts/check-pii.sh` 를 실행해 통과시킨다.
 

--- a/.claude/planning-overlay.md
+++ b/.claude/planning-overlay.md
@@ -8,88 +8,48 @@
 코어 `step-3` 부터 `step-6` 이 도메인 변형을 오버레이에 위임한다.
 각 단계가 대조할 소유 문서는 아래와 같다. 규약 본문을 여기 옮겨 적지 않는다 — 옮기면 갈라진다.
 
-| 단계 | 대조할 곳 |
-| --- | --- |
-| 3 호출 시나리오 | `CLAUDE.md` "명령 공통 규약" — 입력 형식, 출력 모드, 에러와 빈 상태 |
-| 4 인터페이스 | `CLAUDE.md` 출력 규약. 표·JSON·quiet 세 포맷터 중 무엇을 고치는지 명시한다 |
-| 5 API | `src/api/client.ts` 에 재사용할 메서드가 있는지. 새 endpoint 면 `docs/adr/INDEX.md` 에서 해당 API 함정 ADR 을 찾는다 |
-| 6 코드 구조 | `docs/code-architecture.md` 의 레이어와 의존 방향. 새 resolver 는 기존 매칭 정책을 따른다 |
+
+| 단계        | 대조할 곳                                                                                        |
+| --------- | -------------------------------------------------------------------------------------------- |
+| 3 호출 시나리오 | `CLAUDE.md` "명령 공통 규약" — 입력 형식, 출력 모드, 에러와 빈 상태                                              |
+| 4 인터페이스   | `CLAUDE.md` 출력 규약. 표·JSON·quiet 세 포맷터 중 무엇을 고치는지 명시한다                                        |
+| 5 API     | `src/api/client.ts` 에 재사용할 메서드가 있는지. 새 endpoint 면 `docs/adr/INDEX.md` 에서 해당 API 함정 ADR 을 찾는다 |
+| 6 코드 구조   | `docs/code-architecture.md` 의 레이어와 의존 방향. 새 resolver 는 기존 매칭 정책을 따른다                         |
+
 
 ### CLI 레포 전 규모 4단계 압축
 
 전 규모에서 8단계를 4단계로 압축 가능 — 단 압축된 각 단계 내부에서 모호함 제거는 동일하게 수행한다.
 
-| 압축 단계 | 원 단계 |
-|---|---|
-| (1+2) | 구현 가능성, 기술 스택 |
-| (3+4) | 호출 시나리오, 인터페이스 |
-| (5+6) | API, 코드 구조 |
+
+| 압축 단계 | 원 단계             |
+| ----- | ---------------- |
+| (1+2) | 구현 가능성, 기술 스택    |
+| (3+4) | 호출 시나리오, 인터페이스   |
+| (5+6) | API, 코드 구조       |
 | (7+8) | docs 영향, task 생성 |
 
-## docs 컨벤션
-
-필수 관리 문서 다섯은 코어 `SKILL.md` "필수 관리 문서" 가 소유한다. 이 레포의 추가 사항만 여기 둔다.
-
-- ADR 은 1개가 파일 1개이고 목록은 `docs/adr/INDEX.md` 다
-- `README.md` 와 `skills/` 는 외부 facing 이라 내부 추적 번호를 넣지 않는다
 
 ### 변경 유형별 docs 영향 표 (필수 — 누락 0 화)
 
 신규 작업 시 해당 행을 찾아 표시된 모든 docs 를 손댄다. 표시 없으면 미손.
 
-| 변경 유형 | CLAUDE.md | adr/ | code-architecture.md | prd.md | flow.md | data-schema.md | README.md | skills/dooray-cli/SKILL.md |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| 신규 CLI 명령 (소) | — (명령별 스펙은 CLAUDE.md 에 쌓지 않는다) | — | 디렉터리 트리, 필요 시 utils 추가 | MVP 범위 한 줄 | 사용자 흐름 섹션 | (캐시 도입 시) | 사용 예 섹션 | 빠른 참조 표, 자동화 시나리오 |
-| 신규 ADR 동반 변경 | — (ADR 목록은 `docs/adr/INDEX.md` 가 소유) | ADR 본문 | 해당 영역 ADR-NNN 역참조 | (사용자 facing 시) | (사용자 흐름 변경 시) | (스키마 결정 시) | 사용 예 (해당 명령) | 시나리오 (해당 명령) |
-| 캐시 schema / TTL 변경 | 캐시 규약 행 | ADR 갱신 (ADR-004/010) | utils/cache 섹션 | — | — | 캐시 디렉터리, 스키마 본문 | — | — |
-| 새 API 호출 패턴 (재시도/redirect 등) | — | 정책 결정 ADR | api/ 섹션, ADR-NNN 역참조 | — | — | — | — | — |
-| 기존 resolver 입력 형식 확대 | 공통 규약의 resolver 줄 (규약이 바뀔 때만) | — | resolver 주석 1줄 갱신 | — | 사용 예 (자동 분기 시나리오) | — | 사용 예 | 빠른 참조 표 |
-| 의존성 추가 / 빌드 설정 | 빌드 명령 (해당 시) | ADR 작성 전 점검 후 ADR | 기술 스택 표 | — | — | — | — | — |
-| 신규 스킬 추가 (`skills/<name>/`) | — | 배포 정책, 스킬이 의존하는 API 함정 | — (src 레이어 무변경 시) | MVP 범위 한 줄 | — (CLI 명령 흐름이 아니면 미손) | 스킬이 만드는 설정·산출물 스키마 | 내려받아 쓰는 방법 | — |
 
-**갱신 시점 분리**: `README.md` 와 `skills/` 는 코드 산출물에 의존하므로 **마지막 phase** 에서 갱신한다.
-나머지 결정 docs 를 task 생성 전에 반영하는 것은 코어 7단계가 요구한다.
+| 변경 유형                        | CLAUDE.md                            | adr/                   | code-architecture.md   | prd.md         | flow.md               | data-schema.md     | README.md    | skills/dooray-cli/SKILL.md |
+| ---------------------------- | :------------------------------------: | :----------------------: | :----------------------: | :--------------: | :---------------------: | :------------------: | :------------: | :--------------------------: |
+| 신규 CLI 명령 (소)                | — (명령별 스펙은 CLAUDE.md 에 쌓지 않는다)       | —                      | 디렉터리 트리, 필요 시 utils 추가 | MVP 범위 한 줄     | 사용자 흐름 섹션             | (캐시 도입 시)          | 사용 예 섹션      | 빠른 참조 표, 자동화 시나리오          |
+| 신규 ADR 동반 변경                 | — (ADR 목록은 `docs/adr/INDEX.md` 가 소유) | ADR 본문                 | 해당 영역 ADR-NNN 역참조      | (사용자 facing 시) | (사용자 흐름 변경 시)         | (스키마 결정 시)         | 사용 예 (해당 명령) | 시나리오 (해당 명령)               |
+| 캐시 schema / TTL 변경           | 캐시 규약 행                              | ADR 갱신 (ADR-004/010)   | utils/cache 섹션         | —              | —                     | 캐시 디렉터리, 스키마 본문    | —            | —                          |
+| 새 API 호출 패턴 (재시도/redirect 등) | —                                    | 정책 결정 ADR              | api/ 섹션, ADR-NNN 역참조   | —              | —                     | —                  | —            | —                          |
+| 기존 resolver 입력 형식 확대         | 공통 규약의 resolver 줄 (규약이 바뀔 때만)        | —                      | resolver 주석 1줄 갱신      | —              | 사용 예 (자동 분기 시나리오)     | —                  | 사용 예         | 빠른 참조 표                    |
+| 의존성 추가 / 빌드 설정               | 빌드 명령 (해당 시)                         | ADR 작성 전 점검 후 ADR      | 기술 스택 표                | —              | —                     | —                  | —            | —                          |
+| 신규 스킬 추가 (`skills/<name>/`)  | —                                    | 배포 정책, 스킬이 의존하는 API 함정 | — (src 레이어 무변경 시)      | MVP 범위 한 줄     | — (CLI 명령 흐름이 아니면 미손) | 스킬이 만드는 설정·산출물 스키마 | 내려받아 쓰는 방법   | —                          |
 
-### ADR 작성 전 점검
-
-"자명하면 ADR 로 남기지 않는다" 는 판정은 코어 7단계가 요구한다.
-이 레포에서 자명한지 보려면 `package.json`, lockfile, `tsconfig.json`, `src/api/types.ts`, 디렉터리 트리를 본다.
-그중 하나만 봐도 같은 정보를 얻으면 ADR 이 아니다.
-
-남길 가치가 있던 것은 이 레포에서 이런 성격이었다.
-
-- 라이브러리 고유 함정 (ky retry 정책, imapflow UID 처리 등)
-- 실측 수치 (캐시 응답 시간, API 제한 헤더 값 등)
-- 대안 기각 근거, 정책, 비용·성능 트레이드오프
-
-본문 구조와 넣지 않을 것은 코어 `task-create.md` "ADR 구조 템플릿" 이 소유한다.
-채워진 예시는 `docs/adr/026-wiki-api-pitfalls.md` 다.
 
 ### 공개 문서 내부 참조 제거 (필수 — README / SKILL 갱신 시)
 
 규칙과 검증 grep 은 `CLAUDE.md` "공개 문서(README · 공개 SKILL) — 내부 참조 번호 제외" 가 소유한다.
 planning 에서는 README 와 `skills/` 를 손대는 phase 마다 그 grep 을 통과시킨다.
-
-## index.json 스키마
-
-기본 형태는 코어 `task-create.md` 의 스키마를 따른다. 전체 객체를 여기 복제하지 않는다.
-
-이 레포는 중단된 plan 을 이어서 실행할 수 있도록 상태 필드를 더한다.
-코어는 "이어서 작업" 과 "새로 시작" 분기를 요구하면서 어떤 필드가 그것을 나르는지는 레포에 맡긴다.
-
-| 위치 | 필드 | 쓰임 |
-| --- | --- | --- |
-| task, phase | `status` | `pending` / `running` / `completed` / `failed` / `blocked` |
-| task | `current_phase` | 어디까지 끝났는지. 0 이 미시작 |
-| task | `error_message`, `blocked_reason` | 왜 멈췄는지. 없으면 `null` |
-
-`verify-task.sh` 는 `execution_profile` 스키마와 phase 파일 위생만 본다.
-아래는 검사하지 않으므로 직접 확인한다.
-
-- `name` 이 디렉터리명과 같은가
-- `total_phases` 가 `phases` 배열 길이와 같은가
-- `number` 가 1부터 순차 증가하는가
-- 각 `file` 이 실제로 있는가
 
 ## 검증
 
@@ -99,32 +59,3 @@ planning 에서는 README 와 `skills/` 를 손대는 phase 마다 그 grep 을 
   - 그 agent 가 이 표를 검증 기준으로 그대로 쓴다 — 표를 고치면 검증도 함께 달라진다.
 - **개인 식별 정보 노출 금지**: task 파일 제출 전 `CLAUDE.md` 의 검증 grep 을 실행해 0건을 확인한다.
 
-## plan 네이밍
-
-**형식**: `tasks/{NNN}-{task-name}/` — 코어 기본값(`plan{N}-{slug}`)과 다르다. `plan` 접두어를 붙이지 않는다.
-
-- `NNN` 은 3자리 zero-padded 순차 번호다. Issue 연결은 폴더명이 아니라 `index.json` 의 `description` 에 남긴다
-- `task-name` 은 케밥 케이스이며 카테고리 접두(`feat-`/`fix-`/`refactor-`/`chore-`/`docs-`)로 시작한다
-- 서브넘버 표기도 코어의 `plan003-2` 가 아니라 `006-2-feat-...` 형태다
-
-### 번호 확인
-
-번호 선점 원칙과 서브넘버 규칙은 코어 `SKILL.md` "동시성 안전" 이 소유한다.
-다만 이 레포는 번호가 브랜치가 아니라 `tasks/` 디렉터리에 있어 확인 명령이 다르다.
-
-```bash
-# cwd: <repo root>
-ls tasks/ | grep -E "^[0-9]{3}-" | sort
-gh pr list --state open --json number,headRefName,title --jq '.[] | "\(.headRefName) \(.title)"'
-```
-
-번호 없는 레거시 폴더는 세지 않는다. 소급해서 이름을 바꾸지 않는다.
-
-## branch 와 핸드오프
-
-브랜치 전략과 docs-first 두 커밋 순서는 코어 `SKILL.md` 의 "동시성 안전" 과 "완료 후" 가 소유한다.
-이 레포의 차이만 여기 둔다.
-
-- 브랜치 이름은 `plan{NNN}-{task-name}` 으로, task 디렉터리 `tasks/{NNN}-{task-name}` 와 1:1 대응한다
-- main 에 docs 를 먼저 넣지 않는다. `build-with-teams` 의 사전 검증이 원격 plan 브랜치에서 task 를 찾으므로 성립하지 않는다
-- 핸드오프는 `/build-with-teams` 로 안내하고 `tasks/{NNN}-{task-name}` 디렉터리를 인자로 준다

--- a/.claude/planning-overlay.md
+++ b/.claude/planning-overlay.md
@@ -5,14 +5,15 @@
 
 ## 도메인: CLI (TypeScript / Commander.js)
 
-- **3단계 (호출 시나리오)**: 명령 인자·플래그 조합, `--json`/`--quiet` 출력 분기, resolver 입력 형식(이름/이메일/id/URL) 자동 분기 시나리오를 구체화한다.
-  - 엣지 케이스: 정상 / 에러 / 빈 상태 / 모호 매칭(후보 목록) 점검
-- **4단계 (인터페이스)**: 명령 시그니처, 옵션 이름, `stdout`(데이터) / `stderr`(스피너·에러) 출력 분리를 설계한다.
-  - table/json/quiet 3 포맷터 중 무엇을 갱신하는지 명시
-- **5단계 (API)**: 기존 `DoorayApiClient`(`src/api/client.ts`) 메서드 재사용 가능 여부를 확인한다.
-  - 새 endpoint 면 307 redirect·retry 정책(ADR-002/015) 적용 여부 점검
-- **6단계 (코드 구조)**: 레이어는 `api/` → `resolvers/` → `commands/` → `formatters/`.
-  - 새 resolver 는 기존 정책(정확일치 → 이름 부분일치 → 모호 시 에러+후보)을 따르는지 확인
+코어 `step-3` 부터 `step-6` 이 도메인 변형을 오버레이에 위임한다.
+각 단계가 대조할 소유 문서는 아래와 같다. 규약 본문을 여기 옮겨 적지 않는다 — 옮기면 갈라진다.
+
+| 단계 | 대조할 곳 |
+| --- | --- |
+| 3 호출 시나리오 | `CLAUDE.md` "명령 공통 규약" — 입력 형식, 출력 모드, 에러와 빈 상태 |
+| 4 인터페이스 | `CLAUDE.md` 출력 규약. 표·JSON·quiet 세 포맷터 중 무엇을 고치는지 명시한다 |
+| 5 API | `src/api/client.ts` 에 재사용할 메서드가 있는지. 새 endpoint 면 `docs/adr/INDEX.md` 에서 해당 API 함정 ADR 을 찾는다 |
+| 6 코드 구조 | `docs/code-architecture.md` 의 레이어와 의존 방향. 새 resolver 는 기존 매칭 정책을 따른다 |
 
 ### CLI 레포 전 규모 4단계 압축
 
@@ -27,8 +28,10 @@
 
 ## docs 컨벤션
 
-5 핵심 docs — `docs/prd.md` / `docs/flow.md` / `docs/adr/`(ADR 1개 = 파일 1개, 목록은 `docs/adr/INDEX.md`) / `docs/data-schema.md` / `docs/code-architecture.md`.
-`CLAUDE.md` 는 코드 작업 지침. `README.md` 와 `skills/dooray-cli/SKILL.md` 는 외부 facing 사용자 가이드.
+필수 관리 문서 다섯은 코어 `SKILL.md` "필수 관리 문서" 가 소유한다. 이 레포의 추가 사항만 여기 둔다.
+
+- ADR 은 1개가 파일 1개이고 목록은 `docs/adr/INDEX.md` 다
+- `README.md` 와 `skills/` 는 외부 facing 이라 내부 추적 번호를 넣지 않는다
 
 ### 변경 유형별 docs 영향 표 (필수 — 누락 0 화)
 
@@ -44,107 +47,70 @@
 | 의존성 추가 / 빌드 설정 | 빌드 명령 (해당 시) | ADR 작성 전 점검 후 ADR | 기술 스택 표 | — | — | — | — | — |
 | 신규 스킬 추가 (`skills/<name>/`) | — | 배포 정책, 스킬이 의존하는 API 함정 | — (src 레이어 무변경 시) | MVP 범위 한 줄 | — (CLI 명령 흐름이 아니면 미손) | 스킬이 만드는 설정·산출물 스키마 | 내려받아 쓰는 방법 | — |
 
-**갱신 시점 분리**: planning 결정 docs(`adr/`·`code-architecture.md`·`CLAUDE.md`·`data-schema.md`·`flow.md`·`prd.md`)는 **task 생성 전 즉시 반영하고 commit**.
-`README.md` 와 `skills/dooray-cli/`(사용자 가이드)는 코드 산출물에 의존하므로 **마지막 phase** 에서 갱신한다.
-이 분리를 phase 작성 시 명시적으로 따른다.
-planning 결정 docs 를 phase 안에서 고치면 안 된다.
+**갱신 시점 분리**: `README.md` 와 `skills/` 는 코드 산출물에 의존하므로 **마지막 phase** 에서 갱신한다.
+나머지 결정 docs 를 task 생성 전에 반영하는 것은 코어 7단계가 요구한다.
 
-### ADR 작성 전 점검 (필수 자문)
+### ADR 작성 전 점검
 
-아래 3개에 **모두 NO** 여야 ADR 로 기록한다. 하나라도 YES 면 대안 채널(`CLAUDE.md` 규칙 / 코드 주석 / 커밋 메시지 / 다른 docs)로 내려보낸다.
+"자명하면 ADR 로 남기지 않는다" 는 판정은 코어 7단계가 요구한다.
+이 레포에서 자명한지 보려면 `package.json`, lockfile, `tsconfig.json`, `src/api/types.ts`, 디렉터리 트리를 본다.
+그중 하나만 봐도 같은 정보를 얻으면 ADR 이 아니다.
 
-1. `package.json`·lockfile·`tsconfig.json`·`src/api/types.ts`·디렉터리 트리 중 어느 하나를 보면 같은 정보를 얻는가?
-2. "왜 X 를 선택했다"를 1~2 문장 이상으로 설명하기 어려운가?
-3. 다른 프로젝트에서도 일반적으로 하는 선택인가?
-
-**유지 적격**(3개 모두 NO):
+남길 가치가 있던 것은 이 레포에서 이런 성격이었다.
 
 - 라이브러리 고유 함정 (ky retry 정책, imapflow UID 처리 등)
-- 실험 결과 (캐시 cold/warm 응답 시간 등 실측 수치)
-- 대안 기각 근거
-- 정책·규칙
-- 비용·성능 트레이드오프
+- 실측 수치 (캐시 응답 시간, API 제한 헤더 값 등)
+- 대안 기각 근거, 정책, 비용·성능 트레이드오프
 
-**ADR 구조**: `## ADR-NNN: {제목}` → **결정** → **맥락** → **대안 기각** → (선택) **트레이드오프**/**적용 범위**.
-
-**금지**:
-
-- 코드 블록 10줄 이상 (1~3줄 식별자 예시만 허용)
-- 파일 경로 3개 이상 나열
-- "변경 항목 1/2/3/4" 작업 내역
-- CLAUDE.md 스택 규칙 반복
+본문 구조와 넣지 않을 것은 코어 `task-create.md` "ADR 구조 템플릿" 이 소유한다.
+채워진 예시는 `docs/adr/026-wiki-api-pitfalls.md` 다.
 
 ### 공개 문서 내부 참조 제거 (필수 — README / SKILL 갱신 시)
 
-`README.md` 와 `skills/` 는 사용자·에이전트 대상이라 `ADR-NNN`, `Issue #NN`, `task NNN` 같은 내부 참조를 남기지 않는다.
-문장에 녹은 참조도 번호를 빼고 재작성한다.
+규칙과 검증 grep 은 `CLAUDE.md` "공개 문서(README · 공개 SKILL) — 내부 참조 번호 제외" 가 소유한다.
+planning 에서는 README 와 `skills/` 를 손대는 phase 마다 그 grep 을 통과시킨다.
 
-검증 grep 은 `CLAUDE.md` "공개 문서(README · 공개 SKILL) — 내부 참조 번호 제외" 섹션에 있다.
+## index.json 스키마
 
-## index.json 스키마 (레포 특화 — `build-with-teams` 강제)
+기본 형태는 코어 `task-create.md` 의 스키마를 따른다. 전체 객체를 여기 복제하지 않는다.
 
-`build-with-teams` 워크플로우가 아래 필드를 엄격히 강제한다.
-코어 예시와 다른 점:
+이 레포는 중단된 plan 을 이어서 실행할 수 있도록 상태 필드를 더한다.
+코어는 "이어서 작업" 과 "새로 시작" 분기를 요구하면서 어떤 필드가 그것을 나르는지는 레포에 맡긴다.
 
-- task 레벨 — `related_docs`/`depends_on` 대신 `updated_at`/`current_phase`/`error_message`/`blocked_reason` 필수
-- phase 레벨 — `model` 대신 `allowedTools` 필수
+| 위치 | 필드 | 쓰임 |
+| --- | --- | --- |
+| task, phase | `status` | `pending` / `running` / `completed` / `failed` / `blocked` |
+| task | `current_phase` | 어디까지 끝났는지. 0 이 미시작 |
+| task | `error_message`, `blocked_reason` | 왜 멈췄는지. 없으면 `null` |
 
-필드 목록:
+`verify-task.sh` 는 `execution_profile` 스키마와 phase 파일 위생만 본다.
+아래는 검사하지 않으므로 직접 확인한다.
 
-```jsonc
-{
-  "name": "{NNN}-{task-name}",           // 디렉터리명과 일치
-  "description": "무엇을 구현하는 task인지 한 줄 설명",
-  "created_at": "2026-07-14T00:00:00Z",   // ISO 8601
-  "updated_at": "2026-07-14T00:00:00Z",   // team-lead 자동 갱신
-  "status": "pending",                    // pending | running | completed | failed | blocked
-  "current_phase": 0,                     // 0 = 미시작
-  "total_phases": 3,                      // phases 배열 길이와 일치
-  "error_message": null,
-  "blocked_reason": null,
-  "phases": [
-    {
-      "number": 1,                        // 1부터 순차 증가
-      "title": "phase 제목",
-      "file": "phase-01.md",
-      "status": "pending",
-      "allowedTools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
-      "model": "sonnet"                   // (선택) haiku | sonnet | opus
-    }
-  ]
-}
-```
-
-모든 필드 필수 — 생략하면 build-with-teams 가 task 를 읽지 못한다.
-
-검증 체크리스트:
-
-- `total_phases` == `phases` 배열 길이
-- 모든 phase 에 `number`/`title`/`file`/`status`/`allowedTools` 존재
-- `number` 가 1부터 순차 증가
-- 각 `file` 이 실제 존재
+- `name` 이 디렉터리명과 같은가
+- `total_phases` 가 `phases` 배열 길이와 같은가
+- `number` 가 1부터 순차 증가하는가
+- 각 `file` 이 실제로 있는가
 
 ## 검증
 
-- **critic/code-review 회피 패턴**: task 파일 제출 전 아래 경로를 self-check 한다.
-  - `docs/pitfalls/plan/` — critic 의 plan 평가 회피
-  - `docs/pitfalls/team/` — team 협업 회피
-  - `docs/pitfalls/code-review/` — code-reviewer 의 코드 검사 회피
+- **반복 함정 목록**: 코어가 요구하는 task 제출 전 self-check 의 대상은 `docs/pitfalls/` 다. 어느 카테고리를 볼지는 그 안의 `INDEX.md` 라우터가 정한다.
 - **docs-verifier 흡수 원칙**: docs-verifier(`.claude/agents/dooray-cli-docs-verifier.md`)의 반복 지적은 별도 회고 docs 를 신설하지 않는다.
-  - 위 "변경 유형별 docs 영향 표"에 행 추가/보강으로 흡수한다.
-  - 코어 `build-with-teams/SKILL.md` 의 docs-verifier 검증 단계가 이 표를 그대로 검증 기준으로 쓴다 — 표를 수정하면 그쪽 검증도 함께 달라지는지 확인한다.
-- **개인 식별 정보 노출 금지**: task 파일 제출 전 `CLAUDE.md` "개인 식별 정보 / 사내 식별자 노출 금지" 섹션의 검증 grep 을 실행해 0건을 확인한다.
-  - 코어 planning 스킬의 task 자가 점검 항목에 더해 이 검사도 수행한다.
+  - 위 "변경 유형별 docs 영향 표"에 행 추가나 보강으로 흡수한다.
+  - 그 agent 가 이 표를 검증 기준으로 그대로 쓴다 — 표를 고치면 검증도 함께 달라진다.
+- **개인 식별 정보 노출 금지**: task 파일 제출 전 `CLAUDE.md` 의 검증 grep 을 실행해 0건을 확인한다.
 
 ## plan 네이밍
 
 **형식**: `tasks/{NNN}-{task-name}/` — 코어 기본값(`plan{N}-{slug}`)과 다르다. `plan` 접두어를 붙이지 않는다.
 
-- `NNN` = 3자리 zero-padded 순차 번호. Issue 연결은 폴더명이 아니라 `index.json`의 `description` 필드에 남긴다.
-- `task-name` = 케밥 케이스 간결 요약이며 카테고리 접두(`feat-`/`fix-`/`refactor-`/`chore-`/`docs-`)로 시작한다.
-- `index.json`의 `name` 필드는 폴더명과 **동일**하게 설정.
+- `NNN` 은 3자리 zero-padded 순차 번호다. Issue 연결은 폴더명이 아니라 `index.json` 의 `description` 에 남긴다
+- `task-name` 은 케밥 케이스이며 카테고리 접두(`feat-`/`fix-`/`refactor-`/`chore-`/`docs-`)로 시작한다
+- 서브넘버 표기도 코어의 `plan003-2` 가 아니라 `006-2-feat-...` 형태다
 
-### 번호 충돌 방지 (필수)
+### 번호 확인
+
+번호 선점 원칙과 서브넘버 규칙은 코어 `SKILL.md` "동시성 안전" 이 소유한다.
+다만 이 레포는 번호가 브랜치가 아니라 `tasks/` 디렉터리에 있어 확인 명령이 다르다.
 
 ```bash
 # cwd: <repo root>
@@ -152,19 +118,13 @@ ls tasks/ | grep -E "^[0-9]{3}-" | sort
 gh pr list --state open --json number,headRefName,title --jq '.[] | "\(.headRefName) \(.title)"'
 ```
 
-다음 가용 번호(가장 큰 번호 다음 값) 사용. 번호 없는 레거시 폴더는 count 에서 제외(소급 rename 금지).
+번호 없는 레거시 폴더는 세지 않는다. 소급해서 이름을 바꾸지 않는다.
 
-### 서브넘버 규칙
+## branch 와 핸드오프
 
-동일 도메인 확장/동일 패턴 복제 후속 작업은 같은 번호에 서브넘버를 붙인다 (예: `006-feat-wiki-page-edit-non-interactive` → `006-2-feat-wiki-page-bulk-edit`). 서로 다른 도메인/독립 실행 가능이면 별도 번호.
+브랜치 전략과 docs-first 두 커밋 순서는 코어 `SKILL.md` 의 "동시성 안전" 과 "완료 후" 가 소유한다.
+이 레포의 차이만 여기 둔다.
 
-## branch / 커밋 / 핸드오프
-
-- **task 파일과 planning docs 는 plan 브랜치에 commit** — main 직접 commit 금지.
-  - 브랜치 이름은 `plan{NNN}-{task-name}` 으로, task 디렉터리 `tasks/{NNN}-{task-name}` 와 1:1 대응한다.
-  - planning 은 PR 을 만들지 않는다. 이 브랜치에 구현 커밋이 이어 붙어 PR 1개로 닫힌다 — 계획과 코드가 같은 PR 에서 함께 검토된다.
-  - main 에 docs 를 먼저 넣으면 코드가 머지되지 않아도 문서만 앞서 나가고, `build-with-teams` 의 사전 검증(원격 plan 브랜치에 task 존재)도 성립하지 않는다.
-- **커밋 순서 (docs-first, 2개 커밋으로 분리)** — 두 커밋 모두 plan 브랜치에 쌓는다:
-  1. docs 최신화 커밋하고 push (`docs(scope): ...`) — task 생성 전 필수, 건너뛰기 금지
-  2. task 파일(`index.json` 과 `phase-*.md`) 커밋하고 push — 실행 전 필수
-- **핸드오프**: `/build-with-teams` 로 안내한다. `tasks/{NNN}-{task-name}` 디렉터리를 인자로 받아 Agent Teams 가시적 협업(team-lead·critic·executor·docs-verifier)을 수행한다.
+- 브랜치 이름은 `plan{NNN}-{task-name}` 으로, task 디렉터리 `tasks/{NNN}-{task-name}` 와 1:1 대응한다
+- main 에 docs 를 먼저 넣지 않는다. `build-with-teams` 의 사전 검증이 원격 plan 브랜치에서 task 를 찾으므로 성립하지 않는다
+- 핸드오프는 `/build-with-teams` 로 안내하고 `tasks/{NNN}-{task-name}` 디렉터리를 인자로 준다

--- a/.claude/review-fix-overlay.md
+++ b/.claude/review-fix-overlay.md
@@ -12,12 +12,12 @@ conflict 해결 시 코어의 "merge 또는 rebase" 분기에서 **`git merge or
 
 | 증상 (로그 키워드) | 원인 | 해결 |
 | --- | --- | --- |
-| `does not provide an export named 'styleText'` / `node:util` | Node 18 ↔ 의존성이 Node 20.12+ API 사용 (vitest 4 / rolldown 등) | `.github/workflows/ci.yml` `NODE_VERSION` 을 20 으로 바꾸고 `package.json` `engines.node >=20` 설정 |
+| `does not provide an export named 'styleText'` / `node:util` | CI 의 Node 가 의존성이 요구하는 버전보다 낮다 | `.github/workflows/ci.yml` 의 `NODE_VERSION` 과 `package.json` 의 `engines.node` 를 대조해 올린다. 두 값이 현재 기준이다 |
 | `ERR_PNPM_OUTDATED_LOCKFILE` / `frozen-lockfile` 실패 | 로컬에서 의존성 변경 후 lockfile 미커밋 | 로컬 `pnpm install` 후 `pnpm-lock.yaml` 같이 커밋 |
 | `Cannot find module 'X'` | 새 import 추가했는데 의존성 미설치 / package.json 미커밋 | `pnpm add X` 를 실행하고 `package.json` 과 lockfile 을 같이 커밋 |
 | `SyntaxError: Unexpected token` 빌드 단계 | tsup target 불일치 또는 Node 버전 mismatch | 위 styleText 건과 동일 원인 — Node 버전 점검 |
 | `Test Files X failed` / vitest assertion | 테스트 회귀 | 실패 테스트 파일 직접 읽고 픽스 |
-| Lint/format 실패 | dooray-cli 는 별도 lint 단계 없음 — `pnpm build` (tsup/tsc) 가 타입 검증을 겸함 | 타입 에러로 취급하고 수정 |
+| 타입 에러 | dooray-cli 에 별도 lint 단계는 없다. 빌드는 tsup(esbuild) 이라 타입을 보지 않는다 | `pnpm tsc --noEmit` 으로 잡는다. `pnpm run build` 는 타입 오류가 있어도 통과한다 |
 
 표에 없는 증상은 사용자에게 "CI 로그 일부와 의심 원인" 을 제시하고 진행 방향을 확인한다.
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -92,14 +92,19 @@ git log ${LAST_TAG}..HEAD --grep="#[0-9]" --oneline
 
 ### 4. 개인 식별 정보 / 사내 식별자 노출 검증 (필수, 실패 시 중단)
 
-`CLAUDE.md` "개인 식별 정보 / 사내 식별자 노출 금지 (public OSS)" 섹션의 검증 grep 을 모두 실행한다 (현재 3개).
-grep 패턴 정의는 거기에서 단일 소스로 관리 — 본 skill 은 실행 시점과 후속 처리만 정의.
+```bash
+# cwd: <repo root>
+bash scripts/check-pii.sh
+bash scripts/check-public-refs.sh
+```
 
-**히트가 있으면**:
+패턴과 화이트리스트는 두 스크립트가 소유한다. 본 skill 은 실행 시점과 후속 처리만 정의한다.
+
+**종료 코드가 0 이 아니면**:
 
 - 사용자에게 즉시 보고하고 위치를 노출
-- CLAUDE.md 개인 식별 정보 섹션의 placeholder 가이드 (`<project>` / `<tenant>` / `<postId>` 등) 또는 dummy 패턴으로 교체 후 보완 commit
-- 보완 commit 후 grep 재실행 → 0건 확인 후 다음 단계 진행
+- `CLAUDE.md` 의 placeholder 표(`<project>` / `<tenant>` / `<postId>` 등)를 따라 교체하고 보완 commit
+- 보완 commit 후 다시 실행해 통과를 확인하고 다음 단계로 간다
 - **사용자가 "내부 사용 OK" 로 명시 동의하지 않는 한 release 차단**
 
 ### 5. 버전 범프

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,14 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
 
+      # 의존성 설치 전에 돈다. 문서 검사는 Node 가 필요 없고,
+      # 공개 저장소라 식별자 노출은 한 번 새면 되돌리기 어렵다.
+      - name: Check for exposed identifiers
+        run: bash scripts/check-pii.sh
+
+      - name: Check public docs for internal references
+        run: bash scripts/check-public-refs.sh
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ dooray                # 글로벌 링크 시
 
 ## 개인 식별 정보 / 사내 식별자 노출 금지 (public OSS)
 
-아래 식별자는 git 추적 대상 어디에도 넣지 않는다 — 검증 grep 의 `SCAN` 목록이 대상 범위다.
+아래 식별자는 git 추적 대상 어디에도 넣지 않는다. 검사 범위는 `scripts/check-pii.sh` 의 `SCAN` 목록이다.
 `src/` 의 테스트 fixture 와 에러 메시지 예시, 이슈 본문도 포함한다. 항상 placeholder 를 쓴다.
 
 구체적인 사내 식별자는 이 파일에도 적지 않는다 — CLAUDE.md 자체가 public 이라 나열이 곧 노출이다.
@@ -79,40 +79,18 @@ dooray                # 글로벌 링크 시
 | Dooray orgId (실제 19자리)                                        | `<orgId>`                                |
 
 
-**검증 grep** (commit/이슈 작성/release 전 실행):
+**검증** (commit·이슈 작성·release 전 실행):
 
 ```bash
 # cwd: <repo root>
-# 검사 대상 — .claude/ 와 tasks/ 도 git 추적 대상이므로 포함한다
-# 배열 + "${SCAN[@]}" 로 쓴다. 두 셸이 각각 다른 방식으로 조용히 망가지기 때문이다
-#   - 문자열 변수 + $SCAN: zsh 는 단어 분할을 하지 않아 "a b c" 전체가 한 경로가 된다
-#   - 배열 + unquoted $SCAN: bash 는 첫 원소로 축약해 README.md 만 검사한다
-SCAN=(README.md skills/ docs/ CLAUDE.md .claude/ .github/ scripts/ tasks/ src/)
-# 허용 dummy ID + 공개 helpdesk 페이지 ID
-OK_IDS="1234567890123456789|9876543210987654321|2939987647631384419"
-OK_IDS="$OK_IDS|1111222233334444555|2222333344445555666|3333444455556666777"
-OK_IDS="$OK_IDS|4444555566667777888|9999888877776666555|9999999999999999999"
-OK_IDS="$OK_IDS|1111111111111111111|2222222222222222222|123456789012345"
-
-# 1) 공개 도메인 화이트리스트 밖의 URL/이메일 도메인 (사내 도메인 가능성) — 사내 도메인은 여기 명시하지 않는다
-#    https:// 또는 @ prefix 를 요구해 코드의 property 접근(.com/.net) false positive 를 배제
-grep -rnoE "(https?://|@)[A-Za-z0-9.-]+\.(com|co\.kr|net)" "${SCAN[@]}" 2>/dev/null \
-  | grep -vE "dooray\.com|gov-dooray\.com|dooray\.co\.kr|gov-dooray\.co\.kr|helpdesk\.dooray\.com|github\.com|npmjs\.com|example\.com|youtube\.com|anthropic\.com|claude\.com|x\.com"
-# 0건이어야 함 (남으면 사내/미허용 도메인 가능성 — placeholder 또는 화이트리스트 검토)
-
-# 2) 19자리 numeric
-grep -rnE "[0-9]{15,}" "${SCAN[@]}" 2>/dev/null | grep -vE "$OK_IDS|<postId>|<pageId>"
-# 0건이어야 함 (남으면 실제값 가능성 — 검토 후 placeholder 또는 dummy로 교체)
-
-# 3) 사내 프로젝트 코드 — 화이트리스트 방식으로는 잡히지 않는다 (임의 문자열)
-#    CLI 예시의 project 자리 값을 뽑아 placeholder 인지 눈으로 확인한다
-grep -rohE "(post (create|list|get|search)|project (list|members|groups|tags|templates|workflows)|wiki (pages|tree)) [A-Za-z][A-Za-z0-9_-]{2,}" "${SCAN[@]}" 2>/dev/null \
-  | awk '{print $NF}' | sort -u
-# 허용: my-project / testproj / NONEXIST (가상 예시) + body / https / meta (패턴 오탐)
-# 그 밖의 값이 나오면 사내 프로젝트 코드인지 확인 후 placeholder 로 교체
+bash scripts/check-pii.sh
 ```
 
-`/release` 스킬 4단계가 이 점검을 포함한다 — release 전 자동 검증된다.
+세 가지를 본다 — 공개 화이트리스트 밖의 도메인, 허용 목록 밖의 15자리 이상 숫자, 예시에 쓰인 낯선 project 값.
+위반을 출력하고 종료 코드 1 로 끝난다. 화이트리스트는 그 스크립트가 소유한다.
+
+가상 예시를 새로 쓰려면 스크립트의 `OK_PROJECTS` 나 `OK_DOMAINS` 에 먼저 추가한다.
+CI 가 같은 스크립트를 돌리므로 통과하지 않으면 PR 이 막힌다.
 
 ## 공개 문서(README · 공개 SKILL) — 내부 참조 번호 제외
 
@@ -123,12 +101,14 @@ grep -rohE "(post (create|list|get|search)|project (list|members|groups|tags|tem
 - 괄호 참조(`... (ADR-027)`)는 삭제하고, 문장에 녹은 참조는 번호를 빼고 재작성한다
 - 내부 문서(`CLAUDE.md`, `docs/*`, `tasks/*`)는 내부 참조를 그대로 유지한다
 
-**검증 grep** (README/SKILL 작성·수정 후 실행):
+**검증** (README·SKILL 작성·수정 후 실행):
 
 ```bash
-grep -rnE "ADR-[0-9]+|Issue #[0-9]+|task [0-9]+" README.md skills/ 2>/dev/null
-# 0건이어야 함
+# cwd: <repo root>
+bash scripts/check-public-refs.sh
 ```
+
+CI 가 같은 스크립트를 돌린다.
 
 ## `tasks/` — 완료된 plan 은 실행 기록이다
 

--- a/scripts/check-pii.sh
+++ b/scripts/check-pii.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# 개인 식별 정보와 사내 식별자가 git 추적 파일에 들어갔는지 검사한다.
+#
+# 정책과 대체 표기는 CLAUDE.md "개인 식별 정보 / 사내 식별자 노출 금지" 가 소유한다.
+# 이 스크립트는 그 정책의 실행 경로다 — 화이트리스트는 여기가 단일 소스다.
+#
+# 사용법: bash scripts/check-pii.sh   (cwd 는 저장소 루트)
+# 위반을 stdout 으로 출력하고 종료 코드 1, 깨끗하면 0.
+#
+# shebang 으로 bash 를 고정한다. zsh 는 배열을 다르게 확장해
+# 검사 대상이 조용히 첫 원소 하나로 줄어든 적이 있다.
+set -uo pipefail
+
+SCAN=(README.md skills/ docs/ CLAUDE.md .claude/ .github/ scripts/ tasks/ src/)
+
+# 공개 도메인. 이 목록 밖의 도메인은 사내 도메인일 수 있다고 본다.
+OK_DOMAINS="dooray\.com|gov-dooray\.com|dooray\.co\.kr|gov-dooray\.co\.kr"
+OK_DOMAINS="$OK_DOMAINS|helpdesk\.dooray\.com|github\.com|npmjs\.com|example\.com"
+OK_DOMAINS="$OK_DOMAINS|youtube\.com|anthropic\.com|claude\.com|x\.com"
+
+# 문서에 써도 되는 dummy ID 와 공개 helpdesk 페이지 ID.
+OK_IDS="1234567890123456789|9876543210987654321|2939987647631384419"
+OK_IDS="$OK_IDS|1111222233334444555|2222333344445555666|3333444455556666777"
+OK_IDS="$OK_IDS|4444555566667777888|9999888877776666555|9999999999999999999"
+OK_IDS="$OK_IDS|1111111111111111111|2222222222222222222|123456789012345"
+
+# CLI 예시의 project 자리에 와도 되는 값.
+# 앞 셋은 가상 예시이고, 뒤 셋은 명령 패턴이 잘못 잡아내는 단어다.
+# `<project>` 같은 placeholder 는 아래 정규식이 `<` 로 시작하는 값을 보지 않아 애초에 안 잡힌다.
+OK_PROJECTS="my-project testproj NONEXIST body https meta"
+
+failed=0
+
+report() {
+  failed=1
+  printf '\n[위반] %s\n' "$1"
+  shift
+  printf '%s\n' "$@"
+}
+
+# 1) 공개 화이트리스트 밖의 URL·이메일 도메인
+#    https:// 또는 @ 접두를 요구해 코드의 property 접근(.com/.net)을 배제한다
+domains=$(grep -rnoE "(https?://|@)[A-Za-z0-9.-]+\.(com|co\.kr|net)" "${SCAN[@]}" 2>/dev/null \
+  | grep -vE "$OK_DOMAINS")
+[ -n "$domains" ] && report "화이트리스트 밖 도메인 — placeholder 로 바꾸거나 이 스크립트의 OK_DOMAINS 를 검토한다" "$domains"
+
+# 2) 15자리 이상 numeric — 실제 Dooray ID 일 수 있다
+ids=$(grep -rnE "[0-9]{15,}" "${SCAN[@]}" 2>/dev/null \
+  | grep -vE "$OK_IDS|<postId>|<pageId>")
+[ -n "$ids" ] && report "허용 목록 밖의 긴 숫자 — 실제 ID 인지 확인하고 placeholder 나 dummy 로 바꾼다" "$ids"
+
+# 3) CLI 예시의 project 인자
+#    프로젝트 코드는 임의 문자열이라 패턴으로 못 거른다. 허용 목록 밖이면 사람이 확인한다
+projects=$(grep -rohE "(post (create|list|get|search)|project (list|members|groups|tags|templates|workflows)|wiki (pages|tree)) [A-Za-z][A-Za-z0-9_-]{2,}" "${SCAN[@]}" 2>/dev/null \
+  | awk '{print $NF}' | sort -u)
+unknown=""
+for p in $projects; do
+  case " $OK_PROJECTS " in
+    *" $p "*) ;;
+    *) unknown="$unknown$p"$'\n' ;;
+  esac
+done
+[ -n "$unknown" ] && report "예시에 쓰인 낯선 project 값 — 사내 코드면 placeholder 로 바꾸고, 가상 예시면 이 스크립트의 OK_PROJECTS 에 추가한다" "$unknown"
+
+if [ "$failed" -eq 0 ]; then
+  echo "개인 식별 정보 검사 통과"
+fi
+exit "$failed"

--- a/scripts/check-pii.sh
+++ b/scripts/check-pii.sh
@@ -39,14 +39,20 @@ report() {
 }
 
 # 1) 공개 화이트리스트 밖의 URL·이메일 도메인
-#    https:// 또는 @ 접두를 요구해 코드의 property 접근(.com/.net)을 배제한다
+#    https:// 또는 @ 접두를 요구해 코드의 property 접근(.com/.net)을 배제한다.
+#
+#    화이트리스트는 호스트 경계에 앵커한다. 앵커가 없으면 `dooray.com` 이
+#    `evil-dooray.com` 안에서도 매치되어 typosquat 이 그대로 통과한다.
 domains=$(grep -rnoE "(https?://|@)[A-Za-z0-9.-]+\.(com|co\.kr|net)" "${SCAN[@]}" 2>/dev/null \
-  | grep -vE "$OK_DOMAINS")
+  | grep -vE "(https?://|@|\.)($OK_DOMAINS)\$")
 [ -n "$domains" ] && report "화이트리스트 밖 도메인 — placeholder 로 바꾸거나 이 스크립트의 OK_DOMAINS 를 검토한다" "$domains"
 
 # 2) 15자리 이상 numeric — 실제 Dooray ID 일 수 있다
-ids=$(grep -rnE "[0-9]{15,}" "${SCAN[@]}" 2>/dev/null \
-  | grep -vE "$OK_IDS|<postId>|<pageId>")
+#
+#    `-o` 로 매치 단위로 뽑는다. 줄 단위로 거르면 허용 ID 와 실제 ID 가
+#    한 줄에 같이 있을 때 그 줄 전체가 걸러져 실제 ID 가 빠져나간다.
+ids=$(grep -rnoE "[0-9]{15,}" "${SCAN[@]}" 2>/dev/null \
+  | grep -vE ":($OK_IDS)\$")
 [ -n "$ids" ] && report "허용 목록 밖의 긴 숫자 — 실제 ID 인지 확인하고 placeholder 나 dummy 로 바꾼다" "$ids"
 
 # 3) CLI 예시의 project 인자

--- a/scripts/check-public-refs.sh
+++ b/scripts/check-public-refs.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# 공개 문서에 내부 추적 번호가 남았는지 검사한다.
+#
+# 이유는 CLAUDE.md "공개 문서(README · 공개 SKILL) — 내부 참조 번호 제외" 가 소유한다.
+# 요약하면 사용자는 ADR 맥락을 모르고, 이 문서를 그대로 에이전트에 붙여 쓰기도 한다.
+#
+# 사용법: bash scripts/check-public-refs.sh   (cwd 는 저장소 루트)
+# 위반을 stdout 으로 출력하고 종료 코드 1, 깨끗하면 0.
+set -uo pipefail
+
+TARGETS=(README.md skills/)
+
+hits=$(grep -rnE "ADR-[0-9]+|Issue #[0-9]+|task [0-9]+" "${TARGETS[@]}" 2>/dev/null)
+
+if [ -n "$hits" ]; then
+  printf '[위반] 공개 문서에 내부 추적 번호가 있다 — 번호를 빼고 문장을 다시 쓴다\n'
+  printf '%s\n' "$hits"
+  exit 1
+fi
+
+echo "공개 문서 내부 참조 검사 통과"


### PR DESCRIPTION
하네스 문서를 실측 기준으로 감사하고, 노출 검증을 스크립트와 CI 로 옮긴다.

## 사실 오류 정정

문서가 주장하는 것을 실제로 실행해 확인했다.

| 고친 것 | 실측 |
| --- | --- |
| "`pnpm build` 가 타입 검증을 겸함" | 거짓. 타입 오류를 심으니 build 는 통과하고 `tsc --noEmit` 만 잡았다 |
| CI Node 해결책 "20 으로" | 현재 CI 는 `22` 다. 고정값 대신 두 설정을 대조하도록 바꿨다 |
| "상황별 ADR 참조 표" | `CLAUDE.md` 에 없다. 두 오버레이가 같은 유령을 가리켰다 |
| "코어의 legacy 절차" | 코어 `docs-check` 에 없다 |

첫 번째가 실질적이다. 그 문구를 따르면 리뷰 반영에서 타입 오류를 놓친다.

## 감사 범위 누락

새 스킬을 추가한 뒤 `docs-check` 오버레이의 목록 명령과 agent 프롬프트를 갱신하지 않아 `skills/dooray-persona` 가 6축 감사 대상에서 빠져 있었다.

## planning 오버레이 축소

코어가 이미 소유하거나 모델이 문맥에서 판단할 수 있는 서술을 뺐다. 170줄에서 61줄로 줄었다.

뺀 것은 필수 관리 문서 나열, ADR 구조와 금지 목록, branch 전략과 커밋 순서, 번호 선점과 서브넘버 원칙, 도메인 절의 레이어·resolver·출력 규약 본문이다.

남긴 것은 코어가 오버레이에 명시적으로 위임한 것과 이 레포에만 있는 것이다 — 단계별 대조 대상, 4단계 압축, 변경 유형별 docs 영향 표, 공개 문서 참조 제거, 검증 세 항목.

`index.json` 스키마 블록은 실제로 갈라져 있었다. 코어는 `execution_profile` 을 요구하는데 오버레이는 `model` 을 권하고 있었다.

## 노출 검증 스크립트화

`CLAUDE.md` 가 28줄짜리 grep 블록을 들고 일곱 곳이 "그걸 실행하라" 고 가리키고 있었다.

- `scripts/check-pii.sh` — 도메인, 15자리 이상 숫자, 예시 project 값
- `scripts/check-public-refs.sh` — 공개 문서의 내부 추적 번호
- 둘 다 위반을 출력하고 종료 코드 1
- CI 가 의존성 설치 전에 돈다

프로젝트 코드 검사는 원래 사람이 목록을 눈으로 확인하는 방식이었다. 허용 값 목록을 두고 그 밖이면 실패하도록 바꿔 자동 판정이 된다.

블록에 있던 셸 확장 경고(zsh 와 bash 가 배열을 다르게 확장해 검사 대상이 조용히 줄어드는 문제)는 shebang 으로 bash 를 고정해 사라졌다.

## 검증

- 두 스크립트에 세 유형을 심어 검출되는 것과, 제거 후 통과하는 것을 양방향으로 확인했다
- zsh 에서 실행해도 같은 결과가 나온다
- 테스트 381개 통과. 코드 변경은 없다
