### PR TITLE
ci(review): 요약과 인라인을 리뷰 하나로 묶어 게시한다

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -66,7 +66,7 @@ jobs:
             --method POST \
             --field content=eyes || true
 
-      - name: 이전 Claude 봇 댓글 삭제
+      - name: 이전 Claude 봇 리뷰 정리
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -74,6 +74,7 @@ jobs:
           PR_NUMBER="${{ env.PR_NUMBER }}"
 
           # 이전 일반 PR 코멘트 삭제 (claude[bot] 작성)
+          # — 요약이 리뷰 body 로 옮겨가기 전 방식으로 올라간 댓글도 계속 걷어낸다.
           gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
             --jq '.[] | select(.user.login == "claude[bot]") | .id' \
             | while read -r comment_id; do
@@ -90,6 +91,26 @@ jobs:
               if [ -n "$comment_id" ]; then
                 echo "오래된 Claude 인라인 댓글 삭제 중: $comment_id"
                 gh api "repos/$REPO/pulls/comments/$comment_id" --method DELETE || true
+              fi
+            done
+
+          # 이전 리뷰 본문을 OUTDATED 로 접기 (claude[bot] 작성)
+          # — 요약이 리뷰 body 에 실리므로 reviews 도 정리 대상이다. 제출된 COMMENT
+          # 리뷰는 REST 로 삭제할 수 없고 (reviews DELETE 는 PENDING 전용) dismiss 도
+          # APPROVED / CHANGES_REQUESTED 에만 되므로, GraphQL minimizeComment 로 접는다.
+          # 인라인·일반 댓글은 위에서 그대로 삭제한다 — 실행당 접히는 블록은 리뷰 본문 1 개다.
+          # 이미 접힌 리뷰를 다시 접어도 안전하므로 isMinimized 필터는 두지 않는다.
+          gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            --jq '.[] | select(.user.login == "claude[bot]") | .node_id' \
+            | while read -r review_node_id; do
+              if [ -n "$review_node_id" ]; then
+                echo "오래된 Claude 리뷰 본문 접는 중: $review_node_id"
+                gh api graphql -f query='
+                  mutation($id: ID!) {
+                    minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) {
+                      minimizedComment { isMinimized }
+                    }
+                  }' -f id="$review_node_id" </dev/null || true
               fi
             done
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -73,9 +73,14 @@ jobs:
           REPO="${{ github.repository }}"
           PR_NUMBER="${{ env.PR_NUMBER }}"
 
+          # 목록 조회는 모두 --paginate 와 per_page=100 을 함께 쓴다.
+          # REST 기본 페이지 크기가 30 이라 그대로 두면 30 건이 넘는 오래된
+          # 댓글과 리뷰가 정리되지 않고 남는다. per_page 를 빼면 --paginate 가
+          # 30 건씩 여러 번 호출해 느려진다.
+
           # 이전 일반 PR 코멘트 삭제 (claude[bot] 작성)
           # — 요약이 리뷰 body 로 옮겨가기 전 방식으로 올라간 댓글도 계속 걷어낸다.
-          gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+          gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
             --jq '.[] | select(.user.login == "claude[bot]") | .id' \
             | while read -r comment_id; do
               if [ -n "$comment_id" ]; then
@@ -85,7 +90,7 @@ jobs:
             done
 
           # 이전 인라인 리뷰 코멘트 삭제 (claude[bot] 작성)
-          gh api "repos/$REPO/pulls/$PR_NUMBER/comments" \
+          gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/comments?per_page=100" \
             --jq '.[] | select(.user.login == "claude[bot]") | .id' \
             | while read -r comment_id; do
               if [ -n "$comment_id" ]; then
@@ -100,7 +105,7 @@ jobs:
           # APPROVED / CHANGES_REQUESTED 에만 되므로, GraphQL minimizeComment 로 접는다.
           # 인라인·일반 댓글은 위에서 그대로 삭제한다 — 실행당 접히는 블록은 리뷰 본문 1 개다.
           # 이미 접힌 리뷰를 다시 접어도 안전하므로 isMinimized 필터는 두지 않는다.
-          gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+          gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/reviews?per_page=100" \
             --jq '.[] | select(.user.login == "claude[bot]") | .node_id' \
             | while read -r review_node_id; do
               if [ -n "$review_node_id" ]; then
@@ -157,7 +162,7 @@ jobs:
           #   1) 본문 길이 12자 미만
           #   2) /^test\s*\d*$/i 같은 단순 placeholder (test, test1, sample, foo 등)
           #   3) 🔴 / 🟡 severity 마커 부재 (정상 review 형식 미준수)
-          ids=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments" --jq '
+          ids=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/comments?per_page=100" --jq '
             .[]
             | select(.user.login == "claude[bot]")
             | select(

--- a/.github/workflows/code-review-prompt.txt
+++ b/.github/workflows/code-review-prompt.txt
@@ -1,7 +1,6 @@
 당신은 dooray-cli 프로젝트(NHN Dooray REST API CLI, TypeScript + Commander.js, ky HTTP 클라이언트, tsup 빌드, vitest 테스트, ~/.dooray/cache/ 파일별 분리 캐시) 의 **단일 코드 리뷰어**입니다.
-서브 에이전트를 spawn 하지 말고 **당신이 직접** 검토한다. 먼저 일반 코드 리뷰(로직 정확성·엣지케이스·async/await 경쟁·자원 누수·입력 파싱 오류·off-by-one)를 수행하고, 그 위에 아래 네 가지 프로젝트 특화 관점(타입 안전성 / 컨벤션 / 보안 / 아키텍처)을 **추가로 우선 점검하되, 이 네 가지에 한정하지 않는다**. 그 뒤:
-1. GitHub review API 로 변경된 라인에 인라인 리뷰 댓글 게시
-2. 모든 발견사항을 모은 일반 요약 댓글 1 개 게시
+서브 에이전트를 spawn 하지 말고 **당신이 직접** 검토한다. 먼저 일반 코드 리뷰(로직 정확성·엣지케이스·async/await 경쟁·자원 누수·입력 파싱 오류·off-by-one)를 수행하고, 그 위에 아래 네 가지 프로젝트 특화 관점(타입 안전성 / 컨벤션 / 보안 / 아키텍처)을 **추가로 우선 점검하되, 이 네 가지에 한정하지 않는다**. 그 뒤 GitHub review API 를 한 번 호출해 **요약과 인라인을 리뷰 하나로 묶어 게시**한다.
+요약은 리뷰의 `body` 에, 인라인 발견사항은 같은 리뷰의 `comments` 배열에 담는다.
 
 ## 1단계: PR 데이터 수집
 
@@ -10,7 +9,7 @@ gh pr diff $PR_NUMBER --repo $REPO -- ':!pnpm-lock.yaml' ':!*.lock' ':!*.snap'
 gh pr view $PR_NUMBER --repo $REPO --json title,body,additions,deletions
 ```
 
-필터링 후 diff 가 비어 있으면 짧은 긍정 댓글을 게시하고 종료한다.
+필터링 후 diff 가 비어 있으면 `body` 만 담은 짧은 긍정 리뷰를 게시하고 종료한다.
 필요하면 변경된 파일 전체를 Read / Grep 으로 읽어 맥락을 파악한다 (코드 수정·파일 생성은 절대 금지 — read-only).
 
 ## 2단계: 직접 검토 (일반 리뷰 + 특화 4관점)
@@ -61,35 +60,51 @@ FINDING_END
 - 🔴 spinner 가 stdout 으로 출력 (process.stderr 분리 위반)
 - 🟡 새 명령이 `--id`/`--url`/positional URL 분기를 `resolvePostInput` 으로 통일 안 하고 자체 분기 작성 (ADR-020), 캐시 entry 신규 추가 시 ADR-010 정책 (TTL + 파일 분리 + atomic write) 미준수, `formatters/` table/json/quiet 분기 누락
 
-## 3단계: 인라인 리뷰 게시
+## 3단계: 리뷰 하나로 게시 (요약 + 인라인)
 
-모든 `TYPE: INLINE` 발견사항을 모아 단일 GitHub PR review 생성:
+요약과 모든 `TYPE: INLINE` 발견사항을 단일 GitHub PR review 로 한 번에 게시한다.
+`gh pr comment` 는 쓰지 않는다 — 일반 댓글로 올리면 요약이 리뷰와 분리되어 Conversation 에 흩어진다.
+
+**CRITICAL**: 요청 본문은 `mktemp` 로 만든 파일에 담아 `--input` 으로 넘긴다.
+JSON 을 인자로 직접 쓰면 줄바꿈이 literal `\n` 으로 들어가 깨진다.
+체크아웃 디렉터리 안에 만들지 않고, 고정 파일명도 쓰지 않는다 (아래 「핵심 규칙」 참조).
 
 ```bash
-gh api repos/$REPO/pulls/$PR_NUMBER/reviews \
-  --method POST --header "Content-Type: application/json" --input - <<'REVIEW_EOF'
-{
-  "event": "COMMENT",
-  "comments": [
-    { "path": "src/commands/post/create.ts", "line": 42, "side": "RIGHT",
-      "body": "🔴 **문제**: ...\n\n**수정**: ..." }
+REVIEW_JSON=$(mktemp)
+BODY_MD=$(mktemp)
+
+# 요약을 먼저 파일로 쓴다 (형식은 아래 「body 에 담을 요약 형식」).
+cat > "$BODY_MD" <<'BODY_EOF'
+## 코드 리뷰 [PR 제목 요약]
+...
+BODY_EOF
+
+# --rawfile 로 읽으면 요약의 개행을 jq 가 알아서 escape 한다.
+# comments 는 TYPE: INLINE 발견사항을 그대로 나열한다 (없으면 빈 배열).
+jq -n --rawfile body "$BODY_MD" '{
+  event: "COMMENT",
+  body: $body,
+  comments: [
+    { path: "src/commands/post/create.ts", line: 42, side: "RIGHT",
+      body: "🔴 **문제**: ...\n\n**수정**: ..." }
   ]
-}
-REVIEW_EOF
+}' > "$REVIEW_JSON"
+
+gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+  --method POST --header "Content-Type: application/json" --input "$REVIEW_JSON"
+
+rm -f "$REVIEW_JSON" "$BODY_MD"
 ```
 
 - `path` 는 diff 와 정확히 매치되는 상대 경로 (앞에 `/` 금지)
 - `line` 은 diff 에 등장하는 숫자 — 불확실하면 GENERAL 처리
 - `side` 는 항상 `"RIGHT"`
-- 인라인 발견사항 없으면 이 단계 skip
-- `gh api` 실패(422 등) 시 로그만 남기고 4단계로 진행
+- 인라인 발견사항이 없으면 `comments` 를 빈 배열 `[]` 로 두고 `body` 만 게시한다 — 호출은 그래도 한 번 한다
+- `gh api` 실패(422 등) 시 로그를 남긴다
 
-## 4단계: 일반 요약 댓글 1 개 게시
+### `body` 에 담을 요약 형식
 
-**CRITICAL**: 반드시 `--body-file -` + HEREDOC 사용. `--body "...\n..."` 는 `\n` 이 literal 로 들어가 깨진다.
-
-```bash
-gh pr comment $PR_NUMBER --repo $REPO --body-file - <<'COMMENT_EOF'
+```markdown
 ## 코드 리뷰 [PR 제목 요약]
 
 [한 줄 전체 평가]
@@ -115,19 +130,17 @@ gh pr comment $PR_NUMBER --repo $REPO --body-file - <<'COMMENT_EOF'
 ---
 🤖 Reviewed with [Claude Code](https://claude.com/claude-code) (single opus reviewer: type · conventions · security · architecture)
 💬 인라인 코멘트는 **Files changed** 탭에서 확인하세요
-COMMENT_EOF
 ```
-
-HEREDOC 안에서는 `\n` escape 없이 실제 newline 만 사용한다.
 
 ## 핵심 규칙
 
-- **PR 브랜치에 어떤 파일도 git add / commit / push 금지** — read-only + GitHub API 호출만. 임시 파일(예: `.claude-pr/summary_comment.md`)도 만들지 말 것 — action wrapper 의 `git add -A` 가 그 파일을 PR 브랜치 commit 으로 흘려보낸다 (실제 사고 PR #83). 요약은 HEREDOC stdin 전달만.
+- **PR 브랜치에 어떤 파일도 git add / commit / push 금지** — read-only + GitHub API 호출만.
+- **체크아웃 디렉터리 안에 임시 파일을 만들지 말 것** (예: `.claude-pr/summary_comment.md`) — action wrapper 의 `git add -A` 가 그 파일을 PR 브랜치 commit 으로 흘려보낸다 (실제 사고 PR #83). 리뷰 요청 본문은 `mktemp` 가 체크아웃 밖에 만드는 파일에만 쓰고, 게시 후 지운다.
 - **테스트 / 더미 / placeholder 댓글 금지** — 실제 production 리뷰. 게시 전 sanity check:
   - body 가 `🔴`/`🟡` + `**문제**:` + `**수정**:` 패턴 포함?
   - `test`, `sample`, `placeholder`, `example`, `<여기에>`, `{ISSUE}`, `{FIX}` 같은 잔재 없음?
   - 12자 미만 / 의미 있는 한국어 0개면 reject
-  실패 entry 제거 후 게시. comments 배열 비면 3단계 skip + 4단계에서 "발견사항 없음" 한 줄.
-- **일반 댓글 정확히 1 개** (4단계) — `gh pr comment` 2회 이상 금지
+  실패 entry 제거 후 게시. 남은 entry 가 없으면 `comments` 를 빈 배열로 두고 `body` 에 "발견사항 없음" 한 줄을 담는다.
+- **리뷰 정확히 1 개** (3단계) — `reviews` POST 는 한 번만 호출하고, `gh pr comment` 는 쓰지 않는다
 - **내용 있는 섹션만 포함** — 빈 🔴/🟡 섹션 생략
-- **이슈 0 건이면** 3단계 skip + 4단계 🟢 짧은 긍정 리뷰
+- **이슈 0 건이면** `comments` 는 빈 배열, `body` 는 🟢 짧은 긍정 리뷰


### PR DESCRIPTION
## 어떤 이유로 PR을 하셨나요?
- 리뷰 요약과 인라인 코멘트를 따로 올려 PR 대화에서 흩어져 있어, 한 리뷰로 묶을 필요가 있었습니다.
- 그래서 게시를 reviews API 한 번의 호출로 합치고, 그것이 강제하는 정리 방식까지 맞췄습니다.

## 작업 내용
- 게시를 한 리뷰로 합침
  - 요약은 리뷰 `body`, 인라인은 같은 리뷰의 `comments` 배열
  - 등록 호출이 2회에서 1회로 줄어듦
  - `gh pr comment` 를 쓰지 않음
- 정리 방식을 함께 맞춤
  - 요약이 리뷰 본문으로 옮겨가면 이전 요약을 지우는 경로가 없어짐
  - 제출된 `COMMENT` 리뷰는 REST 로 삭제 불가. dismiss 도 `APPROVED` 와 `CHANGES_REQUESTED` 에만 됨
  - 리뷰 본문만 GraphQL `minimizeComment` 로 접고 일반 댓글과 인라인은 계속 삭제

- 정리 스텝의 페이지 처리
  - REST 기본 페이지 크기가 30 이라 그것을 넘으면 오래된 것이 정리되지 않던 결함
  - 목록 조회에 `--paginate` 와 `per_page=100` 을 함께 넣음

## 리뷰어가 집중해 주길 바라는 부분이 있다면 입력해 주세요.
- **정리 방식이 혼합입니다.** 접힌 블록이 쌓이는 것을 피하려 리뷰 본문 하나만 접습니다. 실행당 한 개라 기존에 접기를 기각한 근거가 겨누던 누적량과 다릅니다.
- 워크플로는 로컬에서 돌릴 수 없어 YAML 파싱과 셸 문법, 호출 자리 확인으로 검증했습니다. 실제 동작은 다음 PR 리뷰에서 드러납니다.

---
> 이 PR은 AI에 의해 작성되었습니다.
