### PR TITLE
chore(release): CI 게시 워크플로를 만들고 릴리스 스킬을 정리한다

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -47,48 +47,30 @@ git log ${LAST_TAG}..HEAD --pretty=format:"%s" | sort
 추가로 **해결된 GitHub 이슈**를 식별:
 
 ```bash
-# 열린 이슈 목록
 gh issue list --state open --json number,title --jq '.[] | "#\(.number)  \(.title)"'
-
-# task 디렉토리 / 커밋 메시지 / PR 본문에서 "Issue #N" 또는 "#N" 참조 추출
-grep -rE "Issue #[0-9]+|^#[0-9]+" tasks/ 2>/dev/null
 git log ${LAST_TAG}..HEAD --grep="#[0-9]" --oneline
 ```
 
-각 열린 이슈에 대해 "이번 릴리스로 해결되었는가?" 판단:
+열린 이슈마다 이번 릴리스가 그것을 해결했는지 판단한다.
+이슈가 요청한 것과 이번의 신규 명령·옵션을 짝지어 본다.
+후속 작업이 남은 이슈는 닫지 않는다.
 
-- 이슈 제목/본문 ↔ 이번 릴리스의 신규 명령/옵션 매핑
-- 후속 이슈(`feat(... ) follow-up`)는 release 시점에 close하지 않음 — 별도 task가 필요
+close 대상 목록을 사용자에게 제시해 확정받는다.
+그 목록이 7단계의 Release 노트 하단과 10단계의 자동 close 에 쓰인다.
 
-**결과를 사용자에게 제시**하고 close 대상 이슈 목록을 확정. 이 목록은:
+### 3. 문서 동기화 검증
 
-- GitHub Release 노트 하단에 `Closes #N, #M` 으로 기록
-- 10단계에서 release publish 후 자동 close
+2단계에서 뽑은 신규 명령과 옵션이 사용자 문서에 있는지 본다.
 
-이 결과는 다음 단계(문서 동기화 검증)와 GitHub Release 노트에 그대로 활용한다.
+```bash
+# cwd: <repo root>
+# 2단계의 각 문자열을 하나씩 넣는다. 플레이스홀더를 그대로 넣으면 0건이 나와 통과로 오독된다.
+grep -rn '<명령이나 옵션 문자열>' README.md skills/
+```
 
-### 3. 문서 동기화 검증 (README + dooray-cli 스킬)
+0건이면 누락이다. 누락 항목과 넣을 위치를 사용자에게 보고하고 보완 커밋을 따로 만든 뒤 다음 단계로 간다.
 
-신규 명령이나 옵션이 있으면 사용자 문서에 반영됐는지 확인한다.
-
-2단계에서 도출한 명령·옵션 문자열 **하나씩** `grep -rn '<그 문자열>' README.md skills/` 로 조회한다.
-히트가 0이면 누락이다. 플레이스홀더를 그대로 정규식에 넣으면 0건이 나와 통과로 오독된다.
-
-
-| 위치                              | 무엇을 확인                               |
-| ------------------------------- | ------------------------------------ |
-| `README.md`                     | "사용법" 섹션에 등장하는지. 새 명령은 알맞은 카테고리에 넣는다 |
-| `skills/dooray-cli/SKILL.md`    | 의도별 커맨드 표와 공통 규칙에 반영됐는지              |
-| `skills/dooray-cli/references/` | 해당 명령군 reference 에 동작과 함정이 들어갔는지     |
-
-
-**누락 발견 시**:
-
-- 사용자에게 누락 항목을 보고하고, 어느 위치에 어떤 문장으로 추가할지 제안
-- 보완 commit을 별도로 작성한 후 다음 단계 진행 (`docs(readme): document {feature}` 또는 `docs(skill): add {feature} to dooray-cli SKILL.md`)
-- 보완을 건너뛰면 사용자가 명시적으로 동의했을 때만 (예: "이번 릴리스는 인프라만, 기능 추가 없음")
-
-**버그 수정/리팩토링만 있는 릴리스**라면 본 단계는 통과 가능 — 사용자에게 그 사실을 명시하고 진행.
+새 명령이 없으면 이 단계를 통과로 본다. 그 사실을 사용자에게 밝힌다.
 
 ### 4. 개인 식별 정보 / 사내 식별자 노출 검증 (필수, 실패 시 중단)
 
@@ -156,7 +138,7 @@ git push origin v{version}
 
 릴리스 노트는 **2단계 분석 결과를 그대로 활용**해 작성한다 (Highlights / 신규 명령 / 신규 옵션 / 버그 수정 / **Closes** / Full Changelog 링크).
 
-**전달 방식: `--notes-file {path}` 필수** — 인라인 `--notes "..."` 또는 quoted heredoc 금지.
+**전달 방식은 `--notes-file {path}` 만 쓴다.** 인라인 `--notes "..."` 와 quoted heredoc 은 쓰지 않는다.
 
 ```bash
 # 1. 임시 파일에 본문 작성 (Write 도구 / cat / EDITOR 어느 쪽이든 OK)
@@ -173,7 +155,7 @@ gh release create v{version} --title "v{version} — {요약}" --notes-file /tmp
   - v0.10.0 릴리스에서 backtick 66개가 escape 된 형태로 출력되는 사고가 있었다
 - `--notes-file` 은 파일 경로만 넘기므로 shell quoting 과 escape 함정을 아예 피한다
 
-**자가 점검** — release create / edit 직후:
+**자가 점검.** release create 나 edit 직후에 확인한다.
 
 ```bash
 gh release view v{version} --json body -q .body | tr -cd '\\' | wc -c
@@ -185,13 +167,13 @@ gh release view v{version} --json body -q .body | tr -cd '\\' | wc -c
 릴리스 노트 본문 마지막에 close 대상 이슈를 적는다. 10단계에서 이 목록을 그대로 쓴다.
 
 ```markdown
-## Closes
+Closes
 
 이번 릴리스로 해결된 이슈 (release publish 후 자동 close):
 - #{번호} {이슈 제목}
 ```
 
-`--generate-notes` 는 쓰지 않는다 — 2단계에서 판단한 Closes 목록과 신규 명령·옵션 분류가 빠진다.
+`--generate-notes` 는 쓰지 않는다. 2단계에서 판단한 Closes 목록과 신규 명령·옵션 분류가 빠진다.
 
 ### 8. npm Publish
 
@@ -205,8 +187,14 @@ npm publish --access public --otp={code}
 
 ### 9. 최종 확인
 
-- `https://github.com/jon890/dooray-cli/releases/tag/v{version}` 릴리스 확인
-- `https://www.npmjs.com/package/@bifos/dooray-cli` 버전 확인 (반영에 수 분 소요)
+```bash
+# cwd: <repo root>
+gh release view "v{version}" --json tagName,isDraft -q '"\(.tagName) draft=\(.isDraft)"'
+npm view @bifos/dooray-cli version
+```
+
+첫 명령이 그 태그를 내고 `draft=false` 여야 한다.
+둘째가 방금 올린 버전을 내야 한다. npm 색인 반영에 수 분 걸리므로 값이 다르면 잠시 후 다시 조회한다.
 
 ### 10. 해결된 이슈 close
 
@@ -219,7 +207,7 @@ for n in {이슈번호 목록}; do
 done
 ```
 
-각 close에 release 링크 코멘트 첨부 — 이슈에서 release notes로 즉시 이동 가능.
+각 close 에 release 링크를 코멘트로 붙인다. 이슈에서 release 노트로 바로 이동할 수 있다.
 
 **close 금지 케이스**:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: Release
+
+# 태그 push 로 발동한다. 릴리스 스킬의 7단계가 `v{version}` 태그를 만들어 올린다.
+on:
+  push:
+    tags: ["v*"]
+
+env:
+  NODE_VERSION: "22"
+
+jobs:
+  publish:
+    name: npm Publish
+    runs-on: ubuntu-latest
+
+    # OIDC 토큰을 발급받아 npm 에 신원을 증명한다. Trusted publishing 이 이것을 쓴다.
+    # 저장소 secret 에 npm 토큰을 두지 않는 이유가 이 권한이다.
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
+
+      # 의존성 설치 전에 돈다. setup-node 가 앞에 있어 Node 는 준비돼 있고,
+      # 공개 저장소라 식별자 노출은 한 번 새면 되돌리기 어렵다.
+      - name: Check for exposed identifiers
+        run: node scripts/check-pii.mjs
+
+      - name: Check public docs for internal references
+        run: node scripts/check-public-refs.mjs
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run type check
+        run: pnpm tsc --noEmit
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Run build
+        run: pnpm build
+
+      - name: Verify package artifact
+        run: pnpm verify:package
+
+      # 태그가 가리키는 버전과 package.json 이 어긋난 채 게시되는 것을 막는다.
+      - name: Verify tag matches package version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG="$(node -p "require('./package.json').version")"
+          echo "tag=$TAG package.json=$PKG"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "태그와 package.json 버전이 다르다. 게시하지 않는다."
+            exit 1
+          fi
+
+      # Trusted publishing 이라 NODE_AUTH_TOKEN 을 주지 않는다.
+      # npm 이 위 id-token 권한으로 받은 OIDC 신원을 직접 확인한다.
+      # --provenance 는 어느 커밋과 워크플로에서 빌드됐는지를 패키지에 기록한다.
+      - name: Publish to npm
+        run: npm publish --access public --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,20 @@ jobs:
             exit 1
           fi
 
+      # pre-release 태그는 이 워크플로로 게시하지 않는다.
+      # `--tag` 없이 게시하면 dist-tag 가 항상 latest 라, 실수로 올린
+      # pre-release 를 stable 사용자가 받는다. 필요해지면 `--tag next` 분기를 붙인다.
+      - name: Reject pre-release version
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          case "$VERSION" in
+            *-*)
+              echo "pre-release 버전($VERSION)은 이 워크플로로 게시하지 않는다."
+              exit 1
+              ;;
+          esac
+          echo "stable 버전: $VERSION"
+
       # Trusted publishing 이라 NODE_AUTH_TOKEN 을 주지 않는다.
       # npm 이 위 id-token 권한으로 받은 OIDC 신원을 직접 확인한다.
       # --provenance 는 어느 커밋과 워크플로에서 빌드됐는지를 패키지에 기록한다.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Orca 가 워크트리를 저장소 루트의 `worktrees/` 아래에 만든다.
+    // 기본 exclude 에 그 경로가 없어 다른 브랜치의 테스트가 함께 잡힌다.
+    // 실측으로 파일 54개가 108개, 테스트 551건이 1102건으로 두 배가 됐다.
+    // 그 상태에서는 현재 브랜치의 통과 판정에 다른 브랜치의 결과가 섞인다.
+    exclude: ["**/node_modules/**", "**/dist/**", "worktrees/**"],
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, configDefaults } from "vitest/config";
 
 export default defineConfig({
   test: {
@@ -6,6 +6,8 @@ export default defineConfig({
     // 기본 exclude 에 그 경로가 없어 다른 브랜치의 테스트가 함께 잡힌다.
     // 실측으로 파일 54개가 108개, 테스트 551건이 1102건으로 두 배가 됐다.
     // 그 상태에서는 현재 브랜치의 통과 판정에 다른 브랜치의 결과가 섞인다.
-    exclude: ["**/node_modules/**", "**/dist/**", "worktrees/**"],
+    //
+    // 배열을 그대로 지정하면 기본값을 교체한다. spread 로 확장해 기본을 남긴다.
+    exclude: [...configDefaults.exclude, "worktrees/**"],
   },
 });


### PR DESCRIPTION
## 어떤 이유로 PR을 하셨나요?

- npm 이 2FA 를 우회하는 토큰을 제한하기로 해 지금의 로컬 OTP 게시 경로가 닫히므로, CI 게시로 옮길 필요가 있었습니다.
- npm 공지 기준으로 계정 변경은 2026년 8월, 직접 게시는 2027년 1월
- 그래서 Trusted publishing 워크플로를 만들고, 함께 발견한 릴리스 스킬의 어긋남과 테스트 중복 스캔을 고쳤습니다.

## 작업 내용

- CI npm 게시
  - `.github/workflows/release.yml` 신규
    - `v*` 태그 push 로 발동. 릴리스 스킬 7단계가 그 태그를 만든다
    - `id-token: write` 로 OIDC 신원을 증명. 저장소 secret 에 토큰을 두지 않음
    - `--provenance` 로 빌드 출처를 패키지에 기록
  - 태그와 `package.json` 버전 불일치 시 게시 중단
    - 버전 범프 누락으로 엉뚱한 버전이 게시되는 것을 막음
  - 검사 순서는 기존 CI 를 따름. 식별자 검사가 `pnpm install` 앞
- 테스트 중복 스캔

  | 구분 | 변경 전 | 변경 후 |
  |------|---------|---------|
  | 테스트 파일 | 108개 | 54개 |
  | 테스트 | 1102건 | 551건 |
  | 원인 | vitest 설정 부재로 `worktrees/` 스캔 | `vitest.config.ts` 의 exclude |

  - 현재 브랜치 판정에 다른 브랜치 결과가 섞이던 문제
  - `.gitignore` 로는 걸러지지 않음. CI 에는 워크트리가 없어 드러나지 않던 문제
- 릴리스 스킬 정리
  - 실행 명령이 없던 두 절을 명령과 기대값으로 교체
    - 문서 동기화 검증, 최종 확인
  - 코드 블록 안 템플릿이 최상위 절로 파싱돼 층이 어긋난 것을 바로잡음
  - 중복 서술과 제거 대상 경로를 훑는 명령 삭제
  - 평문 엠대시 네 곳을 문장으로 풀어 씀

## 리뷰어가 집중해 주길 바라는 부분이 있다면 입력해 주세요.

- Trusted publishing 은 저장소 쓰기 권한을 가진 사람이 게시할 수 있게 됩니다. 지금은 개인 저장소라 범위가 소유자 자신입니다.
  - 협업자를 추가하면 `--environment` 로 GitHub Environment 를 걸어 승인 절차를 둘 수 있습니다
- npm 등록은 `release.yml` 이 기본 브랜치에 있어야 통합니다. 브랜치에만 있는 상태로 시도해 `400` 을 받았습니다.

---
> 이 PR은 AI에 의해 작성되었습니다.
