### PR TITLE
docs(persona): Windows 네이티브 도구 항목을 건너뛰게 안내

### DIFF
--- a/skills/dooray-persona/references/bootstrap.md
+++ b/skills/dooray-persona/references/bootstrap.md
@@ -95,6 +95,10 @@ node --version 으로 Node.js 20 이상인지 확인한다.
 - 내 운영체제를 확인한다.
 - https://nodejs.org 의 LTS 설치 파일을 내려받아 실행하면 된다고 알려준다.
   macOS 는 `.pkg`, Windows 는 `.msi` 다. 내 운영체제에 맞는 것을 집어서 알려준다.
+- Windows 면 설치 중에 나오는 `Tools for Native Modules` 화면을 체크하지 말라고 미리 알려준다.
+  체크하면 Chocolatey 와 Python, Visual Studio Build Tools 를 함께 설치한다.
+  dooray-cli 는 의존 패키지가 전부 순수 JavaScript 라 컴파일할 것이 없어 필요 없다.
+  이미 체크해서 설치했더라도 Node 를 다시 깔 필요는 없다.
 - 설치 창이 관리자 비밀번호나 권한 확인을 물어볼 수 있다고 미리 알려준다.
 - 설치가 끝나면 알려 달라고 요청하고 기다린다. 임의로 다른 방법을 쓰지 않는다.
 - 내가 끝났다고 하면 node --version 을 다시 확인한다.


### PR DESCRIPTION
## 무엇을

Windows 에서 Node 를 설치할 때 `Tools for Native Modules` 화면을 체크하지 말라고 프롬프트가 미리 알린다.

## 왜 지금인가

프롬프트를 따라 하던 분에게서 문의가 왔다.

> Node.js v20 이상을 아직 구비하지 않아 설치하다보니, Chocolatey를 함께 설치하여야 동작 가능하다해서
> 기본값 설정대로 설치하려는데, 혹시 Chocolatey를 설치하는건 사내 보안규정에 저촉되거나 하진 않을까요

Node 설치 중에 나오는 선택 화면이다.
체크하면 설치가 끝난 뒤 별도 스크립트가 돌면서 Chocolatey 와 Python, Visual Studio Build Tools 를 깐다.
C++ 로 짜인 네이티브 모듈을 컴파일할 때 쓰는 것들이다.

=> 이 작업에는 필요 없는데, 안내가 없어 사내 보안 규정까지 물어야 했다.

## 필요 없다는 근거

| 확인 | 결과 |
| --- | --- |
| 의존 패키지 11개 | 모두 순수 JavaScript |
| `optionalDependencies` | 없음 |
| `node-gyp`, `binding.gyp` | 없음 |
| 설치본의 `.node` 바이너리 | 없음 |

컴파일할 대상이 없으므로 빌드 도구도 필요 없다.

## 넣은 안내

- Windows 면 그 화면을 체크하지 말라고 미리 알린다.
- 무엇이 함께 깔리는지와 왜 필요 없는지를 한 줄씩 적는다.
- 이미 체크해서 설치했더라도 Node 를 다시 깔 필요는 없다고 밝힌다.

마지막 줄이 없으면 이미 체크한 사람이 "잘못했나, 다시 깔아야 하나" 를 다시 묻는다.

## 검증

- 의존성은 `package.json` 과 전역 설치본에서 확인했다.
- 그 화면이 선택 항목이라는 것은 `nodejs/node` PR #22645 로 들어간 기능이고, 같은 질문이 `nodejs/help` #3761 과 `nodejs/node` #30242 에 올라와 있다.
- 문체 검사와 가독성 검사 모두 위반 0건이다.

## 남은 것

Windows 화면을 직접 보지 못했다. 화면 이름은 설치 파일의 표기를 그대로 옮겼다.
