### PR TITLE
feat(messenger): 스레드를 여는 thread-send 를 추가한다

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,36 @@ dooray project tags group <project> "배포환경" --select-one        # 그룹�
 
 태그 이름·색상 수정과 태그 삭제는 Dooray API 에 경로가 없어 웹 설정 화면에서 한다.
 
+### 메신저로 알리기
+
+작업 결과를 메신저로 바로 보낸다.
+
+```bash
+dooray messenger send --to user@example.com --body "배포 완료됐습니다"   # 1:1 메시지
+dooray messenger channel-send --channel "배포알림" --body "v1.2.3 배포"  # 대화방 메시지
+```
+
+`send` 의 `--to` 는 멤버 ID 나 이메일을 받고 이름은 받지 않는다.
+`channel-send` 의 `--channel` 은 channelId 나 대화방 이름을 받고, 이름으로는 자신이 속한 방만 찾는다.
+`--body` 대신 `--body-file` 로 파일을 주거나 둘 다 생략해 `$EDITOR` 에서 쓸 수 있다.
+
+진행 상황을 여러 번 보고할 때는 스레드를 열어 그 안에 쌓는다.
+`thread-send` 에 `--quiet` 을 붙이면 새로 만들어진 스레드 채널의 id 가 나오고,
+그 값을 `channel-send` 의 `--channel` 에 주면 메시지가 스레드에 붙는다.
+
+```bash
+THREAD=$(dooray messenger thread-send --channel "배포알림" --body "v1.2.3 배포" --quiet)
+dooray messenger channel-send --channel "$THREAD" --body "테스트 통과"
+```
+
+`--thread-body` 로 스레드 첫 메시지를 함께 보낼 수 있고, 생략하면 스레드만 열린다.
+
+이미 올라간 메시지에 스레드를 열려면 그 메시지의 log-id 를 `--log` 로 준다.
+
+```bash
+dooray messenger thread-send --channel "배포알림" --log <logId> --body "빌드 로그"
+```
+
 ## 프로젝트 구조
 
 ```

--- a/docs/adr/052-messenger-thread-send.md
+++ b/docs/adr/052-messenger-thread-send.md
@@ -1,0 +1,60 @@
+## ADR-052: 메신저 스레드 생성을 `thread-send` 한 명령으로 둔다
+
+**결정**: `dooray messenger thread-send` 하나를 추가하고 `--log` 유무로 두 endpoint 를 가른다.
+
+| `--log` | 호출하는 endpoint | 요청 body |
+| --- | --- | --- |
+| 없음 | `POST /messenger/v1/channels/{channel-id}/threads/create-and-send` | `{ text, threadText? }` |
+| 있음 | `POST /messenger/v1/channels/{channel-id}/logs/{log-id}/threads/create-and-send` | `{ text }` |
+
+**맥락**: 대화방에 진행 상황을 여러 번 보고하는 자동화가 본문에 메시지를 늘어놓으면 대화방을 읽기 어려워진다.
+스레드로 묶으면 대화방에는 한 줄만 남고 나머지는 그 안에 쌓인다.
+
+공식 API 는 스레드를 여는 방법을 둘로 나눠 둔다.
+새 메시지를 보내면서 여는 것과, 이미 있는 메시지에 여는 것이다.
+받는 인자가 대화방이라는 점과 응답 모양이 같아서, 명령을 나누면 옵션 대부분이 두 곳에 겹친다.
+
+**실측으로 확인한 것**: 공식 문서의 서술이 스스로 어긋나 호출해서 확인했다.
+
+문서는 `POST /channels/{channel-id}/logs` 절에서
+「`threads/create-and-send` API 응답의 `$.result.threadChannelId` 값을 넣어 요청할 수 있습니다」 라고 적는다.
+그런데 같은 문서의 `threads/create-and-send` 응답 예시에는 `threadChannelId` 가 없다.
+
+실제 응답은 이렇다.
+
+```json
+{ "result": { "id": "1111222233334444555", "channelId": "2222333344445555666" } }
+```
+
+`threadChannelId` 라는 필드는 오지 않는다.
+`channelId` 가 새로 만들어진 스레드 채널의 id 이고, 요청에 넣은 대화방 id 와 다른 값이다.
+그 `channelId` 로 `POST /channels/{id}/logs` 를 보내 스레드에 메시지가 붙는 것을 확인했다.
+
+근거 우선순위는 ADR-046 이 정한다. 다만 이번에는 공식 문서 안에서 두 서술이 어긋나므로
+실측한 응답을 따르고 그 사실을 여기 남긴다.
+
+**적용 범위 (설계 결정)**:
+
+- **`--channel`** 은 `channel-send` 와 같다. channelId 이거나 대화방 이름이며 `resolveMessengerChannel` 을 그대로 쓴다.
+- **본문**은 `--body` / `--body-file` 이고 둘 다 없으면 `$EDITOR` 가 열린다. 기존 messenger 명령과 같다.
+- **스레드 첫 메시지**는 `--thread-body` / `--thread-body-file` 로 받는다.
+  자동화가 긴 로그를 스레드에 넣는 경로가 있어 파일 입력을 함께 둔다. 생략하면 스레드만 열리고 첫 메시지는 없다.
+- **`--log` 와 `--thread-body` 를 함께 주면** 경고를 내고 `--thread-body` 를 무시한다.
+  `logs/{log-id}/threads/create-and-send` 는 `text` 만 받기 때문이다.
+  전용 옵션을 무시하고 경고를 내는 것은 `CLAUDE.md` 의 공통 규약이 이미 정한 처리다.
+- **`--quiet` 는 `channelId` 를 낸다.** 다른 messenger 명령은 `id` 를 내지만 여기서는 갈라 둔다.
+  스레드를 연 다음에 하는 일은 그 스레드에 메시지를 잇는 것이고, 그 호출에 필요한 값이 `channelId` 다.
+  `id` 를 내면 사용자가 `--json` 으로 다시 받아 `channelId` 를 꺼내야 한다.
+- **`--json` 은 `res.result` 를 그대로 낸다.** 기존 messenger 명령과 같다.
+
+**스레드에 메시지를 잇는 것은 새 명령을 두지 않는다**:
+`dooray messenger channel-send --channel <스레드의 channelId>` 가 그대로 동작한다.
+스레드 채널도 채널이라 `logs` endpoint 를 공유하기 때문이다. 사용법은 README 와 스킬 문서에 적는다.
+
+**대안 기각**:
+
+- **endpoint 마다 명령을 하나씩 둔다** — `--channel`, 본문 입력, 출력 세 형식이 두 명령에 그대로 겹친다.
+  가르는 것은 대상이 대화방이냐 특정 메시지냐 하나뿐이라 옵션 하나가 그 역할을 한다.
+- **`channel-send` 에 `--thread` 를 붙여 흡수한다** — 그 명령의 반환값은 log-id 하나인데
+  스레드는 log-id 와 스레드 채널 id 둘을 낸다. 출력 규약이 갈려 같은 명령 안에서 두 모양이 된다.
+- **`--quiet` 도 `id` 로 통일한다** — 형식은 맞지만 그 값으로 이어서 할 수 있는 일이 없다.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -60,3 +60,4 @@ ADR-NNN 내용은 `docs/adr/NNN-*.md` (번호 glob) 또는 아래 목록 링크�
 - [ADR-049](049-config-read-result-states.md) — `getConfig` 가 파일 부재와 손상과 읽기 실패를 구분해 돌려준다 (Issue #151)
 - [ADR-050](050-agent-overlay-boundary.md) — 전용 agent 를 두지 않고 저장소 고유 지침은 오버레이가 문서 경로로 실어 코어 역할 계약에 얹는다
 - [ADR-051](051-json-large-integer-precision.md) — 응답 JSON 의 큰 정수를 `ky` 의 `parseJson` 공통 파서로 문자열 보존 (`direct-send` 의 log-id 손실)
+- [ADR-052](052-messenger-thread-send.md) — 메신저 스레드 생성을 `thread-send` 한 명령에 `--log` 분기로 둔다 (`threadChannelId` 필드 부재 실측)

--- a/docs/code-architecture.md
+++ b/docs/code-architecture.md
@@ -28,6 +28,7 @@ src/
     rate-limiter.ts         # 요청 토큰 버킷. 응답 헤더로 서버 잔량과 동기화 (ADR-039)
     imapClient.ts           # IMAP 메일 조회 (imapflow + mailparser). resolveUidByMailId — 도착 시각으로 UID 이분 탐색 (ADR-040)
     smtpClient.ts           # SMTP 메일 발송 (nodemailer)
+    messenger-thread-request.ts # 스레드 생성 요청 경로·body 를 만드는 순수 함수. --log 유무로 channels/{id}/threads/create-and-send 와 logs/{log-id}/threads/create-and-send 를 가른다 (ADR-052)
     types.ts                # 모든 API 요청/응답 타입
     json-large-integer.ts   # 응답 JSON 의 19자리 식별자가 손실되는 정수 리터럴만 문자열로 보존해 파싱 (ADR-051)
 
@@ -114,6 +115,8 @@ src/
       index.ts              # messengerCommand 조립
       send.ts               # 1:1 DM — direct-send (--to id/email + body, resolveMember id/email 공유)
       channel-send.ts       # 대화방 — channels/{id}/logs (--channel id/이름 resolveMessengerChannel + body)
+      thread-send.ts        # 스레드 생성 — --log 유무로 두 endpoint 를 가르고 --quiet 은 스레드 채널 channelId 를 낸다 (ADR-052)
+      thread-options.ts     # thread-send 옵션 조합 판정 — --log 와 --thread-body 충돌 경고, stdin 중복 지정 차단 (ADR-052)
 
     project/
       list.ts

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -477,7 +477,7 @@ dooray wiki page get --id <page-id> --project my-project
 하위 페이지는 기본으로 함께 이동한다.
 이동할 때는 새 부모 페이지를 `--parent` 로 반드시 지정한다.
 
-## 메신저 흐름 (Issue #88, ADR-033)
+## 메신저 흐름 (Issue #88, ADR-033, 스레드는 ADR-052)
 
 빠른 알림·배포 요청을 CLI/에이전트가 메일보다 즉시성 있게 전송.
 
@@ -492,6 +492,22 @@ dooray messenger channel-send --channel <channelId> --body-file -   # stdin
 
 # body 미지정 시 $EDITOR 진입 (comment 와 동일)
 dooray messenger send --to <memberId>
+```
+
+대화방에 스레드를 열어 후속 보고를 그 안에 쌓는다.
+`--quiet` 이 내는 값은 log-id 가 아니라 새로 만들어진 스레드 채널의 channelId 다.
+
+```
+# 대화방에 메시지를 보내면서 스레드를 연다 (--thread-body 는 스레드 첫 메시지, 생략 가능)
+dooray messenger thread-send --channel "배포알림" --body "v1.2.3 배포" --thread-body "빌드 시작"
+
+# 이미 있는 메시지에 스레드를 연다 (--log 는 channel-send 가 낸 log-id)
+dooray messenger thread-send --channel "배포알림" --log <logId> --body "빌드 로그"
+
+# 연 스레드에 메시지를 잇는다 (스레드 채널 id 를 channel-send 의 --channel 로 준다)
+THREAD=$(dooray messenger thread-send --channel "배포알림" --body "v1.2.3 배포" --quiet)
+dooray messenger channel-send --channel "$THREAD" --body "테스트 통과"
+dooray messenger channel-send --channel "$THREAD" --body "배포 완료"
 ```
 
 ## 위키 페이지 첨부파일 흐름 (Issue #70, ADR-029)

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -50,7 +50,7 @@ CLI는 터미널이 있는 환경이면 어디서든 동작하고, 자연스러�
 - `dooray wiki page comment` — 페이지 댓글 목록·최신·조회·추가·수정·삭제 (post comment 패턴 mirror, mention/cc/file 부재 — WikiComment 시그니처 차이)
 - `dooray mail` — 목록·조회·검색·발송·답장 (v0.2.0)
 - `dooray feedback` — `gh` CLI 위임으로 GitHub 이슈 자동 생성 (`--last` 옵션으로 직전 명령 sanitized argv와 에러 자동 첨부, ADR-022/023)
-- `dooray messenger` — 1:1 다이렉트 메시지 (`send`) / 대화방 메시지 (`channel-send`) 전송 (`--to` id·email, `--channel` id·이름, ADR-033)
+- `dooray messenger` — 1:1 다이렉트 메시지 (`send`) / 대화방 메시지 (`channel-send`) / 대화방 스레드 생성 (`thread-send`) 전송 (`--to` id·email, `--channel` id·이름, ADR-033, 스레드는 ADR-052)
 - `skills/dooray-persona` — Dooray 에 쌓인 본인 글을 수집해 업무 글 문체 문서를 만드는 워크플로우 스킬. CLI 명령이 아니라 저장소를 내려받아 쓰는 자산이다 (ADR-038)
 
 ### 제외 (v1)

--- a/skills/dooray-cli/SKILL.md
+++ b/skills/dooray-cli/SKILL.md
@@ -224,6 +224,17 @@ NHN Dooray REST API 를 래핑한 CLI 다. 이 파일은 라우터이므로, 작
 | --- | --- |
 | 1:1 다이렉트 메시지 | `dooray messenger send --to "<id\|email>" --body "..."` — `--to` 는 ID 나 이메일만 받고 이름은 지원하지 않는다 |
 | 대화방 메시지 | `dooray messenger channel-send --channel "<channelId\|이름>" --body "..."` — 이름으로는 자신이 속한 방만 찾는다 |
+| 대화방 스레드 열기 | `dooray messenger thread-send --channel "<channelId\|이름>" --body "..."` — `--thread-body` 로 첫 메시지를 함께 보내고, `--log <log-id>` 로 이미 올라간 메시지에 연다 |
+
+진행 상황을 여러 번 보고할 때는 대화방 본문에 늘어놓지 말고 스레드에 쌓는다.
+`thread-send --quiet` 이 내는 값은 log-id 가 아니라 새로 만들어진 스레드 채널의 id 이고,
+그 값을 `channel-send --channel` 에 주면 메시지가 스레드에 붙는다.
+
+```bash
+THREAD=$(dooray messenger thread-send --channel "배포알림" --body "v1.2.3 배포" --quiet)
+dooray messenger channel-send --channel "$THREAD" --body "빌드 통과"
+dooray messenger channel-send --channel "$THREAD" --body "배포 완료"
+```
 
 ## 옵션 이름
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -7,6 +7,7 @@ import { normalizeDoorayMessage } from "../utils/dooray-message.js";
 import { EXIT_API_ERROR, EXIT_AUTH_ERROR } from "../utils/exit-codes.js";
 import { createTokenBucket, parseRateLimitHeaders } from "./rate-limiter.js";
 import { parseJsonPreservingLargeIntegers } from "./json-large-integer.js";
+import { buildThreadRequest } from "./messenger-thread-request.js";
 import type {
   ProjectListResponse,
   PostListResponse,
@@ -1064,6 +1065,32 @@ export class DoorayApiClient {
           json: { text } satisfies ChannelLogRequest,
         })
         .json<MessengerSendResponse>();
+    } catch (e) {
+      throw await toDoorayCliError(e);
+    }
+  }
+
+  async createChannelThread(
+    channelId: string,
+    text: string,
+    threadText?: string,
+  ): Promise<MessengerSendResponse> {
+    try {
+      const req = buildThreadRequest(channelId, text, { threadText });
+      return await this.api.post(req.path, { json: req.json }).json<MessengerSendResponse>();
+    } catch (e) {
+      throw await toDoorayCliError(e);
+    }
+  }
+
+  async createLogThread(
+    channelId: string,
+    logId: string,
+    text: string,
+  ): Promise<MessengerSendResponse> {
+    try {
+      const req = buildThreadRequest(channelId, text, { logId });
+      return await this.api.post(req.path, { json: req.json }).json<MessengerSendResponse>();
     } catch (e) {
       throw await toDoorayCliError(e);
     }

--- a/src/api/messenger-thread-request.test.ts
+++ b/src/api/messenger-thread-request.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { buildThreadRequest } from "./messenger-thread-request.js";
+
+describe("buildThreadRequest", () => {
+  it("channelId 와 text 만 주면 대화방 스레드 경로를 낸다", () => {
+    const req = buildThreadRequest("1111111111111111111", "본문");
+    expect(req.path).toBe(
+      "messenger/v1/channels/1111111111111111111/threads/create-and-send",
+    );
+  });
+
+  it("threadText 를 생략하면 body 에 threadText 키가 없다", () => {
+    const req = buildThreadRequest("1111111111111111111", "본문");
+    expect(req.json).toEqual({ text: "본문" });
+    expect(req.json).not.toHaveProperty("threadText");
+  });
+
+  it("threadText 를 주면 body 에 그 값이 들어간다", () => {
+    const req = buildThreadRequest("1111111111111111111", "본문", {
+      threadText: "첫 메시지",
+    });
+    expect(req.json).toEqual({ text: "본문", threadText: "첫 메시지" });
+  });
+
+  it("logId 를 주면 경로에 logs/{logId} 가 들어가고 body 는 text 뿐이다", () => {
+    const req = buildThreadRequest("1111111111111111111", "본문", {
+      logId: "2222222222222222222",
+      threadText: "무시된다",
+    });
+    expect(req.path).toBe(
+      "messenger/v1/channels/1111111111111111111/logs/2222222222222222222/threads/create-and-send",
+    );
+    expect(req.json).toEqual({ text: "본문" });
+    expect(req.json).not.toHaveProperty("threadText");
+  });
+});

--- a/src/api/messenger-thread-request.ts
+++ b/src/api/messenger-thread-request.ts
@@ -1,0 +1,37 @@
+import type { ChannelThreadRequest, LogThreadRequest } from "./types.js";
+
+export interface ThreadRequest {
+  path: string;
+  json: ChannelThreadRequest | LogThreadRequest;
+}
+
+/**
+ * 스레드 생성 요청의 경로와 body 를 만든다 (ADR-052).
+ *
+ * - `logId` 가 있으면 `logs/{logId}/threads/create-and-send` 를 호출하고 body 는 `{ text }` 뿐이다.
+ *   `threadText` 는 이 경로에서 받지 않으므로 무시한다.
+ * - `logId` 가 없으면 `threads/create-and-send` 를 호출하고, `threadText` 가 주어졌을 때만
+ *   그 키를 body 에 넣는다. 빈 문자열을 그대로 보내면 빈 메시지가 스레드에 생기기 때문이다.
+ */
+export function buildThreadRequest(
+  channelId: string,
+  text: string,
+  opts?: { logId?: string; threadText?: string },
+): ThreadRequest {
+  if (opts?.logId) {
+    const json: LogThreadRequest = { text };
+    return {
+      path: `messenger/v1/channels/${channelId}/logs/${opts.logId}/threads/create-and-send`,
+      json,
+    };
+  }
+
+  const json: ChannelThreadRequest = { text };
+  if (opts?.threadText) {
+    json.threadText = opts.threadText;
+  }
+  return {
+    path: `messenger/v1/channels/${channelId}/threads/create-and-send`,
+    json,
+  };
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -635,8 +635,19 @@ export interface ChannelLogRequest {
   text: string;
 }
 
+export interface ChannelThreadRequest {
+  text: string;
+  threadText?: string;
+}
+
+export interface LogThreadRequest {
+  text: string;
+}
+
 // direct-send 응답은 id·channelId·senderId·sentAt·seq·text 를 함께 준다 (실측, ADR-051).
 // channel logs 응답은 { id, channelId }. 쓰는 필드만 선언해 하나의 타입으로 흡수한다.
+// 스레드 생성 응답(threads/create-and-send)에서는 channelId 가 요청에 넣은 대화방 id 가 아니라
+// 새로 만들어진 스레드 채널의 id 다 (ADR-052)
 export interface MessengerSendResult {
   id: string;
   channelId?: string;

--- a/src/commands/messenger/index.ts
+++ b/src/commands/messenger/index.ts
@@ -1,9 +1,11 @@
 import { Command } from "commander";
 import { messengerSendCommand } from "./send.js";
 import { messengerChannelSendCommand } from "./channel-send.js";
+import { messengerThreadSendCommand } from "./thread-send.js";
 
 export const messengerCommand = new Command("messenger")
   .description("메신저 관련 명령");
 
 messengerCommand.addCommand(messengerSendCommand);
 messengerCommand.addCommand(messengerChannelSendCommand);
+messengerCommand.addCommand(messengerThreadSendCommand);

--- a/src/commands/messenger/thread-options.test.ts
+++ b/src/commands/messenger/thread-options.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { checkThreadOptions } from "./thread-options.js";
+
+describe("checkThreadOptions", () => {
+  it("--channel 과 --body 기본 조합은 경고도 에러도 없다", () => {
+    expect(checkThreadOptions({ body: "본문" })).toEqual({ warnings: [] });
+  });
+
+  it("--body 와 --thread-body 를 함께 주면 경고도 에러도 없다", () => {
+    expect(checkThreadOptions({ body: "본문", threadBody: "첫 메시지" })).toEqual({
+      warnings: [],
+    });
+  });
+
+  it("--log 와 --body 조합은 경고도 에러도 없다", () => {
+    expect(checkThreadOptions({ log: "1234567890123456789", body: "본문" })).toEqual({
+      warnings: [],
+    });
+  });
+
+  it("--log 와 --thread-body 를 함께 주면 경고 대상이다", () => {
+    const result = checkThreadOptions({
+      log: "1234567890123456789",
+      body: "본문",
+      threadBody: "첫 메시지",
+    });
+    expect(result.warnings).toHaveLength(1);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("--log 와 --thread-body-file 을 함께 주면 경고 대상이다", () => {
+    const result = checkThreadOptions({
+      log: "1234567890123456789",
+      body: "본문",
+      threadBodyFile: "./thread.txt",
+    });
+    expect(result.warnings).toHaveLength(1);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("--thread-body 와 --thread-body-file 을 함께 주면 에러다", () => {
+    const result = checkThreadOptions({
+      body: "본문",
+      threadBody: "첫 메시지",
+      threadBodyFile: "./thread.txt",
+    });
+    expect(result.error).toBe(
+      "--thread-body와 --thread-body-file은 함께 사용할 수 없습니다.",
+    );
+  });
+
+  it("--body - 와 --thread-body - 를 함께 주면 에러다", () => {
+    const result = checkThreadOptions({ body: "-", threadBody: "-" });
+    expect(result.error).toBe(
+      "--body와 --thread-body는 동시에 stdin(-)을 지정할 수 없습니다.",
+    );
+  });
+
+  it("--body-file - 와 --thread-body-file - 를 함께 주면 에러다", () => {
+    const result = checkThreadOptions({ bodyFile: "-", threadBodyFile: "-" });
+    expect(result.error).toBe(
+      "--body와 --thread-body는 동시에 stdin(-)을 지정할 수 없습니다.",
+    );
+  });
+});

--- a/src/commands/messenger/thread-options.test.ts
+++ b/src/commands/messenger/thread-options.test.ts
@@ -52,14 +52,23 @@ describe("checkThreadOptions", () => {
   it("--body - 와 --thread-body - 를 함께 주면 에러다", () => {
     const result = checkThreadOptions({ body: "-", threadBody: "-" });
     expect(result.error).toBe(
-      "--body와 --thread-body는 동시에 stdin(-)을 지정할 수 없습니다.",
+      '--body 과 --thread-body 에 동시에 "-" 를 줄 수 없습니다. stdin 은 한 번만 읽습니다.',
     );
   });
 
-  it("--body-file - 와 --thread-body-file - 를 함께 주면 에러다", () => {
+  // 에러 문구가 실제로 준 옵션 이름을 낸다. 계열 이름으로 고정하면
+  // --body-file 을 준 사용자가 --body 를 지적받아 어느 옵션을 고칠지 알 수 없다.
+  it("--body-file - 와 --thread-body-file - 를 함께 주면 그 옵션 이름으로 에러를 낸다", () => {
     const result = checkThreadOptions({ bodyFile: "-", threadBodyFile: "-" });
     expect(result.error).toBe(
-      "--body와 --thread-body는 동시에 stdin(-)을 지정할 수 없습니다.",
+      '--body-file 과 --thread-body-file 에 동시에 "-" 를 줄 수 없습니다. stdin 은 한 번만 읽습니다.',
+    );
+  });
+
+  it("--body - 와 --thread-body-file - 처럼 계열이 섞여도 준 옵션을 낸다", () => {
+    const result = checkThreadOptions({ body: "-", threadBodyFile: "-" });
+    expect(result.error).toBe(
+      '--body 과 --thread-body-file 에 동시에 "-" 를 줄 수 없습니다. stdin 은 한 번만 읽습니다.',
     );
   });
 });

--- a/src/commands/messenger/thread-options.ts
+++ b/src/commands/messenger/thread-options.ts
@@ -35,13 +35,17 @@ export function checkThreadOptions(opts: ThreadSendOptions): ThreadOptionsCheck 
     };
   }
 
-  // stdin은 한 번만 읽을 수 있어 --body와 --thread-body 계열이 동시에 "-" 를 가리킬 수 없다.
-  const bodyIsStdin = opts.body === "-" || opts.bodyFile === "-";
-  const threadBodyIsStdin = opts.threadBody === "-" || opts.threadBodyFile === "-";
-  if (bodyIsStdin && threadBodyIsStdin) {
+  // stdin은 한 번만 읽을 수 있어 본문과 스레드 본문이 동시에 "-" 를 가리킬 수 없다.
+  // 실제로 준 옵션 이름을 문구에 넣는다. 계열 이름만 쓰면 --body-file 을 준
+  // 사용자가 --body 를 지적받아 어느 옵션을 고쳐야 할지 알 수 없다.
+  const bodyStdinOption =
+    opts.body === "-" ? "--body" : opts.bodyFile === "-" ? "--body-file" : null;
+  const threadStdinOption =
+    opts.threadBody === "-" ? "--thread-body" : opts.threadBodyFile === "-" ? "--thread-body-file" : null;
+  if (bodyStdinOption && threadStdinOption) {
     return {
       warnings,
-      error: "--body와 --thread-body는 동시에 stdin(-)을 지정할 수 없습니다.",
+      error: `${bodyStdinOption} 과 ${threadStdinOption} 에 동시에 "-" 를 줄 수 없습니다. stdin 은 한 번만 읽습니다.`,
     };
   }
 

--- a/src/commands/messenger/thread-options.ts
+++ b/src/commands/messenger/thread-options.ts
@@ -1,0 +1,49 @@
+export interface ThreadSendOptions {
+  log?: string;
+  body?: string;
+  bodyFile?: string;
+  threadBody?: string;
+  threadBodyFile?: string;
+}
+
+export interface ThreadOptionsCheck {
+  warnings: string[];
+  error?: string;
+}
+
+/**
+ * `thread-send` 옵션 조합을 판정한다 (ADR-052).
+ *
+ * 던지지 않고 결과를 돌려준다. 호출부가 경고를 stderr 로, 에러를 `DoorayCliError` 로 옮긴다.
+ */
+export function checkThreadOptions(opts: ThreadSendOptions): ThreadOptionsCheck {
+  const warnings: string[] = [];
+
+  // logs/{log-id}/threads/create-and-send 는 text 만 받는다. threadText 는 전달할 곳이 없다.
+  if (opts.log && (opts.threadBody != null || opts.threadBodyFile != null)) {
+    warnings.push(
+      "--log 와 함께 --thread-body/--thread-body-file 을 지정해도 무시됩니다. logs 스레드는 --body 만 사용합니다.",
+    );
+  }
+
+  // readBodyInputOrNull({ body, bodyFile }) 은 이 이름으로만 동시 지정을 검사하므로,
+  // threadBody/threadBodyFile 이름으로 넘기는 이 옵션 쌍은 스스로 잡지 못한다.
+  if (opts.threadBody != null && opts.threadBodyFile != null) {
+    return {
+      warnings,
+      error: "--thread-body와 --thread-body-file은 함께 사용할 수 없습니다.",
+    };
+  }
+
+  // stdin은 한 번만 읽을 수 있어 --body와 --thread-body 계열이 동시에 "-" 를 가리킬 수 없다.
+  const bodyIsStdin = opts.body === "-" || opts.bodyFile === "-";
+  const threadBodyIsStdin = opts.threadBody === "-" || opts.threadBodyFile === "-";
+  if (bodyIsStdin && threadBodyIsStdin) {
+    return {
+      warnings,
+      error: "--body와 --thread-body는 동시에 stdin(-)을 지정할 수 없습니다.",
+    };
+  }
+
+  return { warnings };
+}

--- a/src/commands/messenger/thread-send.ts
+++ b/src/commands/messenger/thread-send.ts
@@ -66,24 +66,25 @@ export const messengerThreadSendCommand = new Command("thread-send")
             bodyContent,
             threadBodyContent ?? undefined,
           );
-      stopSpinner(
-        true,
-        `스레드를 열었습니다 (log-id: ${res.result.id}, thread-channel-id: ${res.result.channelId})`,
-      );
+      // `channelId` 는 타입상 optional 이다. 문구를 만들기 전에 한 곳에서 검증해
+      // 세 출력 경로가 같은 실패로 모이게 한다. 검증을 quiet 경로에만 두면
+      // 나머지 둘이 `thread-channel-id: undefined` 를 그대로 낸다.
+      const threadChannelId = res.result.channelId;
+      if (!threadChannelId) {
+        throw new DoorayCliError(
+          "응답에 channelId가 없어 스레드 채널을 특정할 수 없습니다.",
+          EXIT_API_ERROR,
+        );
+      }
+
+      const summary = `스레드를 열었습니다 (log-id: ${res.result.id}, thread-channel-id: ${threadChannelId})`;
+      stopSpinner(true, summary);
       if (globalOpts.json) {
         printJson(res.result);
       } else if (globalOpts.quiet) {
-        if (!res.result.channelId) {
-          throw new DoorayCliError(
-            "응답에 channelId가 없어 --quiet로 출력할 값이 없습니다.",
-            EXIT_API_ERROR,
-          );
-        }
-        process.stdout.write(`${res.result.channelId}\n`);
+        process.stdout.write(`${threadChannelId}\n`);
       } else {
-        process.stdout.write(
-          `스레드를 열었습니다 (log-id: ${res.result.id}, thread-channel-id: ${res.result.channelId})\n`,
-        );
+        process.stdout.write(`${summary}\n`);
       }
     } catch (e) {
       stopSpinner(false);

--- a/src/commands/messenger/thread-send.ts
+++ b/src/commands/messenger/thread-send.ts
@@ -47,10 +47,15 @@ export const messengerThreadSendCommand = new Command("thread-send")
     }
 
     // 스레드 첫 메시지는 선택이다. 생략을 허용하기 위해 에디터를 열지 않는다.
-    const threadBodyContent = await readBodyInputOrNull({
-      body: opts.threadBody,
-      bodyFile: opts.threadBodyFile,
-    });
+    //
+    // `--log` 분기는 이 값을 쓰지 않는다. 그런데도 읽으면 없는 파일을 준 경우
+    // 「무시됩니다」 경고를 낸 직후 ENOENT 로 죽는다. 경고와 동작이 어긋난다.
+    const threadBodyContent = opts.log
+      ? null
+      : await readBodyInputOrNull({
+          body: opts.threadBody,
+          bodyFile: opts.threadBodyFile,
+        });
 
     startSpinner("스레드 생성 중...");
     try {

--- a/src/commands/messenger/thread-send.ts
+++ b/src/commands/messenger/thread-send.ts
@@ -1,0 +1,87 @@
+import { Command } from "commander";
+import { getConfigOrThrow } from "../../config/store.js";
+import { DoorayApiClient } from "../../api/client.js";
+import { resolveMessengerChannel } from "../../resolvers/messenger-channel.js";
+import { openInEditor } from "../../editor/index.js";
+import { readBodyInputOrNull } from "../../utils/body-input.js";
+import { checkThreadOptions } from "./thread-options.js";
+import type { OutputOptions } from "../../formatters/table.js";
+import { printJson } from "../../formatters/table.js";
+import { startSpinner, stopSpinner } from "../../utils/spinner.js";
+import { DoorayCliError } from "../../utils/errors.js";
+import { EXIT_API_ERROR, EXIT_PARAM_ERROR } from "../../utils/exit-codes.js";
+
+export const messengerThreadSendCommand = new Command("thread-send")
+  .description("메신저 대화방에 스레드를 열어 전송 (--body 없으면 $EDITOR)")
+  .option("--channel <channelId|이름>", "대화방 channelId 또는 이름 (부분일치)")
+  .option("--log <log-id>", "이 메시지에 스레드를 연다. 생략하면 새 메시지를 보내며 연다")
+  .option("--body <text>", "대화방에 보낼 본문 (- 입력 시 stdin에서 읽기)")
+  .option("--body-file <path>", "본문 파일 경로 (- 입력 시 stdin에서 읽기)")
+  .option("--thread-body <text>", "스레드 첫 메시지 (- 입력 시 stdin에서 읽기)")
+  .option("--thread-body-file <path>", "스레드 첫 메시지 파일 경로 (- 입력 시 stdin에서 읽기)")
+  .action(async (opts) => {
+    if (!opts.channel) {
+      throw new DoorayCliError("--channel 옵션은 필수입니다.", EXIT_PARAM_ERROR);
+    }
+
+    const check = checkThreadOptions(opts);
+    if (check.error) {
+      throw new DoorayCliError(check.error, EXIT_PARAM_ERROR);
+    }
+    for (const warning of check.warnings) {
+      process.stderr.write(`경고: ${warning}\n`);
+    }
+
+    const globalOpts = messengerThreadSendCommand.optsWithGlobals() as OutputOptions;
+    const config = await getConfigOrThrow();
+    const client = new DoorayApiClient(config.apiKey, config.baseUrl);
+
+    const channelId = await resolveMessengerChannel(client, opts.channel);
+
+    let bodyContent = await readBodyInputOrNull(opts);
+    if (bodyContent == null) {
+      bodyContent = await openInEditor("");
+    }
+    if (!bodyContent.trim()) {
+      throw new DoorayCliError("빈 메시지는 전송할 수 없습니다.", EXIT_PARAM_ERROR);
+    }
+
+    // 스레드 첫 메시지는 선택이다. 생략을 허용하기 위해 에디터를 열지 않는다.
+    const threadBodyContent = await readBodyInputOrNull({
+      body: opts.threadBody,
+      bodyFile: opts.threadBodyFile,
+    });
+
+    startSpinner("스레드 생성 중...");
+    try {
+      const res = opts.log
+        ? await client.createLogThread(channelId, opts.log, bodyContent)
+        : await client.createChannelThread(
+            channelId,
+            bodyContent,
+            threadBodyContent ?? undefined,
+          );
+      stopSpinner(
+        true,
+        `스레드를 열었습니다 (log-id: ${res.result.id}, thread-channel-id: ${res.result.channelId})`,
+      );
+      if (globalOpts.json) {
+        printJson(res.result);
+      } else if (globalOpts.quiet) {
+        if (!res.result.channelId) {
+          throw new DoorayCliError(
+            "응답에 channelId가 없어 --quiet로 출력할 값이 없습니다.",
+            EXIT_API_ERROR,
+          );
+        }
+        process.stdout.write(`${res.result.channelId}\n`);
+      } else {
+        process.stdout.write(
+          `스레드를 열었습니다 (log-id: ${res.result.id}, thread-channel-id: ${res.result.channelId})\n`,
+        );
+      }
+    } catch (e) {
+      stopSpinner(false);
+      throw e;
+    }
+  });

--- a/tasks/plan066-feat-messenger-thread-send/index.json
+++ b/tasks/plan066-feat-messenger-thread-send/index.json
@@ -1,0 +1,12 @@
+{
+  "name": "plan066-feat-messenger-thread-send",
+  "description": "메신저 스레드 생성을 messenger thread-send 한 명령에 --log 분기로 추가한다",
+  "status": "pending",
+  "created_at": "2026-09-08",
+  "total_phases": 2,
+  "current_phase": 1,
+  "phases": [
+    { "number": 1, "file": "phase-01.md", "execution_profile": "standard", "status": "pending" },
+    { "number": 2, "file": "phase-02.md", "execution_profile": "standard", "status": "pending" }
+  ]
+}

--- a/tasks/plan066-feat-messenger-thread-send/phase-01.md
+++ b/tasks/plan066-feat-messenger-thread-send/phase-01.md
@@ -89,7 +89,46 @@ async createLogThread(
 
 `sendChannelMessage` 와 같은 형태로 쓴다. `try` 로 감싸고 `toDoorayCliError` 로 던진다.
 
-`threadText` 가 없으면 요청 body 에 그 키를 넣지 않는다. 빈 문자열을 보내면 빈 메시지가 스레드에 생긴다.
+**요청 경로와 body 는 항목 2-1 의 순수 함수가 만든다.** 클라이언트 메서드는 그 결과를 `post` 에 넘기기만 한다.
+
+### 2-1. 요청 경로와 body 를 만드는 순수 함수를 뺀다
+
+`src/api/messenger-thread-request.ts` 를 새로 만든다.
+
+```ts
+export interface ThreadRequest {
+  path: string;
+  json: ChannelThreadRequest | LogThreadRequest;
+}
+
+export function buildThreadRequest(
+  channelId: string,
+  text: string,
+  opts?: { logId?: string; threadText?: string },
+): ThreadRequest
+```
+
+- `logId` 가 있으면 `messenger/v1/channels/{channelId}/logs/{logId}/threads/create-and-send` 와 `{ text }` 를 낸다.
+  `threadText` 는 그 경로에서 무시한다
+- `logId` 가 없으면 `messenger/v1/channels/{channelId}/threads/create-and-send` 를 낸다.
+  `threadText` 가 있을 때만 그 키를 body 에 넣는다. 빈 문자열을 보내면 빈 메시지가 스레드에 생긴다
+
+`src/commands/wiki/page-move.ts` 의 `buildMoveBody` 가 같은 형태의 선례다.
+그 함수도 기본값일 때 키를 넣지 않는 것을 `page-move.test.ts` 가 직접 검사한다.
+
+### 2-2. `src/api/messenger-thread-request.test.ts` 를 만든다
+
+담을 것은 넷이다.
+
+| 확인할 것 | 입력 | 기대 |
+| --- | --- | --- |
+| 대화방 스레드 경로 | `channelId` 와 `text` | 경로가 `channels/{id}/threads/create-and-send` 다 |
+| `threadText` 생략 | `threadText` 를 주지 않음 | body 에 `threadText` 키가 없다 |
+| `threadText` 지정 | `threadText` 를 줌 | body 에 그 값이 들어간다 |
+| log 스레드 경로 | `logId` 를 줌 | 경로에 `logs/{logId}` 가 들어가고 body 는 `{ text }` 뿐이다 |
+
+`threadText` 생략 검사는 값 비교가 아니라 키 존재로 본다.
+`expect(json).not.toHaveProperty("threadText")` 형태여야 빈 문자열이 들어간 경우도 잡힌다.
 
 ### 3. 옵션 조합 판정을 순수 함수로 만든다
 
@@ -98,19 +137,30 @@ async createLogThread(
 명령 본체는 네트워크와 편집기를 타서 단위 테스트가 어렵다.
 갈리는 판정만 떼어 내면 테스트할 수 있다.
 
-판정할 것은 둘이다.
+판정할 것은 셋이다.
 
 - **`--log` 와 `--thread-body` 계열을 함께 주면** 경고할 대상이라고 알린다.
   `logs/{log-id}/threads/create-and-send` 는 `text` 만 받기 때문이다.
+- **`--thread-body` 와 `--thread-body-file` 을 함께 주면** 에러다.
+  `readBodyInputOrNull` 이 이 조합을 스스로 잡지 못한다. 아래 「필드명」 항목이 이유를 적는다.
 - **`--body-file -` 과 `--thread-body-file -` 을 함께 주면** 에러다.
   stdin 은 한 번만 읽을 수 있어 둘 다 받을 수 없다. `--body -` 와 `--thread-body -` 도 같다.
+
+**필드명**: `readBodyInputOrNull` 은 `{ body, bodyFile }` 두 이름만 읽는다 (`src/utils/body-input.ts`).
+스레드 첫 메시지를 읽을 때는 `{ body: opts.threadBody, bodyFile: opts.threadBodyFile }` 로 이름을 바꿔 넘긴다.
+그 함수가 내는 동시 지정 에러 문구는 `--body와 --body-file은 함께 사용할 수 없습니다.` 라서
+스레드 옵션에는 맞지 않는다. 그래서 판정 함수가 그 조합을 먼저 잡는다.
 
 함수는 입력한 옵션을 받아 판정 결과를 돌려준다. 던지지 않고 돌려준다.
 그래야 호출부가 경고와 에러를 각각 어떻게 낼지 정할 수 있고 테스트가 쉬워진다.
 
+반환 모양은 `{ warnings: string[]; error?: string }` 이다.
+문제가 없으면 `warnings` 가 빈 배열이고 `error` 가 없다.
+문구를 그대로 담아 호출부가 stderr 와 `DoorayCliError` 에 옮기기만 하게 한다.
+
 ### 4. `src/commands/messenger/thread-options.test.ts` 를 만든다
 
-담을 것은 아래 여섯이다.
+담을 것은 아래 일곱과, 표 아래 한 줄이 요구하는 한 건을 더해 여덟이다.
 
 | 확인할 것 | 입력 | 기대 |
 | --- | --- | --- |
@@ -119,6 +169,7 @@ async createLogThread(
 | log 분기 | `--channel` 과 `--log` 와 `--body` | 경고도 에러도 없다 |
 | log 와 스레드 본문 충돌 | `--log` 와 `--thread-body` | 경고 대상이다 |
 | log 와 스레드 본문 파일 충돌 | `--log` 와 `--thread-body-file` | 경고 대상이다 |
+| 스레드 본문 중복 지정 | `--thread-body` 와 `--thread-body-file` | 에러다 |
 | stdin 중복 | `--body -` 와 `--thread-body -` | 에러다 |
 
 `--body-file -` 과 `--thread-body-file -` 조합도 한 건 넣는다.
@@ -156,7 +207,9 @@ async createLogThread(
 출력은 세 형식이다.
 
 - `--json` — `res.result` 를 그대로 낸다
-- `--quiet` — `res.result.channelId` 를 낸다. 다른 messenger 명령과 다른 점이고 근거는 ADR-052 다
+- `--quiet` — `res.result.channelId` 를 낸다. 다른 messenger 명령과 다른 점이고 근거는 ADR-052 다.
+  타입이 `string | undefined` 라 값이 없으면 빈 줄을 내지 말고 `EXIT_API_ERROR` 로 끝낸다.
+  자동화가 그 값을 다음 호출에 넣기 때문에 빈 문자열이 흘러가면 엉뚱한 곳에 메시지가 간다
 - 기본 — 사람이 읽는 한 줄. log-id 와 스레드 채널 id 를 함께 보여준다.
   스레드에 메시지를 이으려면 뒤의 값이 필요하므로 둘을 구분해 적는다
 
@@ -181,7 +234,7 @@ pnpm test
 
 ```bash
 # cwd: <repo root>
-pnpm vitest run src/commands/messenger/thread-options.test.ts
+pnpm vitest run src/commands/messenger/thread-options.test.ts src/api/messenger-thread-request.test.ts
 ```
 
 명령이 실제로 등록됐는지 본다.
@@ -214,6 +267,7 @@ node dist/index.js messenger thread-send --body "x" ; echo "종료코드=$?"
 ```bash
 # cwd: <repo root>
 ls src/commands/messenger/thread-send.ts src/commands/messenger/thread-options.ts src/commands/messenger/thread-options.test.ts
+ls src/api/messenger-thread-request.ts src/api/messenger-thread-request.test.ts
 grep -c "threadSendCommand" src/commands/messenger/index.ts    # >= 1
 grep -c "createChannelThread" src/api/client.ts                # >= 1
 grep -c "createLogThread" src/api/client.ts                    # >= 1
@@ -249,6 +303,8 @@ node scripts/check-pii.mjs
 |---|---|
 | `src/api/types.ts` | 수정 — 요청 타입 둘 추가 |
 | `src/api/client.ts` | 수정 — 메서드 둘 추가 |
+| `src/api/messenger-thread-request.ts` | 신규 — 경로와 body 를 만드는 순수 함수 |
+| `src/api/messenger-thread-request.test.ts` | 신규 |
 | `src/commands/messenger/thread-options.ts` | 신규 |
 | `src/commands/messenger/thread-options.test.ts` | 신규 |
 | `src/commands/messenger/thread-send.ts` | 신규 |

--- a/tasks/plan066-feat-messenger-thread-send/phase-01.md
+++ b/tasks/plan066-feat-messenger-thread-send/phase-01.md
@@ -1,0 +1,255 @@
+# Phase 01. `messenger thread-send` 를 만든다
+
+**Execution profile**: standard
+
+## 목표
+
+대화방에 스레드를 여는 `dooray messenger thread-send` 를 추가한다.
+`--log` 유무로 공식 endpoint 둘을 가른다.
+
+**범위 외**: 이 phase 는 문서를 고치지 않는다. README 와 스킬 문서와 `docs/` 는 phase 02 다.
+메시지 수정과 삭제와 답장 endpoint 는 이 plan 이 다루지 않는다.
+
+## 컨텍스트
+
+**근거 문서**: `docs/adr/052-messenger-thread-send.md`.
+
+호출할 endpoint 는 둘이다.
+
+| `--log` | endpoint | 요청 body |
+| --- | --- | --- |
+| 없음 | `POST messenger/v1/channels/{channel-id}/threads/create-and-send` | `{ text, threadText? }` |
+| 있음 | `POST messenger/v1/channels/{channel-id}/logs/{log-id}/threads/create-and-send` | `{ text }` |
+
+**응답 모양은 둘이 같다.** 실측한 것이 아래다.
+
+```json
+{"header":{"resultCode":0,"resultMessage":"","isSuccessful":true},"result":{"id":"1111222233334444555","channelId":"2222333344445555666"}}
+```
+
+`id` 는 log-id 이고 `channelId` 는 새로 만들어진 스레드 채널의 id 다.
+요청에 넣은 대화방 id 와 다른 값이 온다.
+
+**공식 문서가 말하는 `threadChannelId` 필드는 오지 않는다.**
+문서의 `logs` 절이 `$.result.threadChannelId` 를 쓰라고 적지만 응답에 그 이름의 필드가 없다.
+`channelId` 가 그 역할이며, 그 값으로 `POST channels/{id}/logs` 를 보내 스레드에 메시지가 붙는 것을 실측했다.
+근거는 ADR-052 의 「실측으로 확인한 것」 절이다.
+
+응답의 `id` 와 `channelId` 는 문자열로 온다. 이 endpoint 에는 정밀도 문제가 없다.
+
+**재사용할 것**은 셋이다.
+
+| 무엇 | 어디 | 쓰는 이유 |
+| --- | --- | --- |
+| `resolveMessengerChannel` | `src/resolvers/messenger-channel.ts` | `--channel` 이 channelId 나 대화방 이름을 받는다 |
+| `readBodyInputOrNull` | `src/utils/body-input.ts` | `--body` 와 `--body-file` 과 `-` stdin 을 함께 처리한다 |
+| `openInEditor` | `src/editor/index.ts` | 본문이 없으면 편집기를 연다 |
+
+`src/commands/messenger/channel-send.ts` 가 이 셋을 모두 쓴다. 구조를 그대로 따른다.
+
+## 의도 메모
+
+- 명령을 둘로 나누지 않는 이유는 ADR-052 의 「대안 기각」 이 적는다. 옵션 대부분이 겹치기 때문이다.
+- `--quiet` 가 `channelId` 를 내는 것은 다른 messenger 명령과 다르다. 근거도 그 ADR 이 적는다.
+  스레드를 연 다음에 하는 일이 그 스레드에 메시지를 잇는 것이고, 그 호출에 필요한 값이 `channelId` 다.
+- 옵션 조합 판정을 순수 함수로 빼서 테스트한다. 명령 본체는 네트워크를 타서 단위 테스트가 어렵다.
+
+## 작업 항목
+
+### 1. `src/api/types.ts` 에 요청 타입 둘을 넣는다
+
+`ChannelLogRequest` 바로 아래에 둔다. 같은 Messenger 절이다.
+
+- `ChannelThreadRequest` — `text: string` 과 `threadText?: string`
+- `LogThreadRequest` — `text: string`
+
+응답 타입은 새로 만들지 않는다. `MessengerSendResult` 가 `id` 와 `channelId?` 를 이미 담는다.
+스레드 응답은 둘 다 항상 오지만, 그 타입을 좁히려고 새 타입을 만들면 같은 모양이 둘이 된다.
+
+주석으로 `channelId` 가 스레드 응답에서는 스레드 채널 id 라는 것을 한 줄 남긴다.
+이름만 보면 요청에 넣은 대화방 id 로 읽히기 때문이다.
+
+### 2. `src/api/client.ts` 에 메서드 둘을 넣는다
+
+기존 Messenger 절 안, `sendChannelMessage` 아래에 둔다.
+
+```ts
+async createChannelThread(
+  channelId: string,
+  text: string,
+  threadText?: string,
+): Promise<MessengerSendResponse>
+
+async createLogThread(
+  channelId: string,
+  logId: string,
+  text: string,
+): Promise<MessengerSendResponse>
+```
+
+`sendChannelMessage` 와 같은 형태로 쓴다. `try` 로 감싸고 `toDoorayCliError` 로 던진다.
+
+`threadText` 가 없으면 요청 body 에 그 키를 넣지 않는다. 빈 문자열을 보내면 빈 메시지가 스레드에 생긴다.
+
+### 3. 옵션 조합 판정을 순수 함수로 만든다
+
+`src/commands/messenger/thread-options.ts` 를 새로 만든다.
+
+명령 본체는 네트워크와 편집기를 타서 단위 테스트가 어렵다.
+갈리는 판정만 떼어 내면 테스트할 수 있다.
+
+판정할 것은 둘이다.
+
+- **`--log` 와 `--thread-body` 계열을 함께 주면** 경고할 대상이라고 알린다.
+  `logs/{log-id}/threads/create-and-send` 는 `text` 만 받기 때문이다.
+- **`--body-file -` 과 `--thread-body-file -` 을 함께 주면** 에러다.
+  stdin 은 한 번만 읽을 수 있어 둘 다 받을 수 없다. `--body -` 와 `--thread-body -` 도 같다.
+
+함수는 입력한 옵션을 받아 판정 결과를 돌려준다. 던지지 않고 돌려준다.
+그래야 호출부가 경고와 에러를 각각 어떻게 낼지 정할 수 있고 테스트가 쉬워진다.
+
+### 4. `src/commands/messenger/thread-options.test.ts` 를 만든다
+
+담을 것은 아래 여섯이다.
+
+| 확인할 것 | 입력 | 기대 |
+| --- | --- | --- |
+| 기본 조합 | `--channel` 과 `--body` | 경고도 에러도 없다 |
+| 스레드 본문 동반 | `--channel` 과 `--body` 와 `--thread-body` | 경고도 에러도 없다 |
+| log 분기 | `--channel` 과 `--log` 와 `--body` | 경고도 에러도 없다 |
+| log 와 스레드 본문 충돌 | `--log` 와 `--thread-body` | 경고 대상이다 |
+| log 와 스레드 본문 파일 충돌 | `--log` 와 `--thread-body-file` | 경고 대상이다 |
+| stdin 중복 | `--body -` 와 `--thread-body -` | 에러다 |
+
+`--body-file -` 과 `--thread-body-file -` 조합도 한 건 넣는다.
+
+### 5. `src/commands/messenger/thread-send.ts` 를 만든다
+
+`channel-send.ts` 를 구조의 본으로 삼는다.
+
+옵션은 이렇다.
+
+| 옵션 | 설명 |
+| --- | --- |
+| `--channel <channelId\|이름>` | 대화방. 필수 |
+| `--log <log-id>` | 이 메시지에 스레드를 연다. 생략하면 새 메시지를 보내며 연다 |
+| `--body <text>` | 대화방에 보낼 본문. `-` 는 stdin |
+| `--body-file <path>` | 본문 파일. `-` 는 stdin |
+| `--thread-body <text>` | 스레드 첫 메시지. `-` 는 stdin |
+| `--thread-body-file <path>` | 스레드 첫 메시지 파일. `-` 는 stdin |
+
+실행 순서는 이렇다.
+
+1. `--channel` 이 없으면 `EXIT_PARAM_ERROR` 로 에러를 낸다. `channel-send.ts` 와 같은 문구 형식을 쓴다
+2. 항목 3 의 판정 함수를 부른다. 에러면 `EXIT_PARAM_ERROR`, 경고면 stderr 에 한 줄 낸다
+3. 설정을 읽고 클라이언트를 만든다
+4. `resolveMessengerChannel` 로 channelId 를 얻는다
+5. 본문을 읽는다. `--body` 와 `--body-file` 이 둘 다 없으면 `openInEditor` 를 연다
+6. 본문이 비어 있으면 `EXIT_PARAM_ERROR` 로 에러를 낸다
+7. 스레드 첫 메시지를 읽는다. 없으면 `undefined` 로 둔다. 여기서는 편집기를 열지 않는다
+8. `--log` 유무로 `createLogThread` 나 `createChannelThread` 를 부른다
+9. 결과를 낸다
+
+**스레드 첫 메시지가 없을 때 편집기를 열지 않는다.** 본문과 달리 이 값은 선택이다.
+편집기를 열면 생략할 방법이 사라진다.
+
+출력은 세 형식이다.
+
+- `--json` — `res.result` 를 그대로 낸다
+- `--quiet` — `res.result.channelId` 를 낸다. 다른 messenger 명령과 다른 점이고 근거는 ADR-052 다
+- 기본 — 사람이 읽는 한 줄. log-id 와 스레드 채널 id 를 함께 보여준다.
+  스레드에 메시지를 이으려면 뒤의 값이 필요하므로 둘을 구분해 적는다
+
+스피너는 `channel-send.ts` 와 같이 쓴다. 실패하면 `stopSpinner(false)` 후 다시 던진다.
+
+### 6. `src/commands/messenger/index.ts` 에 등록한다
+
+`messengerChannelSendCommand` 아래에 `addCommand` 한 줄을 더한다.
+
+## 검증
+
+```bash
+# cwd: <repo root>
+pnpm tsc --noEmit
+pnpm run build
+pnpm test
+```
+
+셋 다 통과해야 한다.
+
+새 테스트만 골라 돌려 확인한다.
+
+```bash
+# cwd: <repo root>
+pnpm vitest run src/commands/messenger/thread-options.test.ts
+```
+
+명령이 실제로 등록됐는지 본다.
+
+```bash
+# cwd: <repo root>
+node dist/index.js messenger --help
+```
+
+출력에 `thread-send` 가 있어야 한다.
+
+```bash
+# cwd: <repo root>
+node dist/index.js messenger thread-send --help
+```
+
+출력에 위 표의 옵션 여섯이 모두 있어야 한다.
+
+`--channel` 없이 부르면 종료 코드 3 으로 끝나는지 본다.
+
+```bash
+# cwd: <repo root>
+node dist/index.js messenger thread-send --body "x" ; echo "종료코드=$?"
+```
+
+`종료코드=3` 이어야 한다. `EXIT_PARAM_ERROR` 가 3 이다.
+
+파일이 생겼는지 본다.
+
+```bash
+# cwd: <repo root>
+ls src/commands/messenger/thread-send.ts src/commands/messenger/thread-options.ts src/commands/messenger/thread-options.test.ts
+grep -c "threadSendCommand" src/commands/messenger/index.ts    # >= 1
+grep -c "createChannelThread" src/api/client.ts                # >= 1
+grep -c "createLogThread" src/api/client.ts                    # >= 1
+```
+
+**실제 발송으로 한 번 확인한다.** 응답 모양은 서버만 알려준다.
+
+본인과의 대화방에 스레드를 열고, 나온 `channelId` 로 메시지를 이어 본다.
+
+```bash
+# cwd: <repo root>
+CH=$(node dist/index.js messenger thread-send --channel <본인 대화방> --body "스레드 확인" --thread-body "첫 메시지" --quiet)
+node dist/index.js messenger channel-send --channel "$CH" --body "이어 붙인 메시지"
+```
+
+둘 다 성공하고, 두 번째 메시지가 대화방 본문이 아니라 스레드 안에 붙어야 한다.
+
+**이 확인은 실제 메시지를 보낸다.** 본인에게 보내면 다른 사람에게 알림이 가지 않는다.
+설정이 없어 실행할 수 없으면 건너뛰고 그 사실을 보고한다.
+
+개인 식별 정보를 확인한다.
+
+```bash
+# cwd: <repo root>
+node scripts/check-pii.mjs
+```
+
+종료 코드 0 이어야 한다.
+
+## Critical Files
+
+| 파일 | 변경 |
+|---|---|
+| `src/api/types.ts` | 수정 — 요청 타입 둘 추가 |
+| `src/api/client.ts` | 수정 — 메서드 둘 추가 |
+| `src/commands/messenger/thread-options.ts` | 신규 |
+| `src/commands/messenger/thread-options.test.ts` | 신규 |
+| `src/commands/messenger/thread-send.ts` | 신규 |
+| `src/commands/messenger/index.ts` | 수정 — 명령 등록 |

--- a/tasks/plan066-feat-messenger-thread-send/phase-01.md
+++ b/tasks/plan066-feat-messenger-thread-send/phase-01.md
@@ -273,20 +273,16 @@ grep -c "createChannelThread" src/api/client.ts                # >= 1
 grep -c "createLogThread" src/api/client.ts                    # >= 1
 ```
 
-**실제 발송으로 한 번 확인한다.** 응답 모양은 서버만 알려준다.
+**실제 발송은 하지 않는다.** 이 phase 는 메시지를 보내지 않는다.
 
-본인과의 대화방에 스레드를 열고, 나온 `channelId` 로 메시지를 이어 본다.
+응답 모양은 이미 `docs/adr/052-messenger-thread-send.md` 가 실측으로 적어 두었다.
+경로와 요청 body 가 맞는지는 `buildThreadRequest` 의 단위 테스트가 판정하고,
+옵션 조합은 `checkThreadOptions` 의 테스트가 판정한다. 둘 다 서버로 나가지 않는다.
 
-```bash
-# cwd: <repo root>
-CH=$(node dist/index.js messenger thread-send --channel <본인 대화방> --body "스레드 확인" --thread-body "첫 메시지" --quiet)
-node dist/index.js messenger channel-send --channel "$CH" --body "이어 붙인 메시지"
-```
-
-둘 다 성공하고, 두 번째 메시지가 대화방 본문이 아니라 스레드 안에 붙어야 한다.
-
-**이 확인은 실제 메시지를 보낸다.** 본인에게 보내면 다른 사람에게 알림이 가지 않는다.
-설정이 없어 실행할 수 없으면 건너뛰고 그 사실을 보고한다.
+발송으로 확인하고 싶으면 사람이 대상을 직접 정해서 실행한다.
+이 문서에 대상 자리를 비워 두면 실행하는 쪽이 그 자리를 채우게 된다.
+`--channel` 은 이름 부분일치도 받고 목록에서 고를 수도 있어, 엉뚱한 대화방으로 나갈 수 있다.
+메신저 발송은 되돌리기 어렵다.
 
 개인 식별 정보를 확인한다.
 

--- a/tasks/plan066-feat-messenger-thread-send/phase-02.md
+++ b/tasks/plan066-feat-messenger-thread-send/phase-02.md
@@ -1,0 +1,156 @@
+# Phase 02. 스레드 명령을 문서에 반영한다
+
+**Execution profile**: standard
+
+## 목표
+
+phase 01 이 만든 `messenger thread-send` 를 문서 다섯에 반영한다.
+스레드에 메시지를 잇는 방법도 함께 적는다. 그 경로가 새 명령이 아니라 기존 명령이라 적지 않으면 알 수 없다.
+
+**범위 외**: `src/` 를 고치지 않는다. 이 phase 는 문서만 다룬다.
+`CLAUDE.md` 는 손대지 않는다. 명령별 스펙을 그 파일에 쌓지 않는 것이 이 저장소 규약이다.
+
+## 컨텍스트
+
+**근거 문서**: `docs/adr/052-messenger-thread-send.md`.
+
+`.claude/planning-overlay.md` 의 「변경 유형별 docs 영향 표」 가 손댈 곳을 정한다.
+이 변경은 「신규 CLI 명령 (소)」 와 「신규 ADR 동반 변경」 두 행에 걸린다.
+
+| 문서 | 담을 것 | 지금 상태 |
+| --- | --- | --- |
+| `docs/code-architecture.md` | `src/commands/messenger/` 트리에 새 파일 셋 | 112행부터가 그 절이다 |
+| `docs/prd.md` | MVP 범위 한 줄에 스레드 추가 | 53행이 messenger 줄이다 |
+| `docs/flow.md` | 사용자 흐름에 스레드 예시 | 486행부터가 messenger 절이다 |
+| `README.md` | 사용 예 | messenger 절을 찾아 잇는다 |
+| `skills/dooray-cli/SKILL.md` | 빠른 참조 표와 자동화 시나리오 | 225행부터가 messenger 행이다 |
+
+**공개 문서에는 내부 추적 번호를 넣지 않는다.**
+`README.md` 와 `skills/dooray-cli/SKILL.md` 가 그 대상이다. `ADR-052` 를 그 둘에 쓰지 않는다.
+규칙은 `CLAUDE.md` 의 「공개 문서의 내부 참조 번호 제외」 절이 소유하고, 검사는 `scripts/check-public-refs.mjs` 가 소유한다.
+
+## 의도 메모
+
+- **스레드에 메시지를 잇는 방법을 반드시 적는다.** 그 동작에 새 명령이 없어서,
+  적지 않으면 사용자가 방법이 없다고 판단한다. `channel-send` 에 스레드 채널 id 를 주면 된다.
+- `--quiet` 가 `channelId` 를 내는 것은 다른 messenger 명령과 다르다.
+  사용 예를 그 차이가 드러나는 형태로 쓴다. 스레드를 열고 그 값으로 이어 붙이는 두 줄이면 충분하다.
+- 공개 문서에는 왜 그렇게 설계했는지를 적지 않는다. 무엇을 어떻게 하는지만 적는다.
+
+## 작업 항목
+
+### 1. `docs/code-architecture.md` 의 messenger 트리를 늘린다
+
+112행부터의 `messenger/` 절에 파일 셋을 더한다.
+
+- `thread-send.ts` — 스레드 생성. `--log` 유무로 두 endpoint 를 가른다
+- `thread-options.ts` — 옵션 조합 판정
+- `thread-options.test.ts` 는 적지 않는다. 이 트리가 테스트 파일을 나열하지 않는다
+
+같은 절의 기존 항목이 쓰는 형식을 따른다. endpoint 와 ADR 역참조를 담는 형태다.
+
+### 2. `docs/prd.md` 의 messenger 줄을 고친다
+
+53행이다. 지금 `send` 와 `channel-send` 둘을 적는다.
+스레드 생성을 그 줄에 더하고 ADR 역참조에 `ADR-052` 를 넣는다.
+
+### 3. `docs/flow.md` 의 messenger 절에 스레드 흐름을 넣는다
+
+486행부터다. 기존 예시가 명령줄을 나열하는 형식이다. 그 형식을 따른다.
+
+담을 것은 셋이다.
+
+- 대화방에 스레드를 열면서 메시지를 보내는 것
+- 이미 있는 메시지에 스레드를 여는 것
+- 연 스레드에 메시지를 잇는 것
+
+세 번째가 `channel-send` 를 쓰는 것이라는 점이 드러나야 한다.
+
+### 4. `README.md` 에 사용 예를 넣는다
+
+messenger 를 다루는 절을 찾아 잇는다.
+
+스레드를 열고 그 값으로 메시지를 잇는 두 줄을 담는다.
+`--quiet` 가 스레드 채널 id 를 낸다는 것이 예시에서 보여야 한다.
+
+`--log` 로 기존 메시지에 스레드를 여는 것도 한 줄 넣는다.
+
+**`ADR-052` 를 쓰지 않는다.** 왜 그렇게 설계했는지도 적지 않는다.
+
+### 5. `skills/dooray-cli/SKILL.md` 를 고친다
+
+두 곳이다.
+
+- **빠른 참조 표** — 225행부터의 messenger 행 아래에 스레드 행을 더한다.
+  기존 두 행이 쓰는 형식을 따른다. 명령과 짧은 설명이다
+- **자동화 시나리오** — 스레드를 쓰는 시나리오를 담는다.
+  대화방에 진행 상황을 여러 번 보고할 때 본문 대신 스레드에 쌓는 형태다.
+  스레드를 열고 그 채널 id 를 받아 이어 붙이는 흐름이 드러나야 한다
+
+**`ADR-052` 를 쓰지 않는다.**
+
+## 검증
+
+```bash
+# cwd: <repo root>
+pnpm tsc --noEmit
+pnpm run build
+pnpm test
+```
+
+셋 다 통과해야 한다. 이 phase 는 `src/` 를 고치지 않으므로 회귀가 없어야 한다.
+
+문서에 실제로 들어갔는지 본다.
+
+```bash
+# cwd: <repo root>
+grep -c "thread-send" docs/code-architecture.md          # >= 1
+grep -c "thread-options" docs/code-architecture.md       # >= 1
+grep -c "ADR-052" docs/code-architecture.md              # >= 1
+grep -c "thread-send" docs/prd.md                        # >= 1
+grep -c "thread-send" docs/flow.md                       # >= 1
+grep -c "thread-send" README.md                          # >= 1
+grep -c "thread-send" skills/dooray-cli/SKILL.md         # >= 1
+```
+
+일곱이 모두 맞아야 한다.
+
+**스레드에 메시지를 잇는 방법이 적혔는지 본다.** 이 phase 의 핵심이다.
+
+```bash
+# cwd: <repo root>
+grep -c "channel-send" docs/flow.md                      # >= 3
+grep -c "channel-send" README.md                         # >= 2
+```
+
+기존에 있던 `channel-send` 예시에 스레드로 잇는 예시가 더해져 수가 늘어야 한다.
+실행 전에 현재 수를 세어 두고 늘었는지 확인한다.
+
+**공개 문서에 내부 참조가 들어가지 않았는지 본다.**
+
+```bash
+# cwd: <repo root>
+node scripts/check-public-refs.mjs
+```
+
+종료 코드 0 이어야 한다.
+
+문서 검사와 개인 식별 정보 검사를 통과시킨다.
+
+```bash
+# cwd: <repo root>
+~/.claude/skills/korean-check/scripts/check.sh docs/code-architecture.md docs/prd.md docs/flow.md README.md skills/dooray-cli/SKILL.md
+node scripts/check-pii.mjs
+```
+
+둘 다 종료 코드 0 이어야 한다.
+
+## Critical Files
+
+| 파일 | 변경 |
+|---|---|
+| `docs/code-architecture.md` | 수정 — messenger 트리에 파일 둘 |
+| `docs/prd.md` | 수정 — MVP 범위 줄 |
+| `docs/flow.md` | 수정 — 사용자 흐름 예시 |
+| `README.md` | 수정 — 사용 예 |
+| `skills/dooray-cli/SKILL.md` | 수정 — 빠른 참조 표와 자동화 시나리오 |

--- a/tasks/plan066-feat-messenger-thread-send/phase-02.md
+++ b/tasks/plan066-feat-messenger-thread-send/phase-02.md
@@ -21,9 +21,15 @@ phase 01 이 만든 `messenger thread-send` 를 문서 다섯에 반영한다.
 | --- | --- | --- |
 | `docs/code-architecture.md` | `src/commands/messenger/` 트리에 새 파일 셋 | 112행부터가 그 절이다 |
 | `docs/prd.md` | MVP 범위 한 줄에 스레드 추가 | 53행이 messenger 줄이다 |
-| `docs/flow.md` | 사용자 흐름에 스레드 예시 | 486행부터가 messenger 절이다 |
-| `README.md` | 사용 예 | messenger 절을 찾아 잇는다 |
-| `skills/dooray-cli/SKILL.md` | 빠른 참조 표와 자동화 시나리오 | 225행부터가 messenger 행이다 |
+| `docs/flow.md` | 사용자 흐름에 스레드 예시 | 480행의 `## 메신저 흐름` 이 그 절이다 |
+| `README.md` | 사용 예 | messenger 절이 없다. 새로 만든다 |
+| `skills/dooray-cli/SKILL.md` | 빠른 참조 표와 시나리오 예시 | 221행의 `## 메신저` 절이다 |
+
+**`README.md` 와 `skills/dooray-cli/SKILL.md` 의 현재 상태를 실측했다.**
+
+- `README.md` 에 messenger 를 다루는 절이 없다. 10행의 소개 문장 하나뿐이고 `channel-send` 는 0 건이다
+- `skills/dooray-cli/SKILL.md` 에 「자동화 시나리오」 라는 절이 없다.
+  `## 메신저` 절의 빠른 참조 표 하나뿐이다
 
 **공개 문서에는 내부 추적 번호를 넣지 않는다.**
 `README.md` 와 `skills/dooray-cli/SKILL.md` 가 그 대상이다. `ADR-052` 를 그 둘에 쓰지 않는다.
@@ -39,13 +45,21 @@ phase 01 이 만든 `messenger thread-send` 를 문서 다섯에 반영한다.
 
 ## 작업 항목
 
-### 1. `docs/code-architecture.md` 의 messenger 트리를 늘린다
+### 1. `docs/code-architecture.md` 의 트리 둘을 늘린다
 
-112행부터의 `messenger/` 절에 파일 셋을 더한다.
+phase 01 이 만드는 파일은 `src/commands/messenger/` 와 `src/api/` 두 곳에 걸친다.
+트리도 두 곳을 고친다.
+
+112행부터의 `messenger/` 절에 둘을 더한다.
 
 - `thread-send.ts` — 스레드 생성. `--log` 유무로 두 endpoint 를 가른다
 - `thread-options.ts` — 옵션 조합 판정
-- `thread-options.test.ts` 는 적지 않는다. 이 트리가 테스트 파일을 나열하지 않는다
+
+26행부터의 `api/` 절에 하나를 더한다.
+
+- `messenger-thread-request.ts` — 스레드 endpoint 경로와 요청 body 를 만드는 순수 함수
+
+테스트 파일은 적지 않는다. 이 트리가 테스트 파일을 나열하지 않는다.
 
 같은 절의 기존 항목이 쓰는 형식을 따른다. endpoint 와 ADR 역참조를 담는 형태다.
 
@@ -56,7 +70,7 @@ phase 01 이 만든 `messenger thread-send` 를 문서 다섯에 반영한다.
 
 ### 3. `docs/flow.md` 의 messenger 절에 스레드 흐름을 넣는다
 
-486행부터다. 기존 예시가 명령줄을 나열하는 형식이다. 그 형식을 따른다.
+480행의 `## 메신저 흐름` 절이다. 기존 예시가 명령줄을 나열하는 형식이다. 그 형식을 따른다.
 
 담을 것은 셋이다.
 
@@ -66,9 +80,13 @@ phase 01 이 만든 `messenger thread-send` 를 문서 다섯에 반영한다.
 
 세 번째가 `channel-send` 를 쓰는 것이라는 점이 드러나야 한다.
 
-### 4. `README.md` 에 사용 예를 넣는다
+### 4. `README.md` 에 메신저 절을 새로 만든다
 
-messenger 를 다루는 절을 찾아 잇는다.
+`## 에이전트 없이 직접 쓰기` 아래의 `###` 절들과 같은 층에 둔다.
+`### 프로젝트 태그 만들기` 다음, `## 프로젝트 구조` 앞이 그 자리다.
+제목은 `### 메신저로 알리기` 로 한다.
+
+1:1 다이렉트 메시지와 대화방 메시지도 함께 적는다. 지금 README 에 그 둘이 없다.
 
 스레드를 열고 그 값으로 메시지를 잇는 두 줄을 담는다.
 `--quiet` 가 스레드 채널 id 를 낸다는 것이 예시에서 보여야 한다.
@@ -81,10 +99,11 @@ messenger 를 다루는 절을 찾아 잇는다.
 
 두 곳이다.
 
-- **빠른 참조 표** — 225행부터의 messenger 행 아래에 스레드 행을 더한다.
+- **빠른 참조 표** — 226행의 대화방 메시지 행 아래에 스레드 행을 더한다.
   기존 두 행이 쓰는 형식을 따른다. 명령과 짧은 설명이다
-- **자동화 시나리오** — 스레드를 쓰는 시나리오를 담는다.
-  대화방에 진행 상황을 여러 번 보고할 때 본문 대신 스레드에 쌓는 형태다.
+- **시나리오 예시** — 표 아래에 코드블록 하나를 둔다. 절을 새로 만들지 않는다.
+  「자동화 시나리오」 라는 절이 이 파일에 없고, `## 메신저` 절이 이미 그 주제를 담는다.
+  대화방에 진행 상황을 여러 번 보고할 때 본문 대신 스레드에 쌓는 형태를 적는다.
   스레드를 열고 그 채널 id 를 받아 이어 붙이는 흐름이 드러나야 한다
 
 **`ADR-052` 를 쓰지 않는다.**
@@ -106,6 +125,7 @@ pnpm test
 # cwd: <repo root>
 grep -c "thread-send" docs/code-architecture.md          # >= 1
 grep -c "thread-options" docs/code-architecture.md       # >= 1
+grep -c "messenger-thread-request" docs/code-architecture.md  # >= 1
 grep -c "ADR-052" docs/code-architecture.md              # >= 1
 grep -c "thread-send" docs/prd.md                        # >= 1
 grep -c "thread-send" docs/flow.md                       # >= 1
@@ -113,7 +133,7 @@ grep -c "thread-send" README.md                          # >= 1
 grep -c "thread-send" skills/dooray-cli/SKILL.md         # >= 1
 ```
 
-일곱이 모두 맞아야 한다.
+여덟이 모두 맞아야 한다.
 
 **스레드에 메시지를 잇는 방법이 적혔는지 본다.** 이 phase 의 핵심이다.
 
@@ -123,8 +143,9 @@ grep -c "channel-send" docs/flow.md                      # >= 3
 grep -c "channel-send" README.md                         # >= 2
 ```
 
-기존에 있던 `channel-send` 예시에 스레드로 잇는 예시가 더해져 수가 늘어야 한다.
-실행 전에 현재 수를 세어 두고 늘었는지 확인한다.
+착수 전 실측값은 `docs/flow.md` 가 2 이고 `README.md` 가 0 이다.
+`docs/flow.md` 는 스레드에 잇는 예시가 더해져 3 이상이 된다.
+`README.md` 는 절을 새로 만들면서 대화방 메시지와 스레드에 잇는 예시 둘이 들어가 2 이상이 된다.
 
 **공개 문서에 내부 참조가 들어가지 않았는지 본다.**
 
@@ -149,8 +170,8 @@ node scripts/check-pii.mjs
 
 | 파일 | 변경 |
 |---|---|
-| `docs/code-architecture.md` | 수정 — messenger 트리에 파일 둘 |
+| `docs/code-architecture.md` | 수정 — messenger 트리에 둘, api 트리에 하나 |
 | `docs/prd.md` | 수정 — MVP 범위 줄 |
 | `docs/flow.md` | 수정 — 사용자 흐름 예시 |
-| `README.md` | 수정 — 사용 예 |
-| `skills/dooray-cli/SKILL.md` | 수정 — 빠른 참조 표와 자동화 시나리오 |
+| `README.md` | 수정 — 메신저 절 신설 |
+| `skills/dooray-cli/SKILL.md` | 수정 — 빠른 참조 표와 시나리오 예시 |


### PR DESCRIPTION
## 어떤 이유로 PR을 하셨나요?

- 대화방에 진행 상황을 여러 번 보고하면 본문에 메시지가 쌓여 읽기 어려워지는 문제가 있었습니다.
- 스레드로 묶으면 대화방에는 한 줄만 남고 나머지는 그 안에 쌓임
- 그래서 스레드를 여는 `messenger thread-send` 를 추가하고 `--log` 유무로 공식 endpoint 둘을 가르게 했습니다.

## 작업 내용

- `thread-send` 명령

  | `--log` | 호출하는 endpoint | 요청 body |
  |---------|-------------------|-----------|
  | 없음 | `channels/{id}/threads/create-and-send` | `{ text, threadText? }` |
  | 있음 | `channels/{id}/logs/{log-id}/threads/create-and-send` | `{ text }` |

  - `--quiet` 은 log-id 가 아니라 스레드 채널의 `channelId` 를 냄
  - `--thread-body` 는 생략 가능, 생략하면 스레드만 열림
  - `--log` 와 `--thread-body` 를 함께 주면 경고 후 무시

- 순수 함수 분리
  - `buildThreadRequest` 가 경로와 요청 body 를 생성
    - `threadText` 는 값이 있을 때만 키를 넣음
  - `checkThreadOptions` 가 옵션 조합을 판정
    - 던지지 않고 결과를 반환해 호출부가 경고와 에러를 나눠 처리
  - 테스트 12건

- 문서
  - README 에 메신저 절 신설
  - 스레드에 메시지를 잇는 방법을 명시
    - 새 명령이 아니라 `channel-send` 에 스레드 채널 id 를 주는 경로

- phase 검증 절 수정
  - 실제 발송으로 확인하는 단계 제거
    - 대상 자리를 placeholder 로 두면 실행 주체가 그것을 채움
    - `--channel` 은 이름 부분일치도 받아 엉뚱한 대화방으로 나감

## 리뷰어가 집중해 주길 바라는 부분이 있다면 입력해 주세요.

- 공식 문서는 `threads/create-and-send` 응답에서 `$.result.threadChannelId` 를 쓰라고 적지만 그 필드는 오지 않습니다. `channelId` 가 스레드 채널 id 이고, 그 값으로 `logs` 를 보내 스레드에 붙는 것을 실측했습니다. 근거는 ADR-052 에 남겼습니다.
- `--quiet` 이 `channelId` 를 내는 것은 다른 messenger 명령과 다릅니다. 스레드를 연 다음에 하는 일이 그 스레드에 메시지를 잇는 것이라 그 값이 필요합니다.
- base 가 `plan065-fix-json-large-integer-precision` 입니다. 두 브랜치가 `src/api/client.ts` 와 `types.ts` 를 함께 건드려 rebase 로 합쳤습니다.

---
> 이 PR은 AI에 의해 작성되었습니다.
